### PR TITLE
M2: shared sync core — protocol, clock estimator, drift controller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  shared-copies:
+    name: shared copies in sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/sync-shared.mjs --check
+
   backend:
     name: backend (lint, build, test)
     runs-on: ubuntu-latest

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/scripts/sync-shared.mjs
+++ b/scripts/sync-shared.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Mirrors /shared (the canonical sync core) into both packages:
+//   video-sync-backend/src/shared/   (specs included -> jest runs them)
+//   video-sync-frontend/src/shared/  (specs excluded -> no jsdom double-run)
+//
+// Why copies instead of a workspace: CRA's ModuleScopePlugin forbids imports
+// from outside src/, and symlink transpilation is CRA-hostile. A checked-in
+// copy is boring and honest; --check keeps it from drifting in CI.
+//
+// Usage: node scripts/sync-shared.mjs [--check]
+
+import { createHash } from 'node:crypto';
+import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync, existsSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SRC = join(root, 'shared');
+const HEADER = `// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+`;
+
+const targets = [
+  { dest: join(root, 'video-sync-backend', 'src', 'shared'), includeSpecs: true },
+  { dest: join(root, 'video-sync-frontend', 'src', 'shared'), includeSpecs: false },
+];
+
+function listFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) out.push(...listFiles(p));
+    else if (p.endsWith('.ts')) out.push(p);
+  }
+  return out;
+}
+
+function expected(target) {
+  const files = new Map();
+  for (const file of listFiles(SRC)) {
+    const rel = relative(SRC, file);
+    if (!target.includeSpecs && rel.endsWith('.spec.ts')) continue;
+    files.set(rel, HEADER + readFileSync(file, 'utf8'));
+  }
+  return files;
+}
+
+const check = process.argv.includes('--check');
+let dirty = false;
+
+for (const target of targets) {
+  const files = expected(target);
+  if (check) {
+    for (const [rel, content] of files) {
+      const p = join(target.dest, rel);
+      if (!existsSync(p) || readFileSync(p, 'utf8') !== content) {
+        console.error(`stale copy: ${relative(root, p)}`);
+        dirty = true;
+      }
+    }
+    if (existsSync(target.dest)) {
+      for (const file of listFiles(target.dest)) {
+        const rel = relative(target.dest, file);
+        if (!files.has(rel)) {
+          console.error(`orphan copy: ${relative(root, file)}`);
+          dirty = true;
+        }
+      }
+    }
+  } else {
+    rmSync(target.dest, { recursive: true, force: true });
+    for (const [rel, content] of files) {
+      const p = join(target.dest, rel);
+      mkdirSync(dirname(p), { recursive: true });
+      writeFileSync(p, content);
+    }
+    console.log(`synced ${files.size} files -> ${relative(root, target.dest)}`);
+  }
+}
+
+if (check) {
+  if (dirty) {
+    console.error('\nshared copies are stale. Run: node scripts/sync-shared.mjs');
+    process.exit(1);
+  }
+  console.log('shared copies are up to date');
+}
+
+// convenience: content hash for quick eyeballing in logs
+const all = listFiles(SRC).map((f) => readFileSync(f, 'utf8')).join('\n');
+console.log(`shared content sha1: ${createHash('sha1').update(all).digest('hex').slice(0, 12)}`);

--- a/shared/sync-core/clock-estimator.spec.ts
+++ b/shared/sync-core/clock-estimator.spec.ts
@@ -1,0 +1,123 @@
+import { ClockEstimator, ClockSample } from './clock-estimator';
+
+/**
+ * Build one exchange against a server whose clock leads the client by
+ * `offset` ms, with one-way delays upMs (client→server) and downMs.
+ */
+function exchange(
+  t0: number,
+  offset: number,
+  upMs: number,
+  downMs: number,
+  serverProcMs = 0,
+): ClockSample {
+  const t1 = t0 + upMs + offset;
+  const t2 = t1 + serverProcMs;
+  const t3 = t2 - offset + downMs;
+  return { t0, t1, t2, t3 };
+}
+
+describe('ClockEstimator', () => {
+  it('recovers the exact offset on a symmetric path', () => {
+    const est = new ClockEstimator();
+    let t = 1_000;
+    for (let i = 0; i < 8; i++) {
+      est.addSample(exchange(t, 250, 40, 40));
+      t += 150;
+    }
+    expect(est.getEstimate().offsetMs).toBeCloseTo(250, 5);
+    // uncertainty = δ_min/2 = (40+40)/2 = 40
+    expect(est.getEstimate().uncertaintyMs).toBeCloseTo(40, 5);
+  });
+
+  it('bias on an asymmetric path is bounded by half the asymmetry', () => {
+    const est = new ClockEstimator();
+    let t = 1_000;
+    for (let i = 0; i < 8; i++) {
+      est.addSample(exchange(t, 250, 120, 20)); // 100ms asymmetry
+      t += 150;
+    }
+    const { offsetMs } = est.getEstimate();
+    // θ = offset + (up-down)/2 = 250 + 50
+    expect(offsetMs).toBeCloseTo(300, 5);
+    expect(Math.abs(offsetMs - 250)).toBeLessThanOrEqual(50 + 1e-9);
+  });
+
+  it('min-RTT selection rejects delay spikes', () => {
+    const est = new ClockEstimator();
+    let t = 1_000;
+    for (let i = 0; i < 6; i++) {
+      est.addSample(exchange(t, 250, 20, 20));
+      t += 150;
+    }
+    // burst of congested samples with wild asymmetric delays
+    for (let i = 0; i < 3; i++) {
+      est.addSample(exchange(t, 250, 900, 30));
+      t += 150;
+    }
+    expect(est.getEstimate().offsetMs).toBeCloseTo(250, 3);
+  });
+
+  it('discards non-causal samples (negative rtt)', () => {
+    const est = new ClockEstimator();
+    // t3-t0 = 30ms but the server claims 50ms of processing: δ = -20
+    expect(est.addSample({ t0: 1000, t1: 1240, t2: 1290, t3: 1030 })).toBe(
+      false,
+    );
+    expect(est.hasEstimate()).toBe(false);
+  });
+
+  it('small corrections slew instead of stepping', () => {
+    const est = new ClockEstimator();
+    let t = 1_000;
+    for (let i = 0; i < 8; i++) {
+      est.addSample(exchange(t, 250, 30, 30));
+      t += 150;
+    }
+    est.tick(t);
+    // nudge the true offset by 10ms — below the 20ms step threshold
+    for (let i = 0; i < 8; i++) {
+      est.addSample(exchange(t, 260, 30, 30));
+      t += 150;
+    }
+    const before = est.getEstimate().offsetMs;
+    expect(before).toBeLessThan(260); // not stepped
+    // 2 simulated seconds of ticking at 4Hz: slew limit 5ms/s → ≤10ms travel
+    for (let i = 0; i < 8; i++) {
+      t += 250;
+      est.tick(t);
+    }
+    const after = est.getEstimate().offsetMs;
+    expect(after).toBeGreaterThan(before);
+    expect(after).toBeLessThanOrEqual(260 + 1e-9);
+  });
+
+  it('large corrections step immediately', () => {
+    const est = new ClockEstimator();
+    let t = 1_000;
+    for (let i = 0; i < 8; i++) {
+      est.addSample(exchange(t, 250, 30, 30));
+      t += 150;
+    }
+    // clock jumped 500ms (e.g. host NTP step)
+    for (let i = 0; i < 8; i++) {
+      est.addSample(exchange(t, 750, 30, 30));
+      t += 150;
+    }
+    expect(est.getEstimate().offsetMs).toBeCloseTo(750, 3);
+  });
+
+  it('serverNow maps local time through the applied offset', () => {
+    const est = new ClockEstimator();
+    est.addSample(exchange(1000, 250, 30, 30));
+    expect(est.serverNow(5000)).toBeCloseTo(5250, 5);
+  });
+
+  it('reset clears history for reconnect re-burst', () => {
+    const est = new ClockEstimator();
+    est.addSample(exchange(1000, 250, 30, 30));
+    est.reset();
+    expect(est.hasEstimate()).toBe(false);
+    expect(est.getEstimate().sampleCount).toBe(0);
+  });
+});

--- a/shared/sync-core/clock-estimator.ts
+++ b/shared/sync-core/clock-estimator.ts
@@ -1,0 +1,156 @@
+// NTP-style clock-offset estimator over the sync:clock exchange.
+//
+// Per exchange: client stamps t0 on send and t3 on receipt; the server's ack
+// carries t1 (receive) and t2 (send), all in its own clock domain.
+//
+//   offset θ = ((t1 - t0) + (t2 - t3)) / 2      (server − client)
+//   rtt    δ = (t3 - t0) - (t2 - t1)
+//
+// |θ_true − θ| ≤ δ/2 + |path asymmetry|/2. The asymmetry term is irreducible
+// for any NTP-family scheme — scenario S6 exists to demonstrate it honestly.
+//
+// Estimation: keep a ring of samples, select the K lowest-δ samples within a
+// recency window (min-RTT filtering tightens the δ/2 bound), use their median
+// θ (kills single-sample jumpiness). Apply small corrections as a slew so the
+// drift controller never sees the clock step under it; large corrections step
+// immediately and the controller re-evaluates.
+//
+// Deterministic: no Date.now() inside — callers pass local timestamps.
+
+export interface ClockSample {
+  t0: number;
+  t1: number;
+  t2: number;
+  t3: number;
+}
+
+export interface ClockEstimate {
+  /** currently applied offset (server − client), ms */
+  offsetMs: number;
+  /** raw target from the sample set, ms */
+  targetOffsetMs: number;
+  /** δ_min/2 over the selected samples, ms; Infinity until a sample lands */
+  uncertaintyMs: number;
+  /** most recent rtt observation, ms */
+  lastRttMs: number;
+  sampleCount: number;
+}
+
+export interface ClockTuning {
+  ringSize: number;
+  /** samples older than this are ignored for selection (bounds skew error) */
+  windowMs: number;
+  /** how many lowest-δ samples the median is taken over */
+  bestK: number;
+  /** |Δθ| below this slews instead of stepping */
+  slewThresholdMs: number;
+  /** slew rate limit, ms of correction per second of local time */
+  slewRatePerS: number;
+}
+
+export const DEFAULT_CLOCK_TUNING: ClockTuning = {
+  ringSize: 64,
+  windowMs: 60_000,
+  bestK: 5,
+  slewThresholdMs: 20,
+  slewRatePerS: 5,
+};
+
+interface StoredSample {
+  theta: number;
+  delta: number;
+  t3: number;
+}
+
+export class ClockEstimator {
+  private samples: StoredSample[] = [];
+  private applied: number | null = null;
+  private target = 0;
+  private uncertainty = Infinity;
+  private lastRtt = NaN;
+  private lastTick: number | null = null;
+
+  constructor(private tuning: ClockTuning = DEFAULT_CLOCK_TUNING) {}
+
+  /** Feed one completed exchange. Returns true if the sample was usable. */
+  addSample(s: ClockSample): boolean {
+    const delta = s.t3 - s.t0 - (s.t2 - s.t1);
+    if (delta < 0) return false; // non-causal: clock stepped mid-exchange
+    const theta = (s.t1 - s.t0 + (s.t2 - s.t3)) / 2;
+    this.samples.push({ theta, delta, t3: s.t3 });
+    if (this.samples.length > this.tuning.ringSize) {
+      this.samples.splice(0, this.samples.length - this.tuning.ringSize);
+    }
+    this.lastRtt = delta;
+    this.recompute(s.t3);
+    return true;
+  }
+
+  private recompute(nowLocal: number): void {
+    const recent = this.samples.filter(
+      (x) => nowLocal - x.t3 <= this.tuning.windowMs,
+    );
+    if (recent.length === 0) return;
+    // lowest δ first; among equal-quality samples prefer the newest, so a
+    // genuine server-clock change wins over stale history within the window
+    const best = [...recent]
+      .sort((a, b) => a.delta - b.delta || b.t3 - a.t3)
+      .slice(0, this.tuning.bestK);
+    const thetas = best.map((x) => x.theta).sort((a, b) => a - b);
+    const median = thetas[Math.floor(thetas.length / 2)];
+    this.target = median;
+    this.uncertainty = best[0].delta / 2;
+
+    if (this.applied === null) {
+      // first estimate: step, there is nothing to disturb yet
+      this.applied = this.target;
+    } else if (
+      Math.abs(this.target - this.applied) >= this.tuning.slewThresholdMs
+    ) {
+      this.applied = this.target;
+    }
+    // otherwise tick() slews toward target
+  }
+
+  /** Advance the slew; call at the controller cadence with local ms time. */
+  tick(nowLocal: number): void {
+    if (this.applied === null) return;
+    if (this.lastTick !== null) {
+      const dtS = (nowLocal - this.lastTick) / 1000;
+      const maxStep = this.tuning.slewRatePerS * dtS;
+      const diff = this.target - this.applied;
+      if (Math.abs(diff) <= maxStep) this.applied = this.target;
+      else this.applied += Math.sign(diff) * maxStep;
+    }
+    this.lastTick = nowLocal;
+  }
+
+  /** Map a local timestamp into the server clock domain. */
+  serverNow(nowLocal: number): number {
+    return nowLocal + (this.applied ?? 0);
+  }
+
+  hasEstimate(): boolean {
+    return this.applied !== null;
+  }
+
+  getEstimate(): ClockEstimate {
+    return {
+      offsetMs: this.applied ?? 0,
+      targetOffsetMs: this.target,
+      uncertaintyMs: this.uncertainty,
+      lastRttMs: this.lastRtt,
+      sampleCount: this.samples.length,
+    };
+  }
+
+  /** Drop history (reconnect, visibility restore): re-burst follows. */
+  reset(): void {
+    this.samples = [];
+    this.applied = null;
+    this.target = 0;
+    this.uncertainty = Infinity;
+    this.lastRtt = NaN;
+    this.lastTick = null;
+  }
+}

--- a/shared/sync-core/drift-controller.spec.ts
+++ b/shared/sync-core/drift-controller.spec.ts
@@ -1,0 +1,228 @@
+import { Timeline } from '../sync-protocol';
+import {
+  ControllerAction,
+  ControllerInput,
+  DriftController,
+} from './drift-controller';
+
+const timeline = (over: Partial<Timeline> = {}): Timeline => ({
+  v: 1,
+  seq: 1,
+  storeEpoch: 'e',
+  videoId: 'vid',
+  isPlaying: true,
+  mediaTime: 100,
+  stampedAt: 0,
+  rate: 1,
+  reason: 'play',
+  ...over,
+});
+
+/**
+ * Drive the controller along simulated time. `driftS` positive = player
+ * ahead of the room timeline. Returns every action taken.
+ */
+function drive(
+  ctrl: DriftController,
+  steps: Array<Partial<ControllerInput> & { driftS?: number }>,
+  startLocal = 100_000,
+): ControllerAction[] {
+  const actions: ControllerAction[] = [];
+  let tLocal = startLocal;
+  for (const step of steps) {
+    tLocal += 250;
+    const tl = step.timeline === undefined ? timeline() : step.timeline;
+    const serverNow = tLocal; // offset 0 keeps expectations legible
+    const expected = tl
+      ? tl.mediaTime + (tl.isPlaying ? (serverNow - tl.stampedAt) / 1000 : 0)
+      : 0;
+    const input: ControllerInput = {
+      tLocal,
+      serverNow,
+      playerTime: expected + (step.driftS ?? 0),
+      playerState: step.playerState ?? 'playing',
+      timeline: tl,
+      fractionalRateOK: step.fractionalRateOK ?? false,
+    };
+    actions.push(ctrl.evaluate(input));
+  }
+  return actions;
+}
+
+const types = (a: ControllerAction[]): string[] => a.map((x) => x.type);
+
+describe('DriftController — SEEK mode (default)', () => {
+  it('stays quiet inside the deadband', () => {
+    const ctrl = new DriftController();
+    const actions = drive(ctrl, [
+      { driftS: 0.05 },
+      { driftS: -0.08 },
+      { driftS: 0.1 },
+      { driftS: 0.02 },
+    ]);
+    expect(types(actions)).toEqual(['none', 'none', 'none', 'none']);
+  });
+
+  it('seeks after sustained drift beyond the seek threshold, with lead', () => {
+    const ctrl = new DriftController();
+    const actions = drive(ctrl, [
+      { driftS: 0.02 },
+      { driftS: -0.5 },
+      { driftS: -0.5 },
+      { driftS: -0.5 },
+    ]);
+    const seekIdx = types(actions).indexOf('seek');
+    expect(seekIdx).toBeGreaterThan(0);
+    const seek = actions[seekIdx] as { type: 'seek'; toMediaTime: number };
+    // target = projected + default 0.3s lead
+    const expectedAt = 100 + (100_000 + 250 * (seekIdx + 1)) / 1000;
+    expect(seek.toMediaTime).toBeCloseTo(expectedAt + 0.3, 1);
+  });
+
+  it('a single gross reading seeks immediately (post-sleep path)', () => {
+    const ctrl = new DriftController();
+    const actions = drive(ctrl, [{ driftS: 0.0 }, { driftS: -30 }]);
+    expect(types(actions)[1]).toBe('seek');
+  });
+
+  it('respects the seek spacing (no seek storms)', () => {
+    const ctrl = new DriftController();
+    const steps = Array.from({ length: 20 }, () => ({ driftS: -3 as number }));
+    const actions = drive(ctrl, steps);
+    const seeks = types(actions).filter((t) => t === 'seek').length;
+    // 20 evals * 250ms = 5s window; 3s spacing → at most 2 seeks
+    expect(seeks).toBeLessThanOrEqual(2);
+    expect(seeks).toBeGreaterThan(0);
+  });
+
+  it('tolerates drift between deadband and threshold without rate support', () => {
+    const ctrl = new DriftController();
+    const actions = drive(ctrl, [
+      { driftS: 0.2 },
+      { driftS: 0.2 },
+      { driftS: 0.2 },
+      { driftS: 0.2 },
+    ]);
+    expect(types(actions)).toEqual(['none', 'none', 'none', 'none']);
+  });
+});
+
+describe('DriftController — RATE mode (probe-gated)', () => {
+  it('nudges within the rate zone and clears on convergence', () => {
+    const ctrl = new DriftController();
+    const actions = drive(ctrl, [
+      { driftS: 0.3, fractionalRateOK: true },
+      { driftS: 0.3, fractionalRateOK: true },
+      { driftS: 0.25, fractionalRateOK: true },
+      { driftS: 0.15, fractionalRateOK: true },
+      { driftS: 0.05, fractionalRateOK: true },
+      { driftS: 0.03, fractionalRateOK: true },
+    ]);
+    const t = types(actions);
+    const first = t.indexOf('set-rate');
+    expect(first).toBeGreaterThanOrEqual(1);
+    const rate = actions[first] as { type: 'set-rate'; rate: number };
+    expect(rate.rate).toBeCloseTo(0.95, 9); // ahead → slow down
+    expect(t).toContain('clear-rate');
+  });
+
+  it('escalates to seek when nudging is stuck', () => {
+    const ctrl = new DriftController();
+    // 70 evals * 250ms = 17.5s stuck at 0.4s drift > 15s stuck limit
+    const steps = Array.from({ length: 70 }, () => ({
+      driftS: 0.4 as number,
+      fractionalRateOK: true,
+    }));
+    const actions = drive(ctrl, steps);
+    expect(types(actions)).toContain('seek');
+  });
+
+  it('never nudges when the probe failed', () => {
+    const ctrl = new DriftController();
+    const steps = Array.from({ length: 10 }, () => ({
+      driftS: 0.4 as number,
+      fractionalRateOK: false,
+    }));
+    const actions = drive(ctrl, steps);
+    expect(types(actions)).not.toContain('set-rate');
+    expect(types(actions)).toContain('seek');
+  });
+});
+
+describe('DriftController — lifecycle', () => {
+  it('suspends corrections while buffering and clears any applied rate', () => {
+    const ctrl = new DriftController();
+    const warmup = drive(ctrl, [
+      { driftS: 0.3, fractionalRateOK: true },
+      { driftS: 0.3, fractionalRateOK: true },
+    ]);
+    expect(types(warmup)).toContain('set-rate');
+    const actions = drive(
+      ctrl,
+      [
+        { driftS: 0.3, playerState: 'buffering', fractionalRateOK: true },
+        { driftS: 0.3, playerState: 'buffering', fractionalRateOK: true },
+      ],
+      101_000,
+    );
+    expect(types(actions)[0]).toBe('clear-rate');
+    expect(types(actions)[1]).toBe('none');
+  });
+
+  it('catches up after buffering ends (P2 free-run policy)', () => {
+    const ctrl = new DriftController();
+    drive(ctrl, [{ driftS: 0, playerState: 'buffering' }]);
+    const actions = drive(
+      ctrl,
+      [{ driftS: -4 }], // fell 4s behind while buffering
+      110_000,
+    );
+    expect(types(actions)[0]).toBe('seek');
+  });
+
+  it('pauses the player when the room pauses, then reconciles position', () => {
+    const ctrl = new DriftController();
+    const paused = timeline({ isPlaying: false, mediaTime: 100 });
+    const a1 = drive(ctrl, [{ timeline: paused, playerState: 'playing' }]);
+    expect(types(a1)).toEqual(['pause']);
+    const a2 = drive(
+      ctrl,
+      [{ timeline: paused, playerState: 'paused', driftS: 0 }],
+      200_000,
+    );
+    // playerTime = projected(=100) + 0 → within reconcile band → no seek
+    expect(types(a2)).toEqual(['none']);
+  });
+
+  it('silently reconciles a paused player that is off-position', () => {
+    const ctrl = new DriftController();
+    const paused = timeline({ isPlaying: false, mediaTime: 100 });
+    const tLocal = 300_000;
+    const input: ControllerInput = {
+      tLocal,
+      serverNow: tLocal,
+      playerTime: 103, // 3s off while paused
+      playerState: 'paused',
+      timeline: paused,
+      fractionalRateOK: false,
+    };
+    const action = ctrl.evaluate(input);
+    expect(action).toEqual({ type: 'seek', toMediaTime: 100 });
+  });
+
+  it('starts a paused player when the room is playing', () => {
+    const ctrl = new DriftController();
+    const a = drive(ctrl, [{ playerState: 'paused', driftS: 0 }]);
+    expect(types(a)).toEqual(['play']);
+  });
+
+  it('does nothing while suspended and acts fast after resume', () => {
+    const ctrl = new DriftController();
+    ctrl.suspend();
+    const quiet = drive(ctrl, [{ driftS: -5 }]);
+    expect(types(quiet)).toEqual(['none']);
+    ctrl.resume();
+    const active = drive(ctrl, [{ driftS: -0.5 }], 400_000);
+    expect(types(active)).toEqual(['seek']); // hysteresis dropped on resume
+  });
+});

--- a/shared/sync-core/drift-controller.ts
+++ b/shared/sync-core/drift-controller.ts
@@ -1,0 +1,305 @@
+// Drift-correction state machine. SEEK-first by design: the YouTube IFrame
+// API rounds unsupported playbackRate values toward 1 (per its reference),
+// so fractional-rate nudging is an opportunistic enhancement enabled per
+// video by a runtime probe (fractionalRateOK) — not the primary path.
+//
+// Pure and deterministic: evaluate() receives everything it needs and
+// returns an action; the engine (browser or SimPlayer bot) executes it.
+// All thresholds are named tuning constants, tuned against committed
+// measurement runs — never adjectives.
+
+import { Timeline } from '../sync-protocol';
+import { projectMediaTime } from './timeline';
+
+export type PlayerLifecycle =
+  | 'unstarted'
+  | 'playing'
+  | 'paused'
+  | 'buffering'
+  | 'ended'
+  | 'cued';
+
+export interface ControllerInput {
+  /** local ms clock (performance-independent, same domain as estimator t0/t3) */
+  tLocal: number;
+  /** estimator-mapped server-domain time for tLocal */
+  serverNow: number;
+  /** de-quantized playhead seconds (edge-reconstructed by the adapter) */
+  playerTime: number;
+  playerState: PlayerLifecycle;
+  timeline: Timeline | null;
+  /** result of the per-video setPlaybackRate probe */
+  fractionalRateOK: boolean;
+}
+
+export type ControllerAction =
+  | { type: 'none' }
+  | { type: 'seek'; toMediaTime: number }
+  | { type: 'set-rate'; rate: number }
+  | { type: 'clear-rate' }
+  | { type: 'play' }
+  | { type: 'pause' };
+
+export type ControllerState =
+  | 'LOCKED'
+  | 'NUDGING'
+  | 'SEEKING'
+  | 'BUFFERING'
+  | 'PAUSED_SYNC'
+  | 'SUSPENDED';
+
+export interface ControllerTuning {
+  /** |drift| below this is noise, not error (floored at 2× measured noise σ) */
+  deadbandS: number;
+  /** SEEK mode: correct when |drift| exceeds this for `sustainEvals` evals */
+  seekThresholdS: number;
+  sustainEvals: number;
+  /** single-reading drift beyond this seeks immediately (post-sleep etc.) */
+  instantSeekS: number;
+  /** minimum spacing between corrective seeks, ms */
+  seekSpacingMs: number;
+  /** post-seek cooldown before drift is trusted again, ms */
+  seekCooldownMs: number;
+  /** stable in-band evals required to re-LOCK after a seek */
+  postSeekStableEvals: number;
+  /** initial seek lead (EMA of measured settle replaces it at runtime), s */
+  seekLeadS: number;
+  seekLeadMaxS: number;
+  /** RATE mode window: nudge between deadband and this bound */
+  rateZoneMaxS: number;
+  nudgeRate: number;
+  /** exit nudging when |drift| falls below this */
+  nudgeExitS: number;
+  /** give up on nudging and seek if not back in band within this, ms */
+  nudgeStuckMs: number;
+  /** paused reconcile: silent seek when |playerTime − mediaTime| exceeds */
+  pausedReconcileS: number;
+}
+
+export const DEFAULT_CONTROLLER_TUNING: ControllerTuning = {
+  deadbandS: 0.12,
+  seekThresholdS: 0.3,
+  sustainEvals: 2,
+  instantSeekS: 2.5,
+  seekSpacingMs: 3000,
+  seekCooldownMs: 1500,
+  postSeekStableEvals: 2,
+  seekLeadS: 0.3,
+  seekLeadMaxS: 1.2,
+  rateZoneMaxS: 0.6,
+  nudgeRate: 0.05,
+  nudgeExitS: 0.06,
+  nudgeStuckMs: 15_000,
+  pausedReconcileS: 0.25,
+};
+
+export interface ControllerStatus {
+  state: ControllerState;
+  lastDriftS: number;
+  seekLeadS: number;
+  seeksIssued: number;
+  nudgesIssued: number;
+}
+
+export class DriftController {
+  private state: ControllerState = 'LOCKED';
+  private driftWindow: number[] = [];
+  private outOfBandCount = 0;
+  private lastSeekAt = -Infinity;
+  private seekTargetS: number | null = null;
+  private stableEvals = 0;
+  private nudgeSince: number | null = null;
+  private rateApplied = false;
+  private seekLead: number;
+  private seeksIssued = 0;
+  private nudgesIssued = 0;
+  private lastDrift = 0;
+
+  constructor(private tuning: ControllerTuning = DEFAULT_CONTROLLER_TUNING) {
+    this.seekLead = tuning.seekLeadS;
+  }
+
+  suspend(): void {
+    this.state = 'SUSPENDED';
+    this.driftWindow = [];
+    this.outOfBandCount = 0;
+  }
+
+  /** visibility restore / reconnect: evaluate immediately, hysteresis dropped */
+  resume(): void {
+    this.state = 'LOCKED';
+    this.driftWindow = [];
+    this.outOfBandCount = this.tuning.sustainEvals; // first out-of-band eval acts
+  }
+
+  getStatus(): ControllerStatus {
+    return {
+      state: this.state,
+      lastDriftS: this.lastDrift,
+      seekLeadS: this.seekLead,
+      seeksIssued: this.seeksIssued,
+      nudgesIssued: this.nudgesIssued,
+    };
+  }
+
+  evaluate(input: ControllerInput): ControllerAction {
+    const { timeline } = input;
+    if (this.state === 'SUSPENDED' || timeline === null)
+      return { type: 'none' };
+
+    // ---- lifecycle reconciliation before drift logic ----
+    if (input.playerState === 'buffering') {
+      this.state = 'BUFFERING';
+      if (this.rateApplied) {
+        this.rateApplied = false;
+        this.nudgeSince = null;
+        return { type: 'clear-rate' };
+      }
+      return { type: 'none' };
+    }
+
+    if (!timeline.isPlaying) {
+      // room is paused: reconcile position, make sure we are paused too
+      if (input.playerState === 'playing') return { type: 'pause' };
+      this.state = 'PAUSED_SYNC';
+      const err = Math.abs(input.playerTime - timeline.mediaTime);
+      if (
+        err > this.tuning.pausedReconcileS &&
+        input.tLocal - this.lastSeekAt > this.tuning.seekSpacingMs
+      ) {
+        this.lastSeekAt = input.tLocal;
+        this.seeksIssued += 1;
+        return { type: 'seek', toMediaTime: timeline.mediaTime };
+      }
+      return { type: 'none' };
+    }
+
+    // room is playing
+    if (input.playerState === 'paused' || input.playerState === 'cued') {
+      return { type: 'play' };
+    }
+    if (input.playerState !== 'playing') return { type: 'none' };
+
+    // leaving BUFFERING: catch-up evaluation with cooldown waived (P2)
+    const wasBuffering = this.state === 'BUFFERING';
+    if (wasBuffering) this.state = 'LOCKED';
+
+    const expected = projectMediaTime(timeline, input.serverNow);
+    const rawDrift = input.playerTime - expected; // positive = ahead
+
+    // median-of-3 guard against readout outliers
+    this.driftWindow.push(rawDrift);
+    if (this.driftWindow.length > 3) this.driftWindow.shift();
+    const sorted = [...this.driftWindow].sort((a, b) => a - b);
+    const drift = sorted[Math.floor(sorted.length / 2)];
+    this.lastDrift = drift;
+    const absDrift = Math.abs(drift);
+
+    // post-seek: measure settle, ignore drift until cooldown + stability
+    if (this.state === 'SEEKING') {
+      const sinceSeek = input.tLocal - this.lastSeekAt;
+      if (sinceSeek < this.tuning.seekCooldownMs) return { type: 'none' };
+      if (absDrift <= this.tuning.deadbandS) {
+        this.stableEvals += 1;
+        if (this.stableEvals >= this.tuning.postSeekStableEvals) {
+          // adapt the lead from the residual error of this seek
+          if (this.seekTargetS !== null) {
+            const residual = drift; // ahead(+)/behind(−) after settling
+            this.seekLead = Math.min(
+              this.tuning.seekLeadMaxS,
+              Math.max(0, this.seekLead - residual * 0.5),
+            );
+            this.seekTargetS = null;
+          }
+          this.state = 'LOCKED';
+          this.stableEvals = 0;
+        }
+        return { type: 'none' };
+      }
+      this.stableEvals = 0;
+      if (sinceSeek < this.tuning.seekSpacingMs) return { type: 'none' };
+      // fall through: still out of band after full spacing → act again
+    }
+
+    // instant path for gross desync (single reading, no filtering)
+    if (Math.abs(rawDrift) > this.tuning.instantSeekS) {
+      return this.issueSeek(input, timeline);
+    }
+
+    if (absDrift <= this.tuning.deadbandS) {
+      this.outOfBandCount = 0;
+      if (this.state === 'NUDGING' && absDrift <= this.tuning.nudgeExitS) {
+        this.state = 'LOCKED';
+        this.nudgeSince = null;
+        this.rateApplied = false;
+        return { type: 'clear-rate' };
+      }
+      if (this.state !== 'NUDGING') this.state = 'LOCKED';
+      return { type: 'none' };
+    }
+
+    // out of band
+    this.outOfBandCount += 1;
+    if (this.outOfBandCount < this.tuning.sustainEvals && !wasBuffering) {
+      return { type: 'none' };
+    }
+
+    // RATE mode: only when the probe proved fractional rates stick and the
+    // error is small enough that a nudge closes it in reasonable time
+    if (
+      input.fractionalRateOK &&
+      absDrift <= this.tuning.rateZoneMaxS &&
+      this.state !== 'SEEKING'
+    ) {
+      if (this.state !== 'NUDGING') {
+        this.state = 'NUDGING';
+        this.nudgeSince = input.tLocal;
+        this.rateApplied = true;
+        this.nudgesIssued += 1;
+        const rate =
+          drift > 0 ? 1 - this.tuning.nudgeRate : 1 + this.tuning.nudgeRate;
+        return { type: 'set-rate', rate };
+      }
+      if (
+        this.nudgeSince !== null &&
+        input.tLocal - this.nudgeSince > this.tuning.nudgeStuckMs
+      ) {
+        // stuck (or the probe lied): escalate
+        this.nudgeSince = null;
+        this.rateApplied = false;
+        return this.issueSeek(input, timeline);
+      }
+      // keep the applied rate; direction flips are handled by exit+re-enter
+      return { type: 'none' };
+    }
+
+    // SEEK mode (the default path)
+    if (absDrift >= this.tuning.seekThresholdS || wasBuffering) {
+      if (input.tLocal - this.lastSeekAt < this.tuning.seekSpacingMs) {
+        return { type: 'none' };
+      }
+      return this.issueSeek(input, timeline);
+    }
+
+    // between deadband and seek threshold without rate support: tolerated
+    // (documented: the SEEK-mode effective deadband is seekThresholdS)
+    return { type: 'none' };
+  }
+
+  private issueSeek(
+    input: ControllerInput,
+    timeline: Timeline,
+  ): ControllerAction {
+    this.state = 'SEEKING';
+    this.lastSeekAt = input.tLocal;
+    this.stableEvals = 0;
+    this.outOfBandCount = 0;
+    this.driftWindow = [];
+    this.seeksIssued += 1;
+    if (this.rateApplied) this.rateApplied = false;
+    const lead = timeline.isPlaying ? this.seekLead : 0;
+    const target = projectMediaTime(timeline, input.serverNow) + lead;
+    this.seekTargetS = target;
+    return { type: 'seek', toMediaTime: Math.max(0, target) };
+  }
+}

--- a/shared/sync-core/player-adapter.ts
+++ b/shared/sync-core/player-adapter.ts
@@ -1,0 +1,20 @@
+import { PlayerLifecycle } from './drift-controller';
+
+/**
+ * The surface the sync engine drives. Implemented by the frontend's
+ * YouTubeAdapter (real IFrame player) and the harness's SimPlayer (bots) —
+ * one controller, three consumers (browser, bots, jest).
+ */
+export interface PlayerAdapter {
+  /** de-quantized playhead in seconds (edge-reconstructed where needed) */
+  getPlayerTime(): number;
+  getLifecycle(): PlayerLifecycle;
+  seekTo(mediaTime: number): void;
+  play(): void;
+  pause(): void;
+  /**
+   * Attempt a playback-rate change; returns the rate actually in effect
+   * afterwards (the YouTube player rounds unsupported values toward 1).
+   */
+  setRate(rate: number): number;
+}

--- a/shared/sync-core/timeline.spec.ts
+++ b/shared/sync-core/timeline.spec.ts
@@ -1,0 +1,88 @@
+import { Timeline } from '../sync-protocol';
+import { applyControl, isNewer, projectMediaTime, snapshot } from './timeline';
+
+const base: Timeline = {
+  v: 1,
+  seq: 5,
+  storeEpoch: 'epoch-a',
+  videoId: 'vid',
+  isPlaying: true,
+  mediaTime: 100,
+  stampedAt: 50_000,
+  rate: 1,
+  reason: 'play',
+};
+
+describe('projectMediaTime', () => {
+  it('advances by elapsed server time while playing', () => {
+    expect(projectMediaTime(base, 60_000)).toBeCloseTo(110, 9);
+  });
+
+  it('is frozen while paused', () => {
+    const paused: Timeline = { ...base, isPlaying: false };
+    expect(projectMediaTime(paused, 90_000)).toBe(100);
+  });
+});
+
+describe('applyControl', () => {
+  it('play restamps at server now from the commanded position', () => {
+    const next = applyControl(base, 'play', 42, 70_000, 'u1');
+    expect(next).toMatchObject({
+      isPlaying: true,
+      mediaTime: 42,
+      stampedAt: 70_000,
+      reason: 'play',
+      by: 'u1',
+    });
+  });
+
+  it("pause freezes at the commander's frozen mediaTime (P4)", () => {
+    // the commander saw 103.2 when pressing pause; projection at receipt
+    // would be ~110 — the frame the presser saw wins
+    const next = applyControl(base, 'pause', 103.2, 60_000, 'u1');
+    expect(next.isPlaying).toBe(false);
+    expect(next.mediaTime).toBe(103.2);
+  });
+
+  it('seek preserves playing state', () => {
+    const playingSeek = applyControl(base, 'seek', 300, 60_000, 'u1');
+    expect(playingSeek.isPlaying).toBe(true);
+    expect(playingSeek.mediaTime).toBe(300);
+    const pausedSeek = applyControl(
+      { ...base, isPlaying: false },
+      'seek',
+      300,
+      60_000,
+      'u1',
+    );
+    expect(pausedSeek.isPlaying).toBe(false);
+  });
+});
+
+describe('snapshot', () => {
+  it('re-anchors the projection without changing state', () => {
+    const snap = snapshot(base, 60_000);
+    expect(snap.mediaTime).toBeCloseTo(110, 9);
+    expect(snap.stampedAt).toBe(60_000);
+    expect(snap.isPlaying).toBe(true);
+    expect(snap.reason).toBe('snapshot');
+  });
+});
+
+describe('isNewer', () => {
+  it('accepts anything when nothing applied yet', () => {
+    expect(isNewer(base, null)).toBe(true);
+  });
+
+  it('same epoch: strictly higher seq wins', () => {
+    expect(isNewer({ ...base, seq: 6 }, base)).toBe(true);
+    expect(isNewer({ ...base, seq: 5 }, base)).toBe(false);
+    expect(isNewer({ ...base, seq: 4 }, base)).toBe(false);
+  });
+
+  it('different epoch always wins (store rehydration)', () => {
+    expect(isNewer({ ...base, storeEpoch: 'epoch-b', seq: 0 }, base)).toBe(
+      true,
+    );
+  });
+});

--- a/shared/sync-core/timeline.ts
+++ b/shared/sync-core/timeline.ts
@@ -1,0 +1,78 @@
+import { ControlIntent, Timeline } from '../sync-protocol';
+
+/** Project the media position (seconds) at a server-domain instant. */
+export function projectMediaTime(tl: Timeline, serverNow: number): number {
+  if (!tl.isPlaying) return tl.mediaTime;
+  return tl.mediaTime + ((serverNow - tl.stampedAt) / 1000) * tl.rate;
+}
+
+/**
+ * Ordering rule for applying received timelines. Same epoch: strictly higher
+ * seq wins. Different epoch: the incoming one wins — an epoch only changes
+ * when the authoritative store was rehydrated, which is by definition newer
+ * than anything from the old epoch (see protocol note on fencing).
+ */
+export function isNewer(incoming: Timeline, applied: Timeline | null): boolean {
+  if (applied === null) return true;
+  if (incoming.storeEpoch !== applied.storeEpoch) return true;
+  return incoming.seq > applied.seq;
+}
+
+/**
+ * Restamp a control intent into a new timeline at server time `serverNow`.
+ * Pure: seq assignment/persistence belong to the state store, which calls
+ * this and commits the result atomically.
+ *
+ * Semantics (design doc P1–P5):
+ * - play: start playing from the commanded position, epoch = now
+ * - pause: freeze at the commander's frozen mediaTime ("the frame I saw"),
+ *   NOT the projected position — projecting forward would pause at a frame
+ *   the presser never saw (P4)
+ * - seek: jump to the commanded position, playing state unchanged
+ */
+export function applyControl(
+  prev: Timeline,
+  intent: ControlIntent,
+  mediaTime: number,
+  serverNow: number,
+  by: string,
+): Omit<Timeline, 'seq'> {
+  const base = {
+    v: 1 as const,
+    storeEpoch: prev.storeEpoch,
+    videoId: prev.videoId,
+    rate: 1 as const,
+    stampedAt: serverNow,
+    by,
+  };
+  switch (intent) {
+    case 'play':
+      return { ...base, isPlaying: true, mediaTime, reason: 'play' };
+    case 'pause':
+      return { ...base, isPlaying: false, mediaTime, reason: 'pause' };
+    case 'seek':
+      return {
+        ...base,
+        isPlaying: prev.isPlaying,
+        mediaTime,
+        reason: 'seek',
+      };
+  }
+}
+
+/** A server-time snapshot re-anchors the projection without changing state. */
+export function snapshot(
+  tl: Timeline,
+  serverNow: number,
+): Omit<Timeline, 'seq'> {
+  return {
+    v: 1,
+    storeEpoch: tl.storeEpoch,
+    videoId: tl.videoId,
+    isPlaying: tl.isPlaying,
+    mediaTime: projectMediaTime(tl, serverNow),
+    stampedAt: serverNow,
+    rate: 1,
+    reason: 'snapshot',
+  };
+}

--- a/shared/sync-protocol.ts
+++ b/shared/sync-protocol.ts
@@ -1,0 +1,106 @@
+// Wire protocol for the sync plane. Canonical copy lives in /shared;
+// scripts/sync-shared.mjs mirrors it into both packages (see that script's
+// header note). Every stateful payload carries v for future evolution —
+// rolling compatibility itself is explicitly out of scope for v1.
+
+/**
+ * The room's playback state as a projectable function of server time,
+ * never a frozen scalar.
+ *
+ *   mediaTimeAt(serverNow) = mediaTime + (isPlaying ? (serverNow - stampedAt)/1000 * rate : 0)
+ *
+ * Ordering: clients drop any timeline older than the last applied
+ * (storeEpoch, seq). storeEpoch changes only when the authoritative store is
+ * rehydrated (restart/flush); a changed epoch is always newer by definition
+ * (plane A has no zombie writers; M13's actor plane adds numeric fencing).
+ */
+export interface Timeline {
+  v: 1;
+  /** monotonic per storeEpoch; assigned atomically by the state store */
+  seq: number;
+  /** random id minted at store rehydration; different epoch === newer */
+  storeEpoch: string;
+  videoId: string | null;
+  isPlaying: boolean;
+  /** media position (seconds) that was true at stampedAt */
+  mediaTime: number;
+  /** server-domain timestamp (ms) at which mediaTime was true */
+  stampedAt: number;
+  /** fixed at 1 in v1; field reserved so the protocol never changes shape */
+  rate: 1;
+  reason: 'play' | 'pause' | 'seek' | 'join' | 'snapshot' | 'succession';
+  /** userId of the commander, when reason is a control intent */
+  by?: string;
+}
+
+/** C→S via Socket.IO ack: client stamps t0, server replies immediately. */
+export interface ClockPing {
+  t0: number;
+}
+
+/** Server ack payload: t1 = receive, t2 = send (both server-domain ms). */
+export interface ClockPong {
+  t0: number;
+  t1: number;
+  t2: number;
+}
+
+export type ControlIntent = 'play' | 'pause' | 'seek';
+
+/**
+ * C→S control. mediaTime is the position the commander intends:
+ * play = start here, pause = freeze at the frame I saw (P4), seek = go here.
+ */
+export interface SyncControl {
+  v: 1;
+  roomCode: string;
+  intent: ControlIntent;
+  mediaTime: number;
+}
+
+/** S→C error for rejected controls (permission, rate limit, no room). */
+export interface SyncControlRejected {
+  v: 1;
+  roomCode: string;
+  intent: ControlIntent;
+  reason: 'not-controller' | 'rate-limited' | 'room-not-found';
+}
+
+/** S→room when the active controller changes (P3 succession). */
+export interface RoomController {
+  v: 1;
+  roomCode: string;
+  controllerId: string;
+  reason: 'creator' | 'succession' | 'reclaim';
+}
+
+/** C→S batched telemetry (off unless debug/harness enables it). */
+export interface SyncReport {
+  v: 1;
+  roomCode: string;
+  samples: Array<{
+    tServerEst: number;
+    playerTime: number;
+    drift: number;
+    offsetMs: number;
+    uncertaintyMs: number;
+    rttMs: number;
+    ctrlState: string;
+    seq: number;
+  }>;
+}
+
+export const SYNC_EVENTS = {
+  /** C→S with ack(ClockPong) */
+  clock: 'sync:clock',
+  /** C→S SyncControl */
+  control: 'sync:control',
+  /** S→room Timeline — the only state message */
+  timeline: 'sync:timeline',
+  /** S→C SyncControlRejected */
+  controlRejected: 'sync:control-rejected',
+  /** C→S SyncReport */
+  report: 'sync:report',
+  /** S→room RoomController */
+  controller: 'room:controller',
+} as const;

--- a/video-sync-backend/src/shared/sync-core/clock-estimator.spec.ts
+++ b/video-sync-backend/src/shared/sync-core/clock-estimator.spec.ts
@@ -1,0 +1,125 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+import { ClockEstimator, ClockSample } from './clock-estimator';
+
+/**
+ * Build one exchange against a server whose clock leads the client by
+ * `offset` ms, with one-way delays upMs (client→server) and downMs.
+ */
+function exchange(
+  t0: number,
+  offset: number,
+  upMs: number,
+  downMs: number,
+  serverProcMs = 0,
+): ClockSample {
+  const t1 = t0 + upMs + offset;
+  const t2 = t1 + serverProcMs;
+  const t3 = t2 - offset + downMs;
+  return { t0, t1, t2, t3 };
+}
+
+describe('ClockEstimator', () => {
+  it('recovers the exact offset on a symmetric path', () => {
+    const est = new ClockEstimator();
+    let t = 1_000;
+    for (let i = 0; i < 8; i++) {
+      est.addSample(exchange(t, 250, 40, 40));
+      t += 150;
+    }
+    expect(est.getEstimate().offsetMs).toBeCloseTo(250, 5);
+    // uncertainty = δ_min/2 = (40+40)/2 = 40
+    expect(est.getEstimate().uncertaintyMs).toBeCloseTo(40, 5);
+  });
+
+  it('bias on an asymmetric path is bounded by half the asymmetry', () => {
+    const est = new ClockEstimator();
+    let t = 1_000;
+    for (let i = 0; i < 8; i++) {
+      est.addSample(exchange(t, 250, 120, 20)); // 100ms asymmetry
+      t += 150;
+    }
+    const { offsetMs } = est.getEstimate();
+    // θ = offset + (up-down)/2 = 250 + 50
+    expect(offsetMs).toBeCloseTo(300, 5);
+    expect(Math.abs(offsetMs - 250)).toBeLessThanOrEqual(50 + 1e-9);
+  });
+
+  it('min-RTT selection rejects delay spikes', () => {
+    const est = new ClockEstimator();
+    let t = 1_000;
+    for (let i = 0; i < 6; i++) {
+      est.addSample(exchange(t, 250, 20, 20));
+      t += 150;
+    }
+    // burst of congested samples with wild asymmetric delays
+    for (let i = 0; i < 3; i++) {
+      est.addSample(exchange(t, 250, 900, 30));
+      t += 150;
+    }
+    expect(est.getEstimate().offsetMs).toBeCloseTo(250, 3);
+  });
+
+  it('discards non-causal samples (negative rtt)', () => {
+    const est = new ClockEstimator();
+    // t3-t0 = 30ms but the server claims 50ms of processing: δ = -20
+    expect(est.addSample({ t0: 1000, t1: 1240, t2: 1290, t3: 1030 })).toBe(
+      false,
+    );
+    expect(est.hasEstimate()).toBe(false);
+  });
+
+  it('small corrections slew instead of stepping', () => {
+    const est = new ClockEstimator();
+    let t = 1_000;
+    for (let i = 0; i < 8; i++) {
+      est.addSample(exchange(t, 250, 30, 30));
+      t += 150;
+    }
+    est.tick(t);
+    // nudge the true offset by 10ms — below the 20ms step threshold
+    for (let i = 0; i < 8; i++) {
+      est.addSample(exchange(t, 260, 30, 30));
+      t += 150;
+    }
+    const before = est.getEstimate().offsetMs;
+    expect(before).toBeLessThan(260); // not stepped
+    // 2 simulated seconds of ticking at 4Hz: slew limit 5ms/s → ≤10ms travel
+    for (let i = 0; i < 8; i++) {
+      t += 250;
+      est.tick(t);
+    }
+    const after = est.getEstimate().offsetMs;
+    expect(after).toBeGreaterThan(before);
+    expect(after).toBeLessThanOrEqual(260 + 1e-9);
+  });
+
+  it('large corrections step immediately', () => {
+    const est = new ClockEstimator();
+    let t = 1_000;
+    for (let i = 0; i < 8; i++) {
+      est.addSample(exchange(t, 250, 30, 30));
+      t += 150;
+    }
+    // clock jumped 500ms (e.g. host NTP step)
+    for (let i = 0; i < 8; i++) {
+      est.addSample(exchange(t, 750, 30, 30));
+      t += 150;
+    }
+    expect(est.getEstimate().offsetMs).toBeCloseTo(750, 3);
+  });
+
+  it('serverNow maps local time through the applied offset', () => {
+    const est = new ClockEstimator();
+    est.addSample(exchange(1000, 250, 30, 30));
+    expect(est.serverNow(5000)).toBeCloseTo(5250, 5);
+  });
+
+  it('reset clears history for reconnect re-burst', () => {
+    const est = new ClockEstimator();
+    est.addSample(exchange(1000, 250, 30, 30));
+    est.reset();
+    expect(est.hasEstimate()).toBe(false);
+    expect(est.getEstimate().sampleCount).toBe(0);
+  });
+});

--- a/video-sync-backend/src/shared/sync-core/clock-estimator.ts
+++ b/video-sync-backend/src/shared/sync-core/clock-estimator.ts
@@ -1,0 +1,158 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+// NTP-style clock-offset estimator over the sync:clock exchange.
+//
+// Per exchange: client stamps t0 on send and t3 on receipt; the server's ack
+// carries t1 (receive) and t2 (send), all in its own clock domain.
+//
+//   offset θ = ((t1 - t0) + (t2 - t3)) / 2      (server − client)
+//   rtt    δ = (t3 - t0) - (t2 - t1)
+//
+// |θ_true − θ| ≤ δ/2 + |path asymmetry|/2. The asymmetry term is irreducible
+// for any NTP-family scheme — scenario S6 exists to demonstrate it honestly.
+//
+// Estimation: keep a ring of samples, select the K lowest-δ samples within a
+// recency window (min-RTT filtering tightens the δ/2 bound), use their median
+// θ (kills single-sample jumpiness). Apply small corrections as a slew so the
+// drift controller never sees the clock step under it; large corrections step
+// immediately and the controller re-evaluates.
+//
+// Deterministic: no Date.now() inside — callers pass local timestamps.
+
+export interface ClockSample {
+  t0: number;
+  t1: number;
+  t2: number;
+  t3: number;
+}
+
+export interface ClockEstimate {
+  /** currently applied offset (server − client), ms */
+  offsetMs: number;
+  /** raw target from the sample set, ms */
+  targetOffsetMs: number;
+  /** δ_min/2 over the selected samples, ms; Infinity until a sample lands */
+  uncertaintyMs: number;
+  /** most recent rtt observation, ms */
+  lastRttMs: number;
+  sampleCount: number;
+}
+
+export interface ClockTuning {
+  ringSize: number;
+  /** samples older than this are ignored for selection (bounds skew error) */
+  windowMs: number;
+  /** how many lowest-δ samples the median is taken over */
+  bestK: number;
+  /** |Δθ| below this slews instead of stepping */
+  slewThresholdMs: number;
+  /** slew rate limit, ms of correction per second of local time */
+  slewRatePerS: number;
+}
+
+export const DEFAULT_CLOCK_TUNING: ClockTuning = {
+  ringSize: 64,
+  windowMs: 60_000,
+  bestK: 5,
+  slewThresholdMs: 20,
+  slewRatePerS: 5,
+};
+
+interface StoredSample {
+  theta: number;
+  delta: number;
+  t3: number;
+}
+
+export class ClockEstimator {
+  private samples: StoredSample[] = [];
+  private applied: number | null = null;
+  private target = 0;
+  private uncertainty = Infinity;
+  private lastRtt = NaN;
+  private lastTick: number | null = null;
+
+  constructor(private tuning: ClockTuning = DEFAULT_CLOCK_TUNING) {}
+
+  /** Feed one completed exchange. Returns true if the sample was usable. */
+  addSample(s: ClockSample): boolean {
+    const delta = s.t3 - s.t0 - (s.t2 - s.t1);
+    if (delta < 0) return false; // non-causal: clock stepped mid-exchange
+    const theta = (s.t1 - s.t0 + (s.t2 - s.t3)) / 2;
+    this.samples.push({ theta, delta, t3: s.t3 });
+    if (this.samples.length > this.tuning.ringSize) {
+      this.samples.splice(0, this.samples.length - this.tuning.ringSize);
+    }
+    this.lastRtt = delta;
+    this.recompute(s.t3);
+    return true;
+  }
+
+  private recompute(nowLocal: number): void {
+    const recent = this.samples.filter(
+      (x) => nowLocal - x.t3 <= this.tuning.windowMs,
+    );
+    if (recent.length === 0) return;
+    // lowest δ first; among equal-quality samples prefer the newest, so a
+    // genuine server-clock change wins over stale history within the window
+    const best = [...recent]
+      .sort((a, b) => a.delta - b.delta || b.t3 - a.t3)
+      .slice(0, this.tuning.bestK);
+    const thetas = best.map((x) => x.theta).sort((a, b) => a - b);
+    const median = thetas[Math.floor(thetas.length / 2)];
+    this.target = median;
+    this.uncertainty = best[0].delta / 2;
+
+    if (this.applied === null) {
+      // first estimate: step, there is nothing to disturb yet
+      this.applied = this.target;
+    } else if (
+      Math.abs(this.target - this.applied) >= this.tuning.slewThresholdMs
+    ) {
+      this.applied = this.target;
+    }
+    // otherwise tick() slews toward target
+  }
+
+  /** Advance the slew; call at the controller cadence with local ms time. */
+  tick(nowLocal: number): void {
+    if (this.applied === null) return;
+    if (this.lastTick !== null) {
+      const dtS = (nowLocal - this.lastTick) / 1000;
+      const maxStep = this.tuning.slewRatePerS * dtS;
+      const diff = this.target - this.applied;
+      if (Math.abs(diff) <= maxStep) this.applied = this.target;
+      else this.applied += Math.sign(diff) * maxStep;
+    }
+    this.lastTick = nowLocal;
+  }
+
+  /** Map a local timestamp into the server clock domain. */
+  serverNow(nowLocal: number): number {
+    return nowLocal + (this.applied ?? 0);
+  }
+
+  hasEstimate(): boolean {
+    return this.applied !== null;
+  }
+
+  getEstimate(): ClockEstimate {
+    return {
+      offsetMs: this.applied ?? 0,
+      targetOffsetMs: this.target,
+      uncertaintyMs: this.uncertainty,
+      lastRttMs: this.lastRtt,
+      sampleCount: this.samples.length,
+    };
+  }
+
+  /** Drop history (reconnect, visibility restore): re-burst follows. */
+  reset(): void {
+    this.samples = [];
+    this.applied = null;
+    this.target = 0;
+    this.uncertainty = Infinity;
+    this.lastRtt = NaN;
+    this.lastTick = null;
+  }
+}

--- a/video-sync-backend/src/shared/sync-core/drift-controller.spec.ts
+++ b/video-sync-backend/src/shared/sync-core/drift-controller.spec.ts
@@ -1,0 +1,230 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+import { Timeline } from '../sync-protocol';
+import {
+  ControllerAction,
+  ControllerInput,
+  DriftController,
+} from './drift-controller';
+
+const timeline = (over: Partial<Timeline> = {}): Timeline => ({
+  v: 1,
+  seq: 1,
+  storeEpoch: 'e',
+  videoId: 'vid',
+  isPlaying: true,
+  mediaTime: 100,
+  stampedAt: 0,
+  rate: 1,
+  reason: 'play',
+  ...over,
+});
+
+/**
+ * Drive the controller along simulated time. `driftS` positive = player
+ * ahead of the room timeline. Returns every action taken.
+ */
+function drive(
+  ctrl: DriftController,
+  steps: Array<Partial<ControllerInput> & { driftS?: number }>,
+  startLocal = 100_000,
+): ControllerAction[] {
+  const actions: ControllerAction[] = [];
+  let tLocal = startLocal;
+  for (const step of steps) {
+    tLocal += 250;
+    const tl = step.timeline === undefined ? timeline() : step.timeline;
+    const serverNow = tLocal; // offset 0 keeps expectations legible
+    const expected = tl
+      ? tl.mediaTime + (tl.isPlaying ? (serverNow - tl.stampedAt) / 1000 : 0)
+      : 0;
+    const input: ControllerInput = {
+      tLocal,
+      serverNow,
+      playerTime: expected + (step.driftS ?? 0),
+      playerState: step.playerState ?? 'playing',
+      timeline: tl,
+      fractionalRateOK: step.fractionalRateOK ?? false,
+    };
+    actions.push(ctrl.evaluate(input));
+  }
+  return actions;
+}
+
+const types = (a: ControllerAction[]): string[] => a.map((x) => x.type);
+
+describe('DriftController — SEEK mode (default)', () => {
+  it('stays quiet inside the deadband', () => {
+    const ctrl = new DriftController();
+    const actions = drive(ctrl, [
+      { driftS: 0.05 },
+      { driftS: -0.08 },
+      { driftS: 0.1 },
+      { driftS: 0.02 },
+    ]);
+    expect(types(actions)).toEqual(['none', 'none', 'none', 'none']);
+  });
+
+  it('seeks after sustained drift beyond the seek threshold, with lead', () => {
+    const ctrl = new DriftController();
+    const actions = drive(ctrl, [
+      { driftS: 0.02 },
+      { driftS: -0.5 },
+      { driftS: -0.5 },
+      { driftS: -0.5 },
+    ]);
+    const seekIdx = types(actions).indexOf('seek');
+    expect(seekIdx).toBeGreaterThan(0);
+    const seek = actions[seekIdx] as { type: 'seek'; toMediaTime: number };
+    // target = projected + default 0.3s lead
+    const expectedAt = 100 + (100_000 + 250 * (seekIdx + 1)) / 1000;
+    expect(seek.toMediaTime).toBeCloseTo(expectedAt + 0.3, 1);
+  });
+
+  it('a single gross reading seeks immediately (post-sleep path)', () => {
+    const ctrl = new DriftController();
+    const actions = drive(ctrl, [{ driftS: 0.0 }, { driftS: -30 }]);
+    expect(types(actions)[1]).toBe('seek');
+  });
+
+  it('respects the seek spacing (no seek storms)', () => {
+    const ctrl = new DriftController();
+    const steps = Array.from({ length: 20 }, () => ({ driftS: -3 as number }));
+    const actions = drive(ctrl, steps);
+    const seeks = types(actions).filter((t) => t === 'seek').length;
+    // 20 evals * 250ms = 5s window; 3s spacing → at most 2 seeks
+    expect(seeks).toBeLessThanOrEqual(2);
+    expect(seeks).toBeGreaterThan(0);
+  });
+
+  it('tolerates drift between deadband and threshold without rate support', () => {
+    const ctrl = new DriftController();
+    const actions = drive(ctrl, [
+      { driftS: 0.2 },
+      { driftS: 0.2 },
+      { driftS: 0.2 },
+      { driftS: 0.2 },
+    ]);
+    expect(types(actions)).toEqual(['none', 'none', 'none', 'none']);
+  });
+});
+
+describe('DriftController — RATE mode (probe-gated)', () => {
+  it('nudges within the rate zone and clears on convergence', () => {
+    const ctrl = new DriftController();
+    const actions = drive(ctrl, [
+      { driftS: 0.3, fractionalRateOK: true },
+      { driftS: 0.3, fractionalRateOK: true },
+      { driftS: 0.25, fractionalRateOK: true },
+      { driftS: 0.15, fractionalRateOK: true },
+      { driftS: 0.05, fractionalRateOK: true },
+      { driftS: 0.03, fractionalRateOK: true },
+    ]);
+    const t = types(actions);
+    const first = t.indexOf('set-rate');
+    expect(first).toBeGreaterThanOrEqual(1);
+    const rate = actions[first] as { type: 'set-rate'; rate: number };
+    expect(rate.rate).toBeCloseTo(0.95, 9); // ahead → slow down
+    expect(t).toContain('clear-rate');
+  });
+
+  it('escalates to seek when nudging is stuck', () => {
+    const ctrl = new DriftController();
+    // 70 evals * 250ms = 17.5s stuck at 0.4s drift > 15s stuck limit
+    const steps = Array.from({ length: 70 }, () => ({
+      driftS: 0.4 as number,
+      fractionalRateOK: true,
+    }));
+    const actions = drive(ctrl, steps);
+    expect(types(actions)).toContain('seek');
+  });
+
+  it('never nudges when the probe failed', () => {
+    const ctrl = new DriftController();
+    const steps = Array.from({ length: 10 }, () => ({
+      driftS: 0.4 as number,
+      fractionalRateOK: false,
+    }));
+    const actions = drive(ctrl, steps);
+    expect(types(actions)).not.toContain('set-rate');
+    expect(types(actions)).toContain('seek');
+  });
+});
+
+describe('DriftController — lifecycle', () => {
+  it('suspends corrections while buffering and clears any applied rate', () => {
+    const ctrl = new DriftController();
+    const warmup = drive(ctrl, [
+      { driftS: 0.3, fractionalRateOK: true },
+      { driftS: 0.3, fractionalRateOK: true },
+    ]);
+    expect(types(warmup)).toContain('set-rate');
+    const actions = drive(
+      ctrl,
+      [
+        { driftS: 0.3, playerState: 'buffering', fractionalRateOK: true },
+        { driftS: 0.3, playerState: 'buffering', fractionalRateOK: true },
+      ],
+      101_000,
+    );
+    expect(types(actions)[0]).toBe('clear-rate');
+    expect(types(actions)[1]).toBe('none');
+  });
+
+  it('catches up after buffering ends (P2 free-run policy)', () => {
+    const ctrl = new DriftController();
+    drive(ctrl, [{ driftS: 0, playerState: 'buffering' }]);
+    const actions = drive(
+      ctrl,
+      [{ driftS: -4 }], // fell 4s behind while buffering
+      110_000,
+    );
+    expect(types(actions)[0]).toBe('seek');
+  });
+
+  it('pauses the player when the room pauses, then reconciles position', () => {
+    const ctrl = new DriftController();
+    const paused = timeline({ isPlaying: false, mediaTime: 100 });
+    const a1 = drive(ctrl, [{ timeline: paused, playerState: 'playing' }]);
+    expect(types(a1)).toEqual(['pause']);
+    const a2 = drive(
+      ctrl,
+      [{ timeline: paused, playerState: 'paused', driftS: 0 }],
+      200_000,
+    );
+    // playerTime = projected(=100) + 0 → within reconcile band → no seek
+    expect(types(a2)).toEqual(['none']);
+  });
+
+  it('silently reconciles a paused player that is off-position', () => {
+    const ctrl = new DriftController();
+    const paused = timeline({ isPlaying: false, mediaTime: 100 });
+    const tLocal = 300_000;
+    const input: ControllerInput = {
+      tLocal,
+      serverNow: tLocal,
+      playerTime: 103, // 3s off while paused
+      playerState: 'paused',
+      timeline: paused,
+      fractionalRateOK: false,
+    };
+    const action = ctrl.evaluate(input);
+    expect(action).toEqual({ type: 'seek', toMediaTime: 100 });
+  });
+
+  it('starts a paused player when the room is playing', () => {
+    const ctrl = new DriftController();
+    const a = drive(ctrl, [{ playerState: 'paused', driftS: 0 }]);
+    expect(types(a)).toEqual(['play']);
+  });
+
+  it('does nothing while suspended and acts fast after resume', () => {
+    const ctrl = new DriftController();
+    ctrl.suspend();
+    const quiet = drive(ctrl, [{ driftS: -5 }]);
+    expect(types(quiet)).toEqual(['none']);
+    ctrl.resume();
+    const active = drive(ctrl, [{ driftS: -0.5 }], 400_000);
+    expect(types(active)).toEqual(['seek']); // hysteresis dropped on resume
+  });
+});

--- a/video-sync-backend/src/shared/sync-core/drift-controller.ts
+++ b/video-sync-backend/src/shared/sync-core/drift-controller.ts
@@ -1,0 +1,307 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+// Drift-correction state machine. SEEK-first by design: the YouTube IFrame
+// API rounds unsupported playbackRate values toward 1 (per its reference),
+// so fractional-rate nudging is an opportunistic enhancement enabled per
+// video by a runtime probe (fractionalRateOK) — not the primary path.
+//
+// Pure and deterministic: evaluate() receives everything it needs and
+// returns an action; the engine (browser or SimPlayer bot) executes it.
+// All thresholds are named tuning constants, tuned against committed
+// measurement runs — never adjectives.
+
+import { Timeline } from '../sync-protocol';
+import { projectMediaTime } from './timeline';
+
+export type PlayerLifecycle =
+  | 'unstarted'
+  | 'playing'
+  | 'paused'
+  | 'buffering'
+  | 'ended'
+  | 'cued';
+
+export interface ControllerInput {
+  /** local ms clock (performance-independent, same domain as estimator t0/t3) */
+  tLocal: number;
+  /** estimator-mapped server-domain time for tLocal */
+  serverNow: number;
+  /** de-quantized playhead seconds (edge-reconstructed by the adapter) */
+  playerTime: number;
+  playerState: PlayerLifecycle;
+  timeline: Timeline | null;
+  /** result of the per-video setPlaybackRate probe */
+  fractionalRateOK: boolean;
+}
+
+export type ControllerAction =
+  | { type: 'none' }
+  | { type: 'seek'; toMediaTime: number }
+  | { type: 'set-rate'; rate: number }
+  | { type: 'clear-rate' }
+  | { type: 'play' }
+  | { type: 'pause' };
+
+export type ControllerState =
+  | 'LOCKED'
+  | 'NUDGING'
+  | 'SEEKING'
+  | 'BUFFERING'
+  | 'PAUSED_SYNC'
+  | 'SUSPENDED';
+
+export interface ControllerTuning {
+  /** |drift| below this is noise, not error (floored at 2× measured noise σ) */
+  deadbandS: number;
+  /** SEEK mode: correct when |drift| exceeds this for `sustainEvals` evals */
+  seekThresholdS: number;
+  sustainEvals: number;
+  /** single-reading drift beyond this seeks immediately (post-sleep etc.) */
+  instantSeekS: number;
+  /** minimum spacing between corrective seeks, ms */
+  seekSpacingMs: number;
+  /** post-seek cooldown before drift is trusted again, ms */
+  seekCooldownMs: number;
+  /** stable in-band evals required to re-LOCK after a seek */
+  postSeekStableEvals: number;
+  /** initial seek lead (EMA of measured settle replaces it at runtime), s */
+  seekLeadS: number;
+  seekLeadMaxS: number;
+  /** RATE mode window: nudge between deadband and this bound */
+  rateZoneMaxS: number;
+  nudgeRate: number;
+  /** exit nudging when |drift| falls below this */
+  nudgeExitS: number;
+  /** give up on nudging and seek if not back in band within this, ms */
+  nudgeStuckMs: number;
+  /** paused reconcile: silent seek when |playerTime − mediaTime| exceeds */
+  pausedReconcileS: number;
+}
+
+export const DEFAULT_CONTROLLER_TUNING: ControllerTuning = {
+  deadbandS: 0.12,
+  seekThresholdS: 0.3,
+  sustainEvals: 2,
+  instantSeekS: 2.5,
+  seekSpacingMs: 3000,
+  seekCooldownMs: 1500,
+  postSeekStableEvals: 2,
+  seekLeadS: 0.3,
+  seekLeadMaxS: 1.2,
+  rateZoneMaxS: 0.6,
+  nudgeRate: 0.05,
+  nudgeExitS: 0.06,
+  nudgeStuckMs: 15_000,
+  pausedReconcileS: 0.25,
+};
+
+export interface ControllerStatus {
+  state: ControllerState;
+  lastDriftS: number;
+  seekLeadS: number;
+  seeksIssued: number;
+  nudgesIssued: number;
+}
+
+export class DriftController {
+  private state: ControllerState = 'LOCKED';
+  private driftWindow: number[] = [];
+  private outOfBandCount = 0;
+  private lastSeekAt = -Infinity;
+  private seekTargetS: number | null = null;
+  private stableEvals = 0;
+  private nudgeSince: number | null = null;
+  private rateApplied = false;
+  private seekLead: number;
+  private seeksIssued = 0;
+  private nudgesIssued = 0;
+  private lastDrift = 0;
+
+  constructor(private tuning: ControllerTuning = DEFAULT_CONTROLLER_TUNING) {
+    this.seekLead = tuning.seekLeadS;
+  }
+
+  suspend(): void {
+    this.state = 'SUSPENDED';
+    this.driftWindow = [];
+    this.outOfBandCount = 0;
+  }
+
+  /** visibility restore / reconnect: evaluate immediately, hysteresis dropped */
+  resume(): void {
+    this.state = 'LOCKED';
+    this.driftWindow = [];
+    this.outOfBandCount = this.tuning.sustainEvals; // first out-of-band eval acts
+  }
+
+  getStatus(): ControllerStatus {
+    return {
+      state: this.state,
+      lastDriftS: this.lastDrift,
+      seekLeadS: this.seekLead,
+      seeksIssued: this.seeksIssued,
+      nudgesIssued: this.nudgesIssued,
+    };
+  }
+
+  evaluate(input: ControllerInput): ControllerAction {
+    const { timeline } = input;
+    if (this.state === 'SUSPENDED' || timeline === null)
+      return { type: 'none' };
+
+    // ---- lifecycle reconciliation before drift logic ----
+    if (input.playerState === 'buffering') {
+      this.state = 'BUFFERING';
+      if (this.rateApplied) {
+        this.rateApplied = false;
+        this.nudgeSince = null;
+        return { type: 'clear-rate' };
+      }
+      return { type: 'none' };
+    }
+
+    if (!timeline.isPlaying) {
+      // room is paused: reconcile position, make sure we are paused too
+      if (input.playerState === 'playing') return { type: 'pause' };
+      this.state = 'PAUSED_SYNC';
+      const err = Math.abs(input.playerTime - timeline.mediaTime);
+      if (
+        err > this.tuning.pausedReconcileS &&
+        input.tLocal - this.lastSeekAt > this.tuning.seekSpacingMs
+      ) {
+        this.lastSeekAt = input.tLocal;
+        this.seeksIssued += 1;
+        return { type: 'seek', toMediaTime: timeline.mediaTime };
+      }
+      return { type: 'none' };
+    }
+
+    // room is playing
+    if (input.playerState === 'paused' || input.playerState === 'cued') {
+      return { type: 'play' };
+    }
+    if (input.playerState !== 'playing') return { type: 'none' };
+
+    // leaving BUFFERING: catch-up evaluation with cooldown waived (P2)
+    const wasBuffering = this.state === 'BUFFERING';
+    if (wasBuffering) this.state = 'LOCKED';
+
+    const expected = projectMediaTime(timeline, input.serverNow);
+    const rawDrift = input.playerTime - expected; // positive = ahead
+
+    // median-of-3 guard against readout outliers
+    this.driftWindow.push(rawDrift);
+    if (this.driftWindow.length > 3) this.driftWindow.shift();
+    const sorted = [...this.driftWindow].sort((a, b) => a - b);
+    const drift = sorted[Math.floor(sorted.length / 2)];
+    this.lastDrift = drift;
+    const absDrift = Math.abs(drift);
+
+    // post-seek: measure settle, ignore drift until cooldown + stability
+    if (this.state === 'SEEKING') {
+      const sinceSeek = input.tLocal - this.lastSeekAt;
+      if (sinceSeek < this.tuning.seekCooldownMs) return { type: 'none' };
+      if (absDrift <= this.tuning.deadbandS) {
+        this.stableEvals += 1;
+        if (this.stableEvals >= this.tuning.postSeekStableEvals) {
+          // adapt the lead from the residual error of this seek
+          if (this.seekTargetS !== null) {
+            const residual = drift; // ahead(+)/behind(−) after settling
+            this.seekLead = Math.min(
+              this.tuning.seekLeadMaxS,
+              Math.max(0, this.seekLead - residual * 0.5),
+            );
+            this.seekTargetS = null;
+          }
+          this.state = 'LOCKED';
+          this.stableEvals = 0;
+        }
+        return { type: 'none' };
+      }
+      this.stableEvals = 0;
+      if (sinceSeek < this.tuning.seekSpacingMs) return { type: 'none' };
+      // fall through: still out of band after full spacing → act again
+    }
+
+    // instant path for gross desync (single reading, no filtering)
+    if (Math.abs(rawDrift) > this.tuning.instantSeekS) {
+      return this.issueSeek(input, timeline);
+    }
+
+    if (absDrift <= this.tuning.deadbandS) {
+      this.outOfBandCount = 0;
+      if (this.state === 'NUDGING' && absDrift <= this.tuning.nudgeExitS) {
+        this.state = 'LOCKED';
+        this.nudgeSince = null;
+        this.rateApplied = false;
+        return { type: 'clear-rate' };
+      }
+      if (this.state !== 'NUDGING') this.state = 'LOCKED';
+      return { type: 'none' };
+    }
+
+    // out of band
+    this.outOfBandCount += 1;
+    if (this.outOfBandCount < this.tuning.sustainEvals && !wasBuffering) {
+      return { type: 'none' };
+    }
+
+    // RATE mode: only when the probe proved fractional rates stick and the
+    // error is small enough that a nudge closes it in reasonable time
+    if (
+      input.fractionalRateOK &&
+      absDrift <= this.tuning.rateZoneMaxS &&
+      this.state !== 'SEEKING'
+    ) {
+      if (this.state !== 'NUDGING') {
+        this.state = 'NUDGING';
+        this.nudgeSince = input.tLocal;
+        this.rateApplied = true;
+        this.nudgesIssued += 1;
+        const rate =
+          drift > 0 ? 1 - this.tuning.nudgeRate : 1 + this.tuning.nudgeRate;
+        return { type: 'set-rate', rate };
+      }
+      if (
+        this.nudgeSince !== null &&
+        input.tLocal - this.nudgeSince > this.tuning.nudgeStuckMs
+      ) {
+        // stuck (or the probe lied): escalate
+        this.nudgeSince = null;
+        this.rateApplied = false;
+        return this.issueSeek(input, timeline);
+      }
+      // keep the applied rate; direction flips are handled by exit+re-enter
+      return { type: 'none' };
+    }
+
+    // SEEK mode (the default path)
+    if (absDrift >= this.tuning.seekThresholdS || wasBuffering) {
+      if (input.tLocal - this.lastSeekAt < this.tuning.seekSpacingMs) {
+        return { type: 'none' };
+      }
+      return this.issueSeek(input, timeline);
+    }
+
+    // between deadband and seek threshold without rate support: tolerated
+    // (documented: the SEEK-mode effective deadband is seekThresholdS)
+    return { type: 'none' };
+  }
+
+  private issueSeek(
+    input: ControllerInput,
+    timeline: Timeline,
+  ): ControllerAction {
+    this.state = 'SEEKING';
+    this.lastSeekAt = input.tLocal;
+    this.stableEvals = 0;
+    this.outOfBandCount = 0;
+    this.driftWindow = [];
+    this.seeksIssued += 1;
+    if (this.rateApplied) this.rateApplied = false;
+    const lead = timeline.isPlaying ? this.seekLead : 0;
+    const target = projectMediaTime(timeline, input.serverNow) + lead;
+    this.seekTargetS = target;
+    return { type: 'seek', toMediaTime: Math.max(0, target) };
+  }
+}

--- a/video-sync-backend/src/shared/sync-core/player-adapter.ts
+++ b/video-sync-backend/src/shared/sync-core/player-adapter.ts
@@ -1,0 +1,22 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+import { PlayerLifecycle } from './drift-controller';
+
+/**
+ * The surface the sync engine drives. Implemented by the frontend's
+ * YouTubeAdapter (real IFrame player) and the harness's SimPlayer (bots) —
+ * one controller, three consumers (browser, bots, jest).
+ */
+export interface PlayerAdapter {
+  /** de-quantized playhead in seconds (edge-reconstructed where needed) */
+  getPlayerTime(): number;
+  getLifecycle(): PlayerLifecycle;
+  seekTo(mediaTime: number): void;
+  play(): void;
+  pause(): void;
+  /**
+   * Attempt a playback-rate change; returns the rate actually in effect
+   * afterwards (the YouTube player rounds unsupported values toward 1).
+   */
+  setRate(rate: number): number;
+}

--- a/video-sync-backend/src/shared/sync-core/timeline.spec.ts
+++ b/video-sync-backend/src/shared/sync-core/timeline.spec.ts
@@ -1,0 +1,90 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+import { Timeline } from '../sync-protocol';
+import { applyControl, isNewer, projectMediaTime, snapshot } from './timeline';
+
+const base: Timeline = {
+  v: 1,
+  seq: 5,
+  storeEpoch: 'epoch-a',
+  videoId: 'vid',
+  isPlaying: true,
+  mediaTime: 100,
+  stampedAt: 50_000,
+  rate: 1,
+  reason: 'play',
+};
+
+describe('projectMediaTime', () => {
+  it('advances by elapsed server time while playing', () => {
+    expect(projectMediaTime(base, 60_000)).toBeCloseTo(110, 9);
+  });
+
+  it('is frozen while paused', () => {
+    const paused: Timeline = { ...base, isPlaying: false };
+    expect(projectMediaTime(paused, 90_000)).toBe(100);
+  });
+});
+
+describe('applyControl', () => {
+  it('play restamps at server now from the commanded position', () => {
+    const next = applyControl(base, 'play', 42, 70_000, 'u1');
+    expect(next).toMatchObject({
+      isPlaying: true,
+      mediaTime: 42,
+      stampedAt: 70_000,
+      reason: 'play',
+      by: 'u1',
+    });
+  });
+
+  it("pause freezes at the commander's frozen mediaTime (P4)", () => {
+    // the commander saw 103.2 when pressing pause; projection at receipt
+    // would be ~110 — the frame the presser saw wins
+    const next = applyControl(base, 'pause', 103.2, 60_000, 'u1');
+    expect(next.isPlaying).toBe(false);
+    expect(next.mediaTime).toBe(103.2);
+  });
+
+  it('seek preserves playing state', () => {
+    const playingSeek = applyControl(base, 'seek', 300, 60_000, 'u1');
+    expect(playingSeek.isPlaying).toBe(true);
+    expect(playingSeek.mediaTime).toBe(300);
+    const pausedSeek = applyControl(
+      { ...base, isPlaying: false },
+      'seek',
+      300,
+      60_000,
+      'u1',
+    );
+    expect(pausedSeek.isPlaying).toBe(false);
+  });
+});
+
+describe('snapshot', () => {
+  it('re-anchors the projection without changing state', () => {
+    const snap = snapshot(base, 60_000);
+    expect(snap.mediaTime).toBeCloseTo(110, 9);
+    expect(snap.stampedAt).toBe(60_000);
+    expect(snap.isPlaying).toBe(true);
+    expect(snap.reason).toBe('snapshot');
+  });
+});
+
+describe('isNewer', () => {
+  it('accepts anything when nothing applied yet', () => {
+    expect(isNewer(base, null)).toBe(true);
+  });
+
+  it('same epoch: strictly higher seq wins', () => {
+    expect(isNewer({ ...base, seq: 6 }, base)).toBe(true);
+    expect(isNewer({ ...base, seq: 5 }, base)).toBe(false);
+    expect(isNewer({ ...base, seq: 4 }, base)).toBe(false);
+  });
+
+  it('different epoch always wins (store rehydration)', () => {
+    expect(isNewer({ ...base, storeEpoch: 'epoch-b', seq: 0 }, base)).toBe(
+      true,
+    );
+  });
+});

--- a/video-sync-backend/src/shared/sync-core/timeline.ts
+++ b/video-sync-backend/src/shared/sync-core/timeline.ts
@@ -1,0 +1,80 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+import { ControlIntent, Timeline } from '../sync-protocol';
+
+/** Project the media position (seconds) at a server-domain instant. */
+export function projectMediaTime(tl: Timeline, serverNow: number): number {
+  if (!tl.isPlaying) return tl.mediaTime;
+  return tl.mediaTime + ((serverNow - tl.stampedAt) / 1000) * tl.rate;
+}
+
+/**
+ * Ordering rule for applying received timelines. Same epoch: strictly higher
+ * seq wins. Different epoch: the incoming one wins — an epoch only changes
+ * when the authoritative store was rehydrated, which is by definition newer
+ * than anything from the old epoch (see protocol note on fencing).
+ */
+export function isNewer(incoming: Timeline, applied: Timeline | null): boolean {
+  if (applied === null) return true;
+  if (incoming.storeEpoch !== applied.storeEpoch) return true;
+  return incoming.seq > applied.seq;
+}
+
+/**
+ * Restamp a control intent into a new timeline at server time `serverNow`.
+ * Pure: seq assignment/persistence belong to the state store, which calls
+ * this and commits the result atomically.
+ *
+ * Semantics (design doc P1–P5):
+ * - play: start playing from the commanded position, epoch = now
+ * - pause: freeze at the commander's frozen mediaTime ("the frame I saw"),
+ *   NOT the projected position — projecting forward would pause at a frame
+ *   the presser never saw (P4)
+ * - seek: jump to the commanded position, playing state unchanged
+ */
+export function applyControl(
+  prev: Timeline,
+  intent: ControlIntent,
+  mediaTime: number,
+  serverNow: number,
+  by: string,
+): Omit<Timeline, 'seq'> {
+  const base = {
+    v: 1 as const,
+    storeEpoch: prev.storeEpoch,
+    videoId: prev.videoId,
+    rate: 1 as const,
+    stampedAt: serverNow,
+    by,
+  };
+  switch (intent) {
+    case 'play':
+      return { ...base, isPlaying: true, mediaTime, reason: 'play' };
+    case 'pause':
+      return { ...base, isPlaying: false, mediaTime, reason: 'pause' };
+    case 'seek':
+      return {
+        ...base,
+        isPlaying: prev.isPlaying,
+        mediaTime,
+        reason: 'seek',
+      };
+  }
+}
+
+/** A server-time snapshot re-anchors the projection without changing state. */
+export function snapshot(
+  tl: Timeline,
+  serverNow: number,
+): Omit<Timeline, 'seq'> {
+  return {
+    v: 1,
+    storeEpoch: tl.storeEpoch,
+    videoId: tl.videoId,
+    isPlaying: tl.isPlaying,
+    mediaTime: projectMediaTime(tl, serverNow),
+    stampedAt: serverNow,
+    rate: 1,
+    reason: 'snapshot',
+  };
+}

--- a/video-sync-backend/src/shared/sync-protocol.ts
+++ b/video-sync-backend/src/shared/sync-protocol.ts
@@ -1,0 +1,108 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+// Wire protocol for the sync plane. Canonical copy lives in /shared;
+// scripts/sync-shared.mjs mirrors it into both packages (see that script's
+// header note). Every stateful payload carries v for future evolution —
+// rolling compatibility itself is explicitly out of scope for v1.
+
+/**
+ * The room's playback state as a projectable function of server time,
+ * never a frozen scalar.
+ *
+ *   mediaTimeAt(serverNow) = mediaTime + (isPlaying ? (serverNow - stampedAt)/1000 * rate : 0)
+ *
+ * Ordering: clients drop any timeline older than the last applied
+ * (storeEpoch, seq). storeEpoch changes only when the authoritative store is
+ * rehydrated (restart/flush); a changed epoch is always newer by definition
+ * (plane A has no zombie writers; M13's actor plane adds numeric fencing).
+ */
+export interface Timeline {
+  v: 1;
+  /** monotonic per storeEpoch; assigned atomically by the state store */
+  seq: number;
+  /** random id minted at store rehydration; different epoch === newer */
+  storeEpoch: string;
+  videoId: string | null;
+  isPlaying: boolean;
+  /** media position (seconds) that was true at stampedAt */
+  mediaTime: number;
+  /** server-domain timestamp (ms) at which mediaTime was true */
+  stampedAt: number;
+  /** fixed at 1 in v1; field reserved so the protocol never changes shape */
+  rate: 1;
+  reason: 'play' | 'pause' | 'seek' | 'join' | 'snapshot' | 'succession';
+  /** userId of the commander, when reason is a control intent */
+  by?: string;
+}
+
+/** C→S via Socket.IO ack: client stamps t0, server replies immediately. */
+export interface ClockPing {
+  t0: number;
+}
+
+/** Server ack payload: t1 = receive, t2 = send (both server-domain ms). */
+export interface ClockPong {
+  t0: number;
+  t1: number;
+  t2: number;
+}
+
+export type ControlIntent = 'play' | 'pause' | 'seek';
+
+/**
+ * C→S control. mediaTime is the position the commander intends:
+ * play = start here, pause = freeze at the frame I saw (P4), seek = go here.
+ */
+export interface SyncControl {
+  v: 1;
+  roomCode: string;
+  intent: ControlIntent;
+  mediaTime: number;
+}
+
+/** S→C error for rejected controls (permission, rate limit, no room). */
+export interface SyncControlRejected {
+  v: 1;
+  roomCode: string;
+  intent: ControlIntent;
+  reason: 'not-controller' | 'rate-limited' | 'room-not-found';
+}
+
+/** S→room when the active controller changes (P3 succession). */
+export interface RoomController {
+  v: 1;
+  roomCode: string;
+  controllerId: string;
+  reason: 'creator' | 'succession' | 'reclaim';
+}
+
+/** C→S batched telemetry (off unless debug/harness enables it). */
+export interface SyncReport {
+  v: 1;
+  roomCode: string;
+  samples: Array<{
+    tServerEst: number;
+    playerTime: number;
+    drift: number;
+    offsetMs: number;
+    uncertaintyMs: number;
+    rttMs: number;
+    ctrlState: string;
+    seq: number;
+  }>;
+}
+
+export const SYNC_EVENTS = {
+  /** C→S with ack(ClockPong) */
+  clock: 'sync:clock',
+  /** C→S SyncControl */
+  control: 'sync:control',
+  /** S→room Timeline — the only state message */
+  timeline: 'sync:timeline',
+  /** S→C SyncControlRejected */
+  controlRejected: 'sync:control-rejected',
+  /** C→S SyncReport */
+  report: 'sync:report',
+  /** S→room RoomController */
+  controller: 'room:controller',
+} as const;

--- a/video-sync-frontend/src/shared/sync-core/clock-estimator.ts
+++ b/video-sync-frontend/src/shared/sync-core/clock-estimator.ts
@@ -1,0 +1,158 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+// NTP-style clock-offset estimator over the sync:clock exchange.
+//
+// Per exchange: client stamps t0 on send and t3 on receipt; the server's ack
+// carries t1 (receive) and t2 (send), all in its own clock domain.
+//
+//   offset θ = ((t1 - t0) + (t2 - t3)) / 2      (server − client)
+//   rtt    δ = (t3 - t0) - (t2 - t1)
+//
+// |θ_true − θ| ≤ δ/2 + |path asymmetry|/2. The asymmetry term is irreducible
+// for any NTP-family scheme — scenario S6 exists to demonstrate it honestly.
+//
+// Estimation: keep a ring of samples, select the K lowest-δ samples within a
+// recency window (min-RTT filtering tightens the δ/2 bound), use their median
+// θ (kills single-sample jumpiness). Apply small corrections as a slew so the
+// drift controller never sees the clock step under it; large corrections step
+// immediately and the controller re-evaluates.
+//
+// Deterministic: no Date.now() inside — callers pass local timestamps.
+
+export interface ClockSample {
+  t0: number;
+  t1: number;
+  t2: number;
+  t3: number;
+}
+
+export interface ClockEstimate {
+  /** currently applied offset (server − client), ms */
+  offsetMs: number;
+  /** raw target from the sample set, ms */
+  targetOffsetMs: number;
+  /** δ_min/2 over the selected samples, ms; Infinity until a sample lands */
+  uncertaintyMs: number;
+  /** most recent rtt observation, ms */
+  lastRttMs: number;
+  sampleCount: number;
+}
+
+export interface ClockTuning {
+  ringSize: number;
+  /** samples older than this are ignored for selection (bounds skew error) */
+  windowMs: number;
+  /** how many lowest-δ samples the median is taken over */
+  bestK: number;
+  /** |Δθ| below this slews instead of stepping */
+  slewThresholdMs: number;
+  /** slew rate limit, ms of correction per second of local time */
+  slewRatePerS: number;
+}
+
+export const DEFAULT_CLOCK_TUNING: ClockTuning = {
+  ringSize: 64,
+  windowMs: 60_000,
+  bestK: 5,
+  slewThresholdMs: 20,
+  slewRatePerS: 5,
+};
+
+interface StoredSample {
+  theta: number;
+  delta: number;
+  t3: number;
+}
+
+export class ClockEstimator {
+  private samples: StoredSample[] = [];
+  private applied: number | null = null;
+  private target = 0;
+  private uncertainty = Infinity;
+  private lastRtt = NaN;
+  private lastTick: number | null = null;
+
+  constructor(private tuning: ClockTuning = DEFAULT_CLOCK_TUNING) {}
+
+  /** Feed one completed exchange. Returns true if the sample was usable. */
+  addSample(s: ClockSample): boolean {
+    const delta = s.t3 - s.t0 - (s.t2 - s.t1);
+    if (delta < 0) return false; // non-causal: clock stepped mid-exchange
+    const theta = (s.t1 - s.t0 + (s.t2 - s.t3)) / 2;
+    this.samples.push({ theta, delta, t3: s.t3 });
+    if (this.samples.length > this.tuning.ringSize) {
+      this.samples.splice(0, this.samples.length - this.tuning.ringSize);
+    }
+    this.lastRtt = delta;
+    this.recompute(s.t3);
+    return true;
+  }
+
+  private recompute(nowLocal: number): void {
+    const recent = this.samples.filter(
+      (x) => nowLocal - x.t3 <= this.tuning.windowMs,
+    );
+    if (recent.length === 0) return;
+    // lowest δ first; among equal-quality samples prefer the newest, so a
+    // genuine server-clock change wins over stale history within the window
+    const best = [...recent]
+      .sort((a, b) => a.delta - b.delta || b.t3 - a.t3)
+      .slice(0, this.tuning.bestK);
+    const thetas = best.map((x) => x.theta).sort((a, b) => a - b);
+    const median = thetas[Math.floor(thetas.length / 2)];
+    this.target = median;
+    this.uncertainty = best[0].delta / 2;
+
+    if (this.applied === null) {
+      // first estimate: step, there is nothing to disturb yet
+      this.applied = this.target;
+    } else if (
+      Math.abs(this.target - this.applied) >= this.tuning.slewThresholdMs
+    ) {
+      this.applied = this.target;
+    }
+    // otherwise tick() slews toward target
+  }
+
+  /** Advance the slew; call at the controller cadence with local ms time. */
+  tick(nowLocal: number): void {
+    if (this.applied === null) return;
+    if (this.lastTick !== null) {
+      const dtS = (nowLocal - this.lastTick) / 1000;
+      const maxStep = this.tuning.slewRatePerS * dtS;
+      const diff = this.target - this.applied;
+      if (Math.abs(diff) <= maxStep) this.applied = this.target;
+      else this.applied += Math.sign(diff) * maxStep;
+    }
+    this.lastTick = nowLocal;
+  }
+
+  /** Map a local timestamp into the server clock domain. */
+  serverNow(nowLocal: number): number {
+    return nowLocal + (this.applied ?? 0);
+  }
+
+  hasEstimate(): boolean {
+    return this.applied !== null;
+  }
+
+  getEstimate(): ClockEstimate {
+    return {
+      offsetMs: this.applied ?? 0,
+      targetOffsetMs: this.target,
+      uncertaintyMs: this.uncertainty,
+      lastRttMs: this.lastRtt,
+      sampleCount: this.samples.length,
+    };
+  }
+
+  /** Drop history (reconnect, visibility restore): re-burst follows. */
+  reset(): void {
+    this.samples = [];
+    this.applied = null;
+    this.target = 0;
+    this.uncertainty = Infinity;
+    this.lastRtt = NaN;
+    this.lastTick = null;
+  }
+}

--- a/video-sync-frontend/src/shared/sync-core/drift-controller.ts
+++ b/video-sync-frontend/src/shared/sync-core/drift-controller.ts
@@ -1,0 +1,307 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+// Drift-correction state machine. SEEK-first by design: the YouTube IFrame
+// API rounds unsupported playbackRate values toward 1 (per its reference),
+// so fractional-rate nudging is an opportunistic enhancement enabled per
+// video by a runtime probe (fractionalRateOK) — not the primary path.
+//
+// Pure and deterministic: evaluate() receives everything it needs and
+// returns an action; the engine (browser or SimPlayer bot) executes it.
+// All thresholds are named tuning constants, tuned against committed
+// measurement runs — never adjectives.
+
+import { Timeline } from '../sync-protocol';
+import { projectMediaTime } from './timeline';
+
+export type PlayerLifecycle =
+  | 'unstarted'
+  | 'playing'
+  | 'paused'
+  | 'buffering'
+  | 'ended'
+  | 'cued';
+
+export interface ControllerInput {
+  /** local ms clock (performance-independent, same domain as estimator t0/t3) */
+  tLocal: number;
+  /** estimator-mapped server-domain time for tLocal */
+  serverNow: number;
+  /** de-quantized playhead seconds (edge-reconstructed by the adapter) */
+  playerTime: number;
+  playerState: PlayerLifecycle;
+  timeline: Timeline | null;
+  /** result of the per-video setPlaybackRate probe */
+  fractionalRateOK: boolean;
+}
+
+export type ControllerAction =
+  | { type: 'none' }
+  | { type: 'seek'; toMediaTime: number }
+  | { type: 'set-rate'; rate: number }
+  | { type: 'clear-rate' }
+  | { type: 'play' }
+  | { type: 'pause' };
+
+export type ControllerState =
+  | 'LOCKED'
+  | 'NUDGING'
+  | 'SEEKING'
+  | 'BUFFERING'
+  | 'PAUSED_SYNC'
+  | 'SUSPENDED';
+
+export interface ControllerTuning {
+  /** |drift| below this is noise, not error (floored at 2× measured noise σ) */
+  deadbandS: number;
+  /** SEEK mode: correct when |drift| exceeds this for `sustainEvals` evals */
+  seekThresholdS: number;
+  sustainEvals: number;
+  /** single-reading drift beyond this seeks immediately (post-sleep etc.) */
+  instantSeekS: number;
+  /** minimum spacing between corrective seeks, ms */
+  seekSpacingMs: number;
+  /** post-seek cooldown before drift is trusted again, ms */
+  seekCooldownMs: number;
+  /** stable in-band evals required to re-LOCK after a seek */
+  postSeekStableEvals: number;
+  /** initial seek lead (EMA of measured settle replaces it at runtime), s */
+  seekLeadS: number;
+  seekLeadMaxS: number;
+  /** RATE mode window: nudge between deadband and this bound */
+  rateZoneMaxS: number;
+  nudgeRate: number;
+  /** exit nudging when |drift| falls below this */
+  nudgeExitS: number;
+  /** give up on nudging and seek if not back in band within this, ms */
+  nudgeStuckMs: number;
+  /** paused reconcile: silent seek when |playerTime − mediaTime| exceeds */
+  pausedReconcileS: number;
+}
+
+export const DEFAULT_CONTROLLER_TUNING: ControllerTuning = {
+  deadbandS: 0.12,
+  seekThresholdS: 0.3,
+  sustainEvals: 2,
+  instantSeekS: 2.5,
+  seekSpacingMs: 3000,
+  seekCooldownMs: 1500,
+  postSeekStableEvals: 2,
+  seekLeadS: 0.3,
+  seekLeadMaxS: 1.2,
+  rateZoneMaxS: 0.6,
+  nudgeRate: 0.05,
+  nudgeExitS: 0.06,
+  nudgeStuckMs: 15_000,
+  pausedReconcileS: 0.25,
+};
+
+export interface ControllerStatus {
+  state: ControllerState;
+  lastDriftS: number;
+  seekLeadS: number;
+  seeksIssued: number;
+  nudgesIssued: number;
+}
+
+export class DriftController {
+  private state: ControllerState = 'LOCKED';
+  private driftWindow: number[] = [];
+  private outOfBandCount = 0;
+  private lastSeekAt = -Infinity;
+  private seekTargetS: number | null = null;
+  private stableEvals = 0;
+  private nudgeSince: number | null = null;
+  private rateApplied = false;
+  private seekLead: number;
+  private seeksIssued = 0;
+  private nudgesIssued = 0;
+  private lastDrift = 0;
+
+  constructor(private tuning: ControllerTuning = DEFAULT_CONTROLLER_TUNING) {
+    this.seekLead = tuning.seekLeadS;
+  }
+
+  suspend(): void {
+    this.state = 'SUSPENDED';
+    this.driftWindow = [];
+    this.outOfBandCount = 0;
+  }
+
+  /** visibility restore / reconnect: evaluate immediately, hysteresis dropped */
+  resume(): void {
+    this.state = 'LOCKED';
+    this.driftWindow = [];
+    this.outOfBandCount = this.tuning.sustainEvals; // first out-of-band eval acts
+  }
+
+  getStatus(): ControllerStatus {
+    return {
+      state: this.state,
+      lastDriftS: this.lastDrift,
+      seekLeadS: this.seekLead,
+      seeksIssued: this.seeksIssued,
+      nudgesIssued: this.nudgesIssued,
+    };
+  }
+
+  evaluate(input: ControllerInput): ControllerAction {
+    const { timeline } = input;
+    if (this.state === 'SUSPENDED' || timeline === null)
+      return { type: 'none' };
+
+    // ---- lifecycle reconciliation before drift logic ----
+    if (input.playerState === 'buffering') {
+      this.state = 'BUFFERING';
+      if (this.rateApplied) {
+        this.rateApplied = false;
+        this.nudgeSince = null;
+        return { type: 'clear-rate' };
+      }
+      return { type: 'none' };
+    }
+
+    if (!timeline.isPlaying) {
+      // room is paused: reconcile position, make sure we are paused too
+      if (input.playerState === 'playing') return { type: 'pause' };
+      this.state = 'PAUSED_SYNC';
+      const err = Math.abs(input.playerTime - timeline.mediaTime);
+      if (
+        err > this.tuning.pausedReconcileS &&
+        input.tLocal - this.lastSeekAt > this.tuning.seekSpacingMs
+      ) {
+        this.lastSeekAt = input.tLocal;
+        this.seeksIssued += 1;
+        return { type: 'seek', toMediaTime: timeline.mediaTime };
+      }
+      return { type: 'none' };
+    }
+
+    // room is playing
+    if (input.playerState === 'paused' || input.playerState === 'cued') {
+      return { type: 'play' };
+    }
+    if (input.playerState !== 'playing') return { type: 'none' };
+
+    // leaving BUFFERING: catch-up evaluation with cooldown waived (P2)
+    const wasBuffering = this.state === 'BUFFERING';
+    if (wasBuffering) this.state = 'LOCKED';
+
+    const expected = projectMediaTime(timeline, input.serverNow);
+    const rawDrift = input.playerTime - expected; // positive = ahead
+
+    // median-of-3 guard against readout outliers
+    this.driftWindow.push(rawDrift);
+    if (this.driftWindow.length > 3) this.driftWindow.shift();
+    const sorted = [...this.driftWindow].sort((a, b) => a - b);
+    const drift = sorted[Math.floor(sorted.length / 2)];
+    this.lastDrift = drift;
+    const absDrift = Math.abs(drift);
+
+    // post-seek: measure settle, ignore drift until cooldown + stability
+    if (this.state === 'SEEKING') {
+      const sinceSeek = input.tLocal - this.lastSeekAt;
+      if (sinceSeek < this.tuning.seekCooldownMs) return { type: 'none' };
+      if (absDrift <= this.tuning.deadbandS) {
+        this.stableEvals += 1;
+        if (this.stableEvals >= this.tuning.postSeekStableEvals) {
+          // adapt the lead from the residual error of this seek
+          if (this.seekTargetS !== null) {
+            const residual = drift; // ahead(+)/behind(−) after settling
+            this.seekLead = Math.min(
+              this.tuning.seekLeadMaxS,
+              Math.max(0, this.seekLead - residual * 0.5),
+            );
+            this.seekTargetS = null;
+          }
+          this.state = 'LOCKED';
+          this.stableEvals = 0;
+        }
+        return { type: 'none' };
+      }
+      this.stableEvals = 0;
+      if (sinceSeek < this.tuning.seekSpacingMs) return { type: 'none' };
+      // fall through: still out of band after full spacing → act again
+    }
+
+    // instant path for gross desync (single reading, no filtering)
+    if (Math.abs(rawDrift) > this.tuning.instantSeekS) {
+      return this.issueSeek(input, timeline);
+    }
+
+    if (absDrift <= this.tuning.deadbandS) {
+      this.outOfBandCount = 0;
+      if (this.state === 'NUDGING' && absDrift <= this.tuning.nudgeExitS) {
+        this.state = 'LOCKED';
+        this.nudgeSince = null;
+        this.rateApplied = false;
+        return { type: 'clear-rate' };
+      }
+      if (this.state !== 'NUDGING') this.state = 'LOCKED';
+      return { type: 'none' };
+    }
+
+    // out of band
+    this.outOfBandCount += 1;
+    if (this.outOfBandCount < this.tuning.sustainEvals && !wasBuffering) {
+      return { type: 'none' };
+    }
+
+    // RATE mode: only when the probe proved fractional rates stick and the
+    // error is small enough that a nudge closes it in reasonable time
+    if (
+      input.fractionalRateOK &&
+      absDrift <= this.tuning.rateZoneMaxS &&
+      this.state !== 'SEEKING'
+    ) {
+      if (this.state !== 'NUDGING') {
+        this.state = 'NUDGING';
+        this.nudgeSince = input.tLocal;
+        this.rateApplied = true;
+        this.nudgesIssued += 1;
+        const rate =
+          drift > 0 ? 1 - this.tuning.nudgeRate : 1 + this.tuning.nudgeRate;
+        return { type: 'set-rate', rate };
+      }
+      if (
+        this.nudgeSince !== null &&
+        input.tLocal - this.nudgeSince > this.tuning.nudgeStuckMs
+      ) {
+        // stuck (or the probe lied): escalate
+        this.nudgeSince = null;
+        this.rateApplied = false;
+        return this.issueSeek(input, timeline);
+      }
+      // keep the applied rate; direction flips are handled by exit+re-enter
+      return { type: 'none' };
+    }
+
+    // SEEK mode (the default path)
+    if (absDrift >= this.tuning.seekThresholdS || wasBuffering) {
+      if (input.tLocal - this.lastSeekAt < this.tuning.seekSpacingMs) {
+        return { type: 'none' };
+      }
+      return this.issueSeek(input, timeline);
+    }
+
+    // between deadband and seek threshold without rate support: tolerated
+    // (documented: the SEEK-mode effective deadband is seekThresholdS)
+    return { type: 'none' };
+  }
+
+  private issueSeek(
+    input: ControllerInput,
+    timeline: Timeline,
+  ): ControllerAction {
+    this.state = 'SEEKING';
+    this.lastSeekAt = input.tLocal;
+    this.stableEvals = 0;
+    this.outOfBandCount = 0;
+    this.driftWindow = [];
+    this.seeksIssued += 1;
+    if (this.rateApplied) this.rateApplied = false;
+    const lead = timeline.isPlaying ? this.seekLead : 0;
+    const target = projectMediaTime(timeline, input.serverNow) + lead;
+    this.seekTargetS = target;
+    return { type: 'seek', toMediaTime: Math.max(0, target) };
+  }
+}

--- a/video-sync-frontend/src/shared/sync-core/player-adapter.ts
+++ b/video-sync-frontend/src/shared/sync-core/player-adapter.ts
@@ -1,0 +1,22 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+import { PlayerLifecycle } from './drift-controller';
+
+/**
+ * The surface the sync engine drives. Implemented by the frontend's
+ * YouTubeAdapter (real IFrame player) and the harness's SimPlayer (bots) —
+ * one controller, three consumers (browser, bots, jest).
+ */
+export interface PlayerAdapter {
+  /** de-quantized playhead in seconds (edge-reconstructed where needed) */
+  getPlayerTime(): number;
+  getLifecycle(): PlayerLifecycle;
+  seekTo(mediaTime: number): void;
+  play(): void;
+  pause(): void;
+  /**
+   * Attempt a playback-rate change; returns the rate actually in effect
+   * afterwards (the YouTube player rounds unsupported values toward 1).
+   */
+  setRate(rate: number): number;
+}

--- a/video-sync-frontend/src/shared/sync-core/timeline.ts
+++ b/video-sync-frontend/src/shared/sync-core/timeline.ts
@@ -1,0 +1,80 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+import { ControlIntent, Timeline } from '../sync-protocol';
+
+/** Project the media position (seconds) at a server-domain instant. */
+export function projectMediaTime(tl: Timeline, serverNow: number): number {
+  if (!tl.isPlaying) return tl.mediaTime;
+  return tl.mediaTime + ((serverNow - tl.stampedAt) / 1000) * tl.rate;
+}
+
+/**
+ * Ordering rule for applying received timelines. Same epoch: strictly higher
+ * seq wins. Different epoch: the incoming one wins — an epoch only changes
+ * when the authoritative store was rehydrated, which is by definition newer
+ * than anything from the old epoch (see protocol note on fencing).
+ */
+export function isNewer(incoming: Timeline, applied: Timeline | null): boolean {
+  if (applied === null) return true;
+  if (incoming.storeEpoch !== applied.storeEpoch) return true;
+  return incoming.seq > applied.seq;
+}
+
+/**
+ * Restamp a control intent into a new timeline at server time `serverNow`.
+ * Pure: seq assignment/persistence belong to the state store, which calls
+ * this and commits the result atomically.
+ *
+ * Semantics (design doc P1–P5):
+ * - play: start playing from the commanded position, epoch = now
+ * - pause: freeze at the commander's frozen mediaTime ("the frame I saw"),
+ *   NOT the projected position — projecting forward would pause at a frame
+ *   the presser never saw (P4)
+ * - seek: jump to the commanded position, playing state unchanged
+ */
+export function applyControl(
+  prev: Timeline,
+  intent: ControlIntent,
+  mediaTime: number,
+  serverNow: number,
+  by: string,
+): Omit<Timeline, 'seq'> {
+  const base = {
+    v: 1 as const,
+    storeEpoch: prev.storeEpoch,
+    videoId: prev.videoId,
+    rate: 1 as const,
+    stampedAt: serverNow,
+    by,
+  };
+  switch (intent) {
+    case 'play':
+      return { ...base, isPlaying: true, mediaTime, reason: 'play' };
+    case 'pause':
+      return { ...base, isPlaying: false, mediaTime, reason: 'pause' };
+    case 'seek':
+      return {
+        ...base,
+        isPlaying: prev.isPlaying,
+        mediaTime,
+        reason: 'seek',
+      };
+  }
+}
+
+/** A server-time snapshot re-anchors the projection without changing state. */
+export function snapshot(
+  tl: Timeline,
+  serverNow: number,
+): Omit<Timeline, 'seq'> {
+  return {
+    v: 1,
+    storeEpoch: tl.storeEpoch,
+    videoId: tl.videoId,
+    isPlaying: tl.isPlaying,
+    mediaTime: projectMediaTime(tl, serverNow),
+    stampedAt: serverNow,
+    rate: 1,
+    reason: 'snapshot',
+  };
+}

--- a/video-sync-frontend/src/shared/sync-protocol.ts
+++ b/video-sync-frontend/src/shared/sync-protocol.ts
@@ -1,0 +1,108 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+// Wire protocol for the sync plane. Canonical copy lives in /shared;
+// scripts/sync-shared.mjs mirrors it into both packages (see that script's
+// header note). Every stateful payload carries v for future evolution —
+// rolling compatibility itself is explicitly out of scope for v1.
+
+/**
+ * The room's playback state as a projectable function of server time,
+ * never a frozen scalar.
+ *
+ *   mediaTimeAt(serverNow) = mediaTime + (isPlaying ? (serverNow - stampedAt)/1000 * rate : 0)
+ *
+ * Ordering: clients drop any timeline older than the last applied
+ * (storeEpoch, seq). storeEpoch changes only when the authoritative store is
+ * rehydrated (restart/flush); a changed epoch is always newer by definition
+ * (plane A has no zombie writers; M13's actor plane adds numeric fencing).
+ */
+export interface Timeline {
+  v: 1;
+  /** monotonic per storeEpoch; assigned atomically by the state store */
+  seq: number;
+  /** random id minted at store rehydration; different epoch === newer */
+  storeEpoch: string;
+  videoId: string | null;
+  isPlaying: boolean;
+  /** media position (seconds) that was true at stampedAt */
+  mediaTime: number;
+  /** server-domain timestamp (ms) at which mediaTime was true */
+  stampedAt: number;
+  /** fixed at 1 in v1; field reserved so the protocol never changes shape */
+  rate: 1;
+  reason: 'play' | 'pause' | 'seek' | 'join' | 'snapshot' | 'succession';
+  /** userId of the commander, when reason is a control intent */
+  by?: string;
+}
+
+/** C→S via Socket.IO ack: client stamps t0, server replies immediately. */
+export interface ClockPing {
+  t0: number;
+}
+
+/** Server ack payload: t1 = receive, t2 = send (both server-domain ms). */
+export interface ClockPong {
+  t0: number;
+  t1: number;
+  t2: number;
+}
+
+export type ControlIntent = 'play' | 'pause' | 'seek';
+
+/**
+ * C→S control. mediaTime is the position the commander intends:
+ * play = start here, pause = freeze at the frame I saw (P4), seek = go here.
+ */
+export interface SyncControl {
+  v: 1;
+  roomCode: string;
+  intent: ControlIntent;
+  mediaTime: number;
+}
+
+/** S→C error for rejected controls (permission, rate limit, no room). */
+export interface SyncControlRejected {
+  v: 1;
+  roomCode: string;
+  intent: ControlIntent;
+  reason: 'not-controller' | 'rate-limited' | 'room-not-found';
+}
+
+/** S→room when the active controller changes (P3 succession). */
+export interface RoomController {
+  v: 1;
+  roomCode: string;
+  controllerId: string;
+  reason: 'creator' | 'succession' | 'reclaim';
+}
+
+/** C→S batched telemetry (off unless debug/harness enables it). */
+export interface SyncReport {
+  v: 1;
+  roomCode: string;
+  samples: Array<{
+    tServerEst: number;
+    playerTime: number;
+    drift: number;
+    offsetMs: number;
+    uncertaintyMs: number;
+    rttMs: number;
+    ctrlState: string;
+    seq: number;
+  }>;
+}
+
+export const SYNC_EVENTS = {
+  /** C→S with ack(ClockPong) */
+  clock: 'sync:clock',
+  /** C→S SyncControl */
+  control: 'sync:control',
+  /** S→room Timeline — the only state message */
+  timeline: 'sync:timeline',
+  /** S→C SyncControlRejected */
+  controlRejected: 'sync:control-rejected',
+  /** C→S SyncReport */
+  report: 'sync:report',
+  /** S→room RoomController */
+  controller: 'room:controller',
+} as const;


### PR DESCRIPTION
The pure-logic heart of the overhaul: one implementation consumed by the browser engine (M4), the synthetic bots (M5), and jest.

## Design
- **Timeline as a projectable function** — `mediaTime + elapsed·rate` from a server-domain `stampedAt`, ordered by `(storeEpoch, seq)`. `applyControl` restamps intents server-side; pause freezes at the commander's frame (P4: "the frame I saw wins").
- **NTP-style clock estimator** — median-θ over the 5 lowest-RTT samples in a 60s window, recency tie-break (a genuine server-clock change beats stale equal-quality history — a bug the tests caught), ≤5ms/s slew under 20ms / step above, uncertainty = δ_min/2. Asymmetry bias bound (δ/2 + asym/2) asserted in tests.
- **SEEK-first drift controller** — the YouTube IFrame API rounds fractional rates toward 1, so rate-nudging is probe-gated opportunism, not the design center. Sustained-drift seeks with an adaptive lead learned from settle residuals, instant path for gross desync, anti-storm spacing, buffering free-run + catch-up (P2), paused reconcile, suspend/resume for hidden tabs. Every threshold is a named tuning constant to be floored/tuned against the M1-measured noise data.
- **Copy mechanism** — CRA's ModuleScopePlugin forbids out-of-src imports, so `scripts/sync-shared.mjs` mirrors `/shared` into both packages (specs only into the backend, where jest runs them) with a CI `--check` job preventing drift.

## Verification
- 32 unit tests (estimator error bounds, controller scenario tables incl. probe-failure and stuck-nudge escalation, timeline/ordering semantics) green in backend jest.
- Frontend `tsc --noEmit` green against the copies (TS 4.9-compatible subset).
- New CI job fails on stale copies; lint enforced on the copies via the backend job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added synchronized playback capabilities, including clock alignment, timeline projection, drift correction, and play/pause/seek coordination.
  * Added support for gradual playback-rate adjustments and corrective seeking to maintain synchronization.
  * Added standardized synchronization messaging for playback controls, clock updates, controller changes, and diagnostics.

* **Bug Fixes**
  * Improved handling of network delay, buffering, stale updates, and playback-state transitions.

* **Tests**
  * Added comprehensive coverage for clock estimation, drift correction, timeline behavior, and synchronization edge cases.

* **Chores**
  * Added automated checks to detect synchronization-file inconsistencies and standardized formatting settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->