### PR TITLE
M3: server-authoritative timeline engine + socket identity

### DIFF
--- a/sync-harness/src/app-api.ts
+++ b/sync-harness/src/app-api.ts
@@ -6,6 +6,8 @@ export interface HarnessUser {
   id: string;
   username: string;
   email: string;
+  /** JWT for the socket handshake (issued at register/login) */
+  token?: string;
 }
 
 async function post<T>(path: string, body: unknown): Promise<T> {

--- a/sync-harness/src/verify-m3.ts
+++ b/sync-harness/src/verify-m3.ts
@@ -1,0 +1,163 @@
+// Socket-level proofs for the M3 backend engine gate:
+//   1. unauthenticated sockets are rejected
+//   2. forged identity cannot control (payload userIds are ignored)
+//   3. non-controllers are rejected on sync:control
+//   4. sync:clock ack carries causally-ordered stamps
+//   5. mid-play joiners receive a projected timeline, not a stale scalar
+//   6. control floods are rate-limited
+// Run: npx tsx src/verify-m3.ts   (backend on :3000 with fresh build)
+import { io, type Socket } from 'socket.io-client';
+import { createRoom, registerUser, type HarnessUser } from './app-api.js';
+
+const WS = 'http://localhost:3000';
+const runId = `m3-${Date.now().toString(36)}`;
+let failures = 0;
+
+function check(name: string, ok: boolean, detail = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+  if (!ok) failures += 1;
+}
+
+function connect(token?: string): Promise<{ socket: Socket; error?: string }> {
+  return new Promise((resolve) => {
+    const socket = io(WS, {
+      transports: ['websocket'],
+      auth: token ? { token } : {},
+      reconnection: false,
+      timeout: 5000,
+    });
+    socket.on('connect', () => resolve({ socket }));
+    socket.on('connect_error', (err) => resolve({ socket, error: err.message }));
+  });
+}
+
+function joinRoom(socket: Socket, roomCode: string, claimedUserId: string): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('join timeout')), 5000);
+    socket.once('room-joined', (payload) => {
+      clearTimeout(timer);
+      resolve(payload);
+    });
+    socket.once('error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(`join error: ${JSON.stringify(err)}`));
+    });
+    socket.emit('join-room', { roomCode, userId: claimedUserId });
+  });
+}
+
+function once<T>(socket: Socket, event: string, timeoutMs = 4000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${event} timeout`)), timeoutMs);
+    socket.once(event, (payload: T) => {
+      clearTimeout(timer);
+      resolve(payload);
+    });
+  });
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// ---------- fixtures ----------
+const creator: HarnessUser & { token?: string } = await registerUser(runId, 0);
+const guest: HarnessUser & { token?: string } = await registerUser(runId, 1);
+const late: HarnessUser & { token?: string } = await registerUser(runId, 2);
+const room = await createRoom(creator, runId, 'https://www.youtube.com/watch?v=aqz-KE-bpKQ');
+
+// 1. unauthenticated rejected
+{
+  const { error } = await connect(undefined);
+  check('unauthenticated socket rejected', Boolean(error?.includes('unauthorized')), error);
+}
+{
+  const { error } = await connect('garbage-token');
+  check('invalid token rejected', Boolean(error?.includes('unauthorized')), error);
+}
+
+// 2 + 3. forged identity / non-controller rejected on both paths
+const creatorSock = (await connect(creator.token)).socket;
+const guestSock = (await connect(guest.token)).socket;
+await joinRoom(creatorSock, room.code, creator.id);
+// the guest CLAIMS to be the creator in the join payload — must be ignored
+await joinRoom(guestSock, room.code, creator.id);
+
+{
+  const rejected = once<{ reason: string }>(guestSock, 'sync:control-rejected');
+  guestSock.emit('sync:control', { v: 1, roomCode: room.code, intent: 'play', mediaTime: 0 });
+  const result = await rejected.catch((e) => ({ reason: `no-rejection: ${e.message}` }));
+  check('forged-identity sync:control rejected', result.reason === 'not-controller', result.reason);
+}
+{
+  const legacyErr = once<{ message: string }>(guestSock, 'error');
+  guestSock.emit('video-state', {
+    roomCode: room.code,
+    state: { currentTime: 999, isPlaying: true },
+    action: 'play',
+  });
+  const result = await legacyErr.catch((e) => ({ message: `no-error: ${e.message}` }));
+  check(
+    'forged-identity legacy video-state rejected',
+    result.message.includes('Only the host'),
+    result.message,
+  );
+}
+
+// 4. clock ack stamps
+{
+  const t0 = Date.now();
+  const pong = await new Promise<{ t0: number; t1: number; t2: number }>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('clock ack timeout')), 4000);
+    creatorSock.emit('sync:clock', { t0 }, (resp: { t0: number; t1: number; t2: number }) => {
+      clearTimeout(timer);
+      resolve(resp);
+    });
+  });
+  const t3 = Date.now();
+  const causal = pong.t0 === t0 && pong.t1 <= pong.t2 && t3 - t0 >= pong.t2 - pong.t1;
+  check('sync:clock ack causally ordered', causal, JSON.stringify({ ...pong, t3 }));
+}
+
+// 5. mid-play join projection
+{
+  const broadcast = once<{ seq: number; mediaTime: number; isPlaying: boolean }>(
+    creatorSock,
+    'sync:timeline',
+  );
+  creatorSock.emit('sync:control', { v: 1, roomCode: room.code, intent: 'play', mediaTime: 100 });
+  const tl = await broadcast;
+  check('control broadcast reaches the commander too', tl.isPlaying && tl.mediaTime === 100);
+
+  await sleep(3000);
+  const lateSock = (await connect(late.token)).socket;
+  const joined = await joinRoom(lateSock, room.code, late.id);
+  const projected = joined.timeline as { mediaTime: number; stampedAt: number; isPlaying: boolean };
+  // server projects at join... the joiner receives mediaTime@stampedAt; with
+  // ~3s elapsed the projection at now is ~103
+  const projectedNow =
+    projected.mediaTime + (projected.isPlaying ? (Date.now() - projected.stampedAt) / 1000 : 0);
+  check(
+    'mid-play joiner gets projected timeline (~103s, not the stale 100)',
+    Math.abs(projectedNow - 103) < 1.5,
+    `projectedNow=${projectedNow.toFixed(2)}`,
+  );
+  lateSock.disconnect();
+}
+
+// 6. rate limit
+{
+  let rejectedCount = 0;
+  guestSock.removeAllListeners('sync:control-rejected');
+  creatorSock.on('sync:control-rejected', (r: { reason: string }) => {
+    if (r.reason === 'rate-limited') rejectedCount += 1;
+  });
+  for (let i = 0; i < 25; i++) {
+    creatorSock.emit('sync:control', { v: 1, roomCode: room.code, intent: 'play', mediaTime: i });
+  }
+  await sleep(1500);
+  check('control flood rate-limited', rejectedCount > 0, `${rejectedCount} rejected of 25`);
+}
+
+creatorSock.disconnect();
+guestSock.disconnect();
+console.log(failures === 0 ? '\nALL CHECKS PASSED' : `\n${failures} CHECKS FAILED`);
+process.exit(failures === 0 ? 0 : 1);

--- a/video-sync-backend/src/auth/auth.module.ts
+++ b/video-sync-backend/src/auth/auth.module.ts
@@ -1,11 +1,24 @@
 // src/auth/auth.module.ts
 import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 
 @Module({
+  imports: [
+    JwtModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        secret: config.get<string>('jwt.secret'),
+        // verified at connect only; an accepted socket outlives its token
+        // (documented limitation - no refresh/revocation in scope)
+        signOptions: { expiresIn: '12h' },
+      }),
+    }),
+  ],
   controllers: [AuthController],
   providers: [AuthService],
-  exports: [AuthService],
+  exports: [AuthService, JwtModule],
 })
 export class AuthModule {}

--- a/video-sync-backend/src/auth/auth.service.ts
+++ b/video-sync-backend/src/auth/auth.service.ts
@@ -4,12 +4,20 @@ import {
   ConflictException,
   UnauthorizedException,
 } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
 import { DatabaseService } from '../database/database.service';
 import * as bcrypt from 'bcrypt';
 
 @Injectable()
 export class AuthService {
-  constructor(private database: DatabaseService) {}
+  constructor(
+    private database: DatabaseService,
+    private jwt: JwtService,
+  ) {}
+
+  private issueToken(user: { id: string; username: string }): string {
+    return this.jwt.sign({ sub: user.id, name: user.username });
+  }
 
   async register(username: string, email: string, password: string) {
     // Check if user exists
@@ -41,7 +49,7 @@ export class AuthService {
       },
     });
 
-    return user;
+    return { ...user, token: this.issueToken(user) };
   }
 
   async login(username: string, password: string) {
@@ -64,6 +72,7 @@ export class AuthService {
       id: user.id,
       username: user.username,
       email: user.email,
+      token: this.issueToken(user),
     };
   }
 }

--- a/video-sync-backend/src/sync/room-state.store.ts
+++ b/video-sync-backend/src/sync/room-state.store.ts
@@ -1,0 +1,102 @@
+import { Injectable } from '@nestjs/common';
+import { randomBytes } from 'node:crypto';
+import { ControlIntent, Timeline } from '../shared/sync-protocol';
+import { applyControl, snapshot } from '../shared/sync-core/timeline';
+
+/**
+ * The authority seam for room playback state. The engine only speaks this
+ * interface; M6 swaps in a Redis/Lua implementation for multi-instance
+ * correctness without touching engine logic. apply() must assign seq
+ * atomically with the state write.
+ */
+export interface RoomStateStore {
+  get(roomCode: string): Promise<Timeline | null>;
+  /** Restamp a control intent and commit it with the next seq. */
+  applyControl(
+    roomCode: string,
+    intent: ControlIntent,
+    mediaTime: number,
+    serverNow: number,
+    by: string,
+  ): Promise<Timeline | null>;
+  /** Re-anchor the projection (periodic sweep); returns the committed state. */
+  applySnapshot(roomCode: string, serverNow: number): Promise<Timeline | null>;
+  /**
+   * First-writer-wins rehydration from persistence. Always restored paused
+   * (P5): a stale epoch must not fast-forward a room that was "playing"
+   * days ago.
+   */
+  init(
+    roomCode: string,
+    videoId: string | null,
+    mediaTime: number,
+    serverNow: number,
+  ): Promise<Timeline>;
+  clear(roomCode: string): Promise<void>;
+}
+
+export const ROOM_STATE_STORE = Symbol('ROOM_STATE_STORE');
+
+@Injectable()
+export class InMemoryRoomStateStore implements RoomStateStore {
+  private rooms = new Map<string, Timeline>();
+
+  // Single-process: JS execution is the serializer, so plain sync mutation
+  // inside async methods is atomic per call.
+  get(roomCode: string): Promise<Timeline | null> {
+    return Promise.resolve(this.rooms.get(roomCode) ?? null);
+  }
+
+  applyControl(
+    roomCode: string,
+    intent: ControlIntent,
+    mediaTime: number,
+    serverNow: number,
+    by: string,
+  ): Promise<Timeline | null> {
+    const prev = this.rooms.get(roomCode);
+    if (!prev) return Promise.resolve(null);
+    const next: Timeline = {
+      ...applyControl(prev, intent, mediaTime, serverNow, by),
+      seq: prev.seq + 1,
+    };
+    this.rooms.set(roomCode, next);
+    return Promise.resolve(next);
+  }
+
+  applySnapshot(roomCode: string, serverNow: number): Promise<Timeline | null> {
+    const prev = this.rooms.get(roomCode);
+    if (!prev) return Promise.resolve(null);
+    const next: Timeline = { ...snapshot(prev, serverNow), seq: prev.seq + 1 };
+    this.rooms.set(roomCode, next);
+    return Promise.resolve(next);
+  }
+
+  init(
+    roomCode: string,
+    videoId: string | null,
+    mediaTime: number,
+    serverNow: number,
+  ): Promise<Timeline> {
+    const existing = this.rooms.get(roomCode);
+    if (existing) return Promise.resolve(existing);
+    const created: Timeline = {
+      v: 1,
+      seq: 0,
+      storeEpoch: randomBytes(6).toString('hex'),
+      videoId,
+      isPlaying: false,
+      mediaTime,
+      stampedAt: serverNow,
+      rate: 1,
+      reason: 'join',
+    };
+    this.rooms.set(roomCode, created);
+    return Promise.resolve(created);
+  }
+
+  clear(roomCode: string): Promise<void> {
+    this.rooms.delete(roomCode);
+    return Promise.resolve();
+  }
+}

--- a/video-sync-backend/src/sync/sync.gateway.ts
+++ b/video-sync-backend/src/sync/sync.gateway.ts
@@ -4,11 +4,22 @@ import {
   SubscribeMessage,
   OnGatewayConnection,
   OnGatewayDisconnect,
+  OnGatewayInit,
   MessageBody,
   ConnectedSocket,
 } from '@nestjs/websockets';
+import { Interval } from '@nestjs/schedule';
+import { JwtService } from '@nestjs/jwt';
 import { Server, Socket } from 'socket.io';
 import { DatabaseService } from '../database/database.service';
+import {
+  ClockPing,
+  ClockPong,
+  SYNC_EVENTS,
+  SyncControl,
+} from '../shared/sync-protocol';
+import { TimelineService } from './timeline.service';
+import { AuthedSocketData, wsAuthMiddleware } from './ws-auth';
 
 interface VideoState {
   currentTime: number;
@@ -31,7 +42,9 @@ interface RoomData {
   pingInterval: 10000,
   pingTimeout: 5000,
 })
-export class SyncGateway implements OnGatewayConnection, OnGatewayDisconnect {
+export class SyncGateway
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+{
   @WebSocketServer()
   server: Server;
 
@@ -40,7 +53,17 @@ export class SyncGateway implements OnGatewayConnection, OnGatewayDisconnect {
   private roomHosts: Map<string, string> = new Map(); // Track room hosts
   private socketToUser: Map<string, string> = new Map(); // Map socket.id to userId
 
-  constructor(private database: DatabaseService) {}
+  constructor(
+    private database: DatabaseService,
+    private jwt: JwtService,
+    private timeline: TimelineService,
+  ) {}
+
+  afterInit(server: Server): void {
+    // identity is derived server-side at connect; client-asserted userIds
+    // in payloads are ignored by every handler below
+    server.use(wsAuthMiddleware(this.jwt));
+  }
 
   handleConnection(client: Socket) {
     console.log(`Client connected: ${client.id}`);
@@ -66,7 +89,8 @@ export class SyncGateway implements OnGatewayConnection, OnGatewayDisconnect {
   ) {
     try {
       const joinStartTime = Date.now();
-      console.log(`User ${data.userId} joining room ${data.roomCode}`);
+      const userId = (client.data as AuthedSocketData).userId;
+      console.log(`User ${userId} joining room ${data.roomCode}`);
 
       const room = await this.database.room.findUnique({
         where: { code: data.roomCode },
@@ -94,7 +118,7 @@ export class SyncGateway implements OnGatewayConnection, OnGatewayDisconnect {
       // against the limit because their slot is already excluded here
       if (room.maxUsers) {
         const otherActive = room.participants.filter(
-          (p) => p.user.id !== data.userId,
+          (p) => p.user.id !== userId,
         ).length;
         if (otherActive >= room.maxUsers) {
           client.emit('error', { message: 'Room is full' });
@@ -104,18 +128,36 @@ export class SyncGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
       await client.join(data.roomCode);
       this.userRooms.set(client.id, data.roomCode);
-      this.socketToUser.set(client.id, data.userId);
+      this.socketToUser.set(client.id, userId);
 
       // Set room host if first user
       if (!this.roomHosts.has(data.roomCode)) {
-        this.roomHosts.set(data.roomCode, data.userId);
+        this.roomHosts.set(data.roomCode, userId);
+      }
+
+      // Authoritative timeline: hydrate on first touch (paused, P5) and
+      // hand the joiner a projectable state instead of a frozen scalar
+      const timeline = await this.timeline.ensureRoom(
+        data.roomCode,
+        room,
+        Date.now(),
+      );
+
+      // P3: the creator returning reclaims control from a promoted stand-in
+      const reclaim = this.timeline.reclaim(data.roomCode, userId);
+      if (reclaim) {
+        this.server.to(data.roomCode).emit(SYNC_EVENTS.controller, {
+          v: 1,
+          roomCode: data.roomCode,
+          ...reclaim,
+        });
       }
 
       // Upsert participant
       const participant = await this.database.participant.upsert({
         where: {
           userId_roomId: {
-            userId: data.userId,
+            userId,
             roomId: room.id,
           },
         },
@@ -124,7 +166,7 @@ export class SyncGateway implements OnGatewayConnection, OnGatewayDisconnect {
           lastPingAt: new Date(),
         },
         create: {
-          userId: data.userId,
+          userId,
           roomId: room.id,
         },
         include: {
@@ -159,8 +201,6 @@ export class SyncGateway implements OnGatewayConnection, OnGatewayDisconnect {
         timestamp: Date.now(),
       };
 
-      console.log(`Sending room state to ${data.userId}:`, currentState);
-
       // Calculate join latency
       const joinLatency = Date.now() - joinStartTime;
 
@@ -174,6 +214,7 @@ export class SyncGateway implements OnGatewayConnection, OnGatewayDisconnect {
           creatorId: room.creatorId,
         },
         state: currentState,
+        timeline,
         participants: updatedParticipants.map((p) => ({
           id: p.user.id,
           username: p.user.username,
@@ -184,7 +225,7 @@ export class SyncGateway implements OnGatewayConnection, OnGatewayDisconnect {
       // Log latency for monitoring
       if (joinLatency > 500) {
         console.warn(
-          `⚠️ High join latency: ${joinLatency}ms for user ${data.userId}`,
+          `⚠️ High join latency: ${joinLatency}ms for user ${userId}`,
         );
       }
 
@@ -328,6 +369,61 @@ export class SyncGateway implements OnGatewayConnection, OnGatewayDisconnect {
       clientTimestamp: data.timestamp,
       serverTimestamp: Date.now(),
     });
+  }
+
+  @SubscribeMessage(SYNC_EVENTS.clock)
+  handleSyncClock(@MessageBody() data: ClockPing): ClockPong {
+    // ack fast-path: stamp immediately, no awaits before t1/t2
+    const t1 = Date.now();
+    return { t0: data.t0, t1, t2: Date.now() };
+  }
+
+  @SubscribeMessage(SYNC_EVENTS.control)
+  async handleSyncControl(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() data: SyncControl,
+  ) {
+    const userId = (client.data as AuthedSocketData).userId;
+    const result = await this.timeline.handleControl(
+      data.roomCode,
+      client.id,
+      userId,
+      data.intent,
+      data.mediaTime,
+      Date.now(),
+    );
+    if (!result.ok) {
+      client.emit(SYNC_EVENTS.controlRejected, {
+        v: 1,
+        roomCode: data.roomCode,
+        intent: data.intent,
+        reason: result.reason,
+      });
+      return;
+    }
+    // wait-for-broadcast semantics: the commander applies its own intent
+    // from this same message, so every client converges on identical state
+    this.server.to(data.roomCode).emit(SYNC_EVENTS.timeline, result.timeline);
+  }
+
+  /**
+   * Repair channel: a periodic re-anchored snapshot per playing room. Late
+   * or lossy deliveries self-heal within one sweep period; clients drop
+   * stale (storeEpoch, seq) so redundancy is harmless.
+   */
+  @Interval(10_000)
+  async sweepTimelines() {
+    const activeRooms = new Set(this.userRooms.values());
+    for (const roomCode of activeRooms) {
+      try {
+        const snap = await this.timeline.sweepSnapshot(roomCode, Date.now());
+        if (snap) {
+          this.server.to(roomCode).emit(SYNC_EVENTS.timeline, snap);
+        }
+      } catch (error) {
+        console.error(`sweep failed for ${roomCode}:`, error);
+      }
+    }
   }
 
   @SubscribeMessage('sync-check')
@@ -606,21 +702,41 @@ export class SyncGateway implements OnGatewayConnection, OnGatewayDisconnect {
       this.userRooms.delete(client.id);
       this.socketToUser.delete(client.id);
 
-      // Clean up room host if leaving
-      const hostId = this.roomHosts.get(roomCode);
-      if (hostId === userId) {
-        const roomSockets = await this.server.in(roomCode).fetchSockets();
-        if (roomSockets.length > 0) {
-          // Assign new host to next user
-          const newHostSocket = roomSockets[0];
-          const newHostId = this.socketToUser.get(newHostSocket.id);
-          if (newHostId) {
-            this.roomHosts.set(roomCode, newHostId);
-          }
-        } else {
-          // Room is empty, clean up
-          this.roomHosts.delete(roomCode);
-          this.roomStates.delete(roomCode);
+      this.timeline.dropSocket(client.id);
+
+      const roomSockets = await this.server.in(roomCode).fetchSockets();
+      if (roomSockets.length === 0) {
+        this.roomHosts.delete(roomCode);
+        this.roomStates.delete(roomCode);
+        await this.timeline.releaseRoom(roomCode);
+      } else if (userId) {
+        // P3: if a controller left, promote the longest-connected participant
+        // (server-derived connect times; the timeline keeps running either way)
+        const candidate = roomSockets
+          .map((sock) => {
+            const sockData = sock.data as Partial<AuthedSocketData>;
+            return {
+              userId: sockData.userId,
+              connectedAt: sockData.connectedAt ?? Infinity,
+            };
+          })
+          .filter((x) => x.userId)
+          .sort((a, b) => a.connectedAt - b.connectedAt)[0];
+        const change = this.timeline.succession(
+          roomCode,
+          userId,
+          candidate?.userId ?? null,
+        );
+        if (change) {
+          this.server.to(roomCode).emit(SYNC_EVENTS.controller, {
+            v: 1,
+            roomCode,
+            ...change,
+          });
+        }
+        // legacy map bookkeeping
+        if (this.roomHosts.get(roomCode) === userId && candidate?.userId) {
+          this.roomHosts.set(roomCode, candidate.userId);
         }
       }
 
@@ -670,12 +786,6 @@ export class SyncGateway implements OnGatewayConnection, OnGatewayDisconnect {
             username: p.user.username,
           })),
         });
-      }
-
-      // Clean up room state if empty
-      const roomSockets = await this.server.in(roomCode).fetchSockets();
-      if (roomSockets.length === 0) {
-        this.roomStates.delete(roomCode);
       }
     } catch (error) {
       console.error('Error handling leave room:', error);

--- a/video-sync-backend/src/sync/sync.module.ts
+++ b/video-sync-backend/src/sync/sync.module.ts
@@ -1,11 +1,22 @@
 // src/sync/sync.module.ts
 import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
 import { SyncGateway } from './sync.gateway';
 import { VoiceGateway } from './voice.gateway';
 import { SyncService } from './sync.service';
+import { TimelineService } from './timeline.service';
+import { InMemoryRoomStateStore, ROOM_STATE_STORE } from './room-state.store';
 
 @Module({
-  providers: [SyncGateway, VoiceGateway, SyncService],
+  imports: [AuthModule],
+  providers: [
+    SyncGateway,
+    VoiceGateway,
+    SyncService,
+    TimelineService,
+    // M6 swaps this provider for the Redis/Lua implementation
+    { provide: ROOM_STATE_STORE, useClass: InMemoryRoomStateStore },
+  ],
   exports: [SyncService],
 })
 export class SyncModule {}

--- a/video-sync-backend/src/sync/timeline.service.spec.ts
+++ b/video-sync-backend/src/sync/timeline.service.spec.ts
@@ -1,0 +1,172 @@
+import { InMemoryRoomStateStore } from './room-state.store';
+import { TimelineService } from './timeline.service';
+
+const roomRow = {
+  creatorId: 'creator',
+  allowGuestControl: false,
+  videoUrl: 'vid',
+  currentTime: 42,
+};
+
+function makeService(): {
+  svc: TimelineService;
+  db: { room: { update: jest.Mock } };
+} {
+  const db = { room: { update: jest.fn().mockResolvedValue({}) } };
+  const svc = new TimelineService(new InMemoryRoomStateStore(), db as never);
+  return { svc, db };
+}
+
+describe('TimelineService', () => {
+  it('hydrates paused from persistence (P5), first writer wins', async () => {
+    const { svc } = makeService();
+    const tl = await svc.ensureRoom('r1', roomRow, 1_000);
+    expect(tl.isPlaying).toBe(false);
+    expect(tl.mediaTime).toBe(42);
+    expect(tl.seq).toBe(0);
+    const again = await svc.ensureRoom(
+      'r1',
+      { ...roomRow, currentTime: 99 },
+      2_000,
+    );
+    expect(again.mediaTime).toBe(42); // not re-hydrated
+  });
+
+  it('restamps controls with monotonically increasing seq', async () => {
+    const { svc } = makeService();
+    await svc.ensureRoom('r1', roomRow, 1_000);
+    const a = await svc.handleControl('r1', 's1', 'creator', 'play', 42, 5_000);
+    const b = await svc.handleControl(
+      'r1',
+      's1',
+      'creator',
+      'seek',
+      100,
+      6_000,
+    );
+    if (!a.ok || !b.ok) throw new Error('controls rejected');
+    expect(a.timeline.seq).toBe(1);
+    expect(b.timeline.seq).toBe(2);
+    expect(b.timeline.mediaTime).toBe(100);
+    expect(b.timeline.isPlaying).toBe(true); // seek preserves playing
+  });
+
+  it('rejects non-controllers; forged identity cannot control', async () => {
+    const { svc } = makeService();
+    await svc.ensureRoom('r1', roomRow, 1_000);
+    // "mallory" claims to be controlling — identity comes from socket.data
+    // server-side, so the check sees the real user id
+    const result = await svc.handleControl(
+      'r1',
+      's2',
+      'mallory',
+      'play',
+      0,
+      5_000,
+    );
+    expect(result).toEqual({ ok: false, reason: 'not-controller' });
+  });
+
+  it('allowGuestControl opens control to everyone', async () => {
+    const { svc } = makeService();
+    await svc.ensureRoom('r2', { ...roomRow, allowGuestControl: true }, 1_000);
+    const result = await svc.handleControl(
+      'r2',
+      's3',
+      'guest',
+      'pause',
+      10,
+      5_000,
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('rate-limits control floods per socket (5/s, burst 10)', async () => {
+    const { svc } = makeService();
+    await svc.ensureRoom('r1', roomRow, 1_000);
+    let accepted = 0;
+    let limited = 0;
+    for (let i = 0; i < 15; i++) {
+      const r = await svc.handleControl(
+        'r1',
+        's1',
+        'creator',
+        'play',
+        0,
+        5_000,
+      );
+      if (r.ok) accepted += 1;
+      else if (r.reason === 'rate-limited') limited += 1;
+    }
+    expect(accepted).toBe(10); // burst capacity
+    expect(limited).toBe(5);
+    // a second later one token has refilled... five tokens after 1s
+    const later = await svc.handleControl(
+      'r1',
+      's1',
+      'creator',
+      'play',
+      0,
+      6_000,
+    );
+    expect(later.ok).toBe(true);
+  });
+
+  it('sweeps only playing rooms and re-anchors the projection', async () => {
+    const { svc } = makeService();
+    await svc.ensureRoom('r1', roomRow, 1_000);
+    expect(await svc.sweepSnapshot('r1', 10_000)).toBeNull(); // paused
+    await svc.handleControl('r1', 's1', 'creator', 'play', 100, 10_000);
+    const snap = await svc.sweepSnapshot('r1', 20_000);
+    expect(snap).not.toBeNull();
+    expect(snap!.mediaTime).toBeCloseTo(110, 9);
+    expect(snap!.stampedAt).toBe(20_000);
+    expect(snap!.reason).toBe('snapshot');
+  });
+
+  it('P3: promotes the longest-connected participant when the controller leaves', async () => {
+    const { svc } = makeService();
+    await svc.ensureRoom('r1', roomRow, 1_000);
+    const change = svc.succession('r1', 'creator', 'oldtimer');
+    expect(change).toEqual({ controllerId: 'oldtimer', reason: 'succession' });
+    // promoted controller can now control
+    const r = await svc.handleControl('r1', 's4', 'oldtimer', 'play', 0, 5_000);
+    expect(r.ok).toBe(true);
+  });
+
+  it('P3: creator reclaims on return', async () => {
+    const { svc } = makeService();
+    await svc.ensureRoom('r1', roomRow, 1_000);
+    svc.succession('r1', 'creator', 'oldtimer');
+    const reclaim = svc.reclaim('r1', 'creator');
+    expect(reclaim).toEqual({ controllerId: 'creator', reason: 'reclaim' });
+    const r = await svc.handleControl('r1', 's5', 'oldtimer', 'play', 0, 6_000);
+    expect(r).toEqual({ ok: false, reason: 'not-controller' });
+  });
+
+  it('no succession needed when guests can control', async () => {
+    const { svc } = makeService();
+    await svc.ensureRoom('r3', { ...roomRow, allowGuestControl: true }, 1_000);
+    expect(svc.succession('r3', 'creator', 'someone')).toBeNull();
+  });
+
+  it('persists the projected position on release', async () => {
+    const { svc, db } = makeService();
+    await svc.ensureRoom('r1', roomRow, 1_000);
+    await svc.handleControl('r1', 's1', 'creator', 'play', 100, 10_000);
+    await svc.releaseRoom('r1');
+    expect(db.room.update).toHaveBeenCalledTimes(1);
+    const calls = db.room.update.mock.calls as unknown as Array<
+      [
+        {
+          where: { code: string };
+          data: { isPlaying: boolean; currentTime: number };
+        },
+      ]
+    >;
+    const arg = calls[0][0];
+    expect(arg.where).toEqual({ code: 'r1' });
+    expect(arg.data.isPlaying).toBe(true);
+    expect(arg.data.currentTime).toBeGreaterThan(100);
+  });
+});

--- a/video-sync-backend/src/sync/timeline.service.ts
+++ b/video-sync-backend/src/sync/timeline.service.ts
@@ -1,0 +1,209 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+import { ControlIntent, Timeline } from '../shared/sync-protocol';
+import { projectMediaTime } from '../shared/sync-core/timeline';
+import { ROOM_STATE_STORE, RoomStateStore } from './room-state.store';
+
+export type ControlResult =
+  | { ok: true; timeline: Timeline }
+  | { ok: false; reason: 'not-controller' | 'rate-limited' | 'room-not-found' };
+
+interface RoomMeta {
+  creatorId: string;
+  allowGuestControl: boolean;
+  videoId: string | null;
+  /** promoted controller while the creator is away (P3) */
+  activeController: string | null;
+}
+
+interface TokenBucket {
+  tokens: number;
+  lastRefill: number;
+}
+
+const BUCKET_CAPACITY = 10;
+const BUCKET_REFILL_PER_S = 5;
+const PERSIST_DEBOUNCE_MS = 10_000;
+
+@Injectable()
+export class TimelineService {
+  private meta = new Map<string, RoomMeta>();
+  private buckets = new Map<string, TokenBucket>();
+  private persistTimers = new Map<string, NodeJS.Timeout>();
+
+  constructor(
+    @Inject(ROOM_STATE_STORE) private store: RoomStateStore,
+    private database: DatabaseService,
+  ) {}
+
+  /**
+   * Ensure the room has an authoritative timeline; called on join. Hydrates
+   * from the Room row on first touch — always paused (P5).
+   */
+  async ensureRoom(
+    roomCode: string,
+    room: {
+      creatorId: string;
+      allowGuestControl: boolean;
+      videoUrl: string | null;
+      currentTime: number;
+    },
+    now: number,
+  ): Promise<Timeline> {
+    if (!this.meta.has(roomCode)) {
+      this.meta.set(roomCode, {
+        creatorId: room.creatorId,
+        allowGuestControl: room.allowGuestControl,
+        videoId: room.videoUrl,
+        activeController: null,
+      });
+    }
+    return this.store.init(roomCode, room.videoUrl, room.currentTime, now);
+  }
+
+  /** Projected timeline for a joiner (or null if the room was never touched). */
+  async currentTimeline(roomCode: string): Promise<Timeline | null> {
+    return this.store.get(roomCode);
+  }
+
+  private allowedToControl(meta: RoomMeta, userId: string): boolean {
+    return (
+      meta.allowGuestControl ||
+      userId === meta.creatorId ||
+      userId === meta.activeController
+    );
+  }
+
+  private takeToken(socketId: string, now: number): boolean {
+    const bucket = this.buckets.get(socketId) ?? {
+      tokens: BUCKET_CAPACITY,
+      lastRefill: now,
+    };
+    bucket.tokens = Math.min(
+      BUCKET_CAPACITY,
+      bucket.tokens + ((now - bucket.lastRefill) / 1000) * BUCKET_REFILL_PER_S,
+    );
+    bucket.lastRefill = now;
+    if (bucket.tokens < 1) {
+      this.buckets.set(socketId, bucket);
+      return false;
+    }
+    bucket.tokens -= 1;
+    this.buckets.set(socketId, bucket);
+    return true;
+  }
+
+  async handleControl(
+    roomCode: string,
+    socketId: string,
+    userId: string,
+    intent: ControlIntent,
+    mediaTime: number,
+    now: number,
+  ): Promise<ControlResult> {
+    const meta = this.meta.get(roomCode);
+    if (!meta) return { ok: false, reason: 'room-not-found' };
+    if (!this.allowedToControl(meta, userId)) {
+      return { ok: false, reason: 'not-controller' };
+    }
+    if (!this.takeToken(socketId, now)) {
+      return { ok: false, reason: 'rate-limited' };
+    }
+    const timeline = await this.store.applyControl(
+      roomCode,
+      intent,
+      mediaTime,
+      now,
+      userId,
+    );
+    if (!timeline) return { ok: false, reason: 'room-not-found' };
+    this.schedulePersist(roomCode);
+    return { ok: true, timeline };
+  }
+
+  /** Periodic re-anchor; null when the room has no state (nothing to sweep). */
+  async sweepSnapshot(roomCode: string, now: number): Promise<Timeline | null> {
+    const current = await this.store.get(roomCode);
+    if (!current) return null;
+    // paused rooms don't advance; re-broadcasting them is pure noise
+    if (!current.isPlaying) return null;
+    return this.store.applySnapshot(roomCode, now);
+  }
+
+  /**
+   * P3 succession: the departing user stops controlling; promote the given
+   * candidate (longest-connected participant) unless guests can control
+   * anyway. Returns the new controller id when a change happened.
+   */
+  succession(
+    roomCode: string,
+    departedUserId: string,
+    candidateUserId: string | null,
+  ): { controllerId: string; reason: 'succession' } | null {
+    const meta = this.meta.get(roomCode);
+    if (!meta || meta.allowGuestControl) return null;
+    const controls =
+      departedUserId === meta.creatorId ||
+      departedUserId === meta.activeController;
+    if (!controls) return null;
+    if (!candidateUserId || candidateUserId === departedUserId) return null;
+    meta.activeController = candidateUserId;
+    return { controllerId: candidateUserId, reason: 'succession' };
+  }
+
+  /** Creator returned: control reverts (P3). */
+  reclaim(
+    roomCode: string,
+    userId: string,
+  ): { controllerId: string; reason: 'reclaim' } | null {
+    const meta = this.meta.get(roomCode);
+    if (!meta) return null;
+    if (userId === meta.creatorId && meta.activeController !== null) {
+      meta.activeController = null;
+      return { controllerId: userId, reason: 'reclaim' };
+    }
+    return null;
+  }
+
+  async releaseRoom(roomCode: string): Promise<void> {
+    await this.flushPersist(roomCode);
+    this.meta.delete(roomCode);
+    await this.store.clear(roomCode);
+  }
+
+  dropSocket(socketId: string): void {
+    this.buckets.delete(socketId);
+  }
+
+  private schedulePersist(roomCode: string): void {
+    if (this.persistTimers.has(roomCode)) return;
+    const timer = setTimeout(() => {
+      this.persistTimers.delete(roomCode);
+      void this.flushPersist(roomCode);
+    }, PERSIST_DEBOUNCE_MS);
+    this.persistTimers.set(roomCode, timer);
+  }
+
+  private async flushPersist(roomCode: string): Promise<void> {
+    const timer = this.persistTimers.get(roomCode);
+    if (timer) {
+      clearTimeout(timer);
+      this.persistTimers.delete(roomCode);
+    }
+    const tl = await this.store.get(roomCode);
+    if (!tl) return;
+    const now = Date.now();
+    try {
+      await this.database.room.update({
+        where: { code: roomCode },
+        data: {
+          currentTime: projectMediaTime(tl, now),
+          isPlaying: tl.isPlaying,
+          lastSyncAt: new Date(now),
+        },
+      });
+    } catch (error) {
+      console.error(`timeline persist failed for ${roomCode}:`, error);
+    }
+  }
+}

--- a/video-sync-backend/src/sync/voice.gateway.ts
+++ b/video-sync-backend/src/sync/voice.gateway.ts
@@ -4,10 +4,13 @@ import {
   SubscribeMessage,
   OnGatewayConnection,
   OnGatewayDisconnect,
+  OnGatewayInit,
   MessageBody,
   ConnectedSocket,
 } from '@nestjs/websockets';
+import { JwtService } from '@nestjs/jwt';
 import { Server, Socket } from 'socket.io';
+import { wsAuthMiddleware } from './ws-auth';
 
 interface VoiceUser {
   userId: string;
@@ -34,12 +37,20 @@ interface SignalData {
   },
   transports: ['websocket', 'polling'],
 })
-export class VoiceGateway implements OnGatewayConnection, OnGatewayDisconnect {
+export class VoiceGateway
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+{
   @WebSocketServer()
   server: Server;
 
   private voiceUsers: Map<string, VoiceUser> = new Map();
   private roomVoiceUsers: Map<string, Set<string>> = new Map();
+
+  constructor(private jwt: JwtService) {}
+
+  afterInit(server: Server): void {
+    server.use(wsAuthMiddleware(this.jwt));
+  }
 
   handleConnection(client: Socket) {
     console.log(`Voice client connected: ${client.id}`);

--- a/video-sync-backend/src/sync/ws-auth.ts
+++ b/video-sync-backend/src/sync/ws-auth.ts
@@ -1,0 +1,41 @@
+import { JwtService } from '@nestjs/jwt';
+import { Socket } from 'socket.io';
+
+interface TokenPayload {
+  sub: string;
+  name: string;
+}
+
+/** Shape of socket.data after the middleware accepted the connection. */
+export interface AuthedSocketData {
+  userId: string;
+  username: string;
+  connectedAt: number;
+}
+
+/**
+ * Socket.IO connection middleware: verify handshake.auth.token, derive
+ * identity server-side into socket.data. Client-asserted userIds in event
+ * payloads are dead from here on — handlers read socket.data.userId only.
+ * Applied to both namespaces (/ and /voice).
+ */
+export function wsAuthMiddleware(jwt: JwtService) {
+  return (socket: Socket, next: (err?: Error) => void): void => {
+    const token = (socket.handshake.auth as { token?: string } | undefined)
+      ?.token;
+    if (!token) {
+      next(new Error('unauthorized: missing token'));
+      return;
+    }
+    try {
+      const payload = jwt.verify<TokenPayload>(token);
+      const data = socket.data as AuthedSocketData;
+      data.userId = payload.sub;
+      data.username = payload.name;
+      data.connectedAt = Date.now();
+      next();
+    } catch {
+      next(new Error('unauthorized: invalid token'));
+    }
+  };
+}

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -295,6 +295,17 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
     latencyRef.current = latency;
   }, [latency]);
 
+  // The YT player registers onStateChange once at init, freezing whatever
+  // render's closures it saw. Reading socket/connected through refs keeps
+  // broadcasts working when the socket connects (or reconnects) after the
+  // player initialized - the baseline's silent-drop bug.
+  const socketRef = useRef(socket);
+  const connectedRef = useRef(connected);
+  useEffect(() => {
+    socketRef.current = socket;
+    connectedRef.current = connected;
+  }, [socket, connected]);
+
   // Baseline telemetry shim: a read-only observer polled by sync-harness via
   // window.__mustardSync. Samples the player at 20Hz; never calls a mutating
   // player API, so measured runs exercise the app exactly as shipped.
@@ -420,7 +431,8 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
   };
 
   const broadcastState = useCallback((action: string) => {
-    if (!socket || !connected || !canControl) return;
+    const liveSocket = socketRef.current;
+    if (!liveSocket || !connectedRef.current || !canControl) return;
 
     const state = {
       currentTime: playerRef.current?.getCurrentTime() || 0,
@@ -428,13 +440,13 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
       clientTimestamp: Date.now()
     };
 
-    socket.emit('video-state', {
+    liveSocket.emit('video-state', {
       roomCode,
       state,
       action,
       clientTimestamp: Date.now()
     });
-  }, [socket, connected, canControl, roomCode]);
+  }, [canControl, roomCode]);
 
   // Socket event listeners
   useEffect(() => {

--- a/video-sync-frontend/src/contexts/AuthContext.tsx
+++ b/video-sync-frontend/src/contexts/AuthContext.tsx
@@ -6,6 +6,8 @@ interface User {
   id: string;
   username: string;
   email: string;
+  /** JWT presented in the socket handshake; verified server-side at connect */
+  token?: string;
 }
 
 interface AuthContextType {

--- a/video-sync-frontend/src/contexts/SocketContext.tsx
+++ b/video-sync-frontend/src/contexts/SocketContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { io, Socket } from 'socket.io-client';
 import { toast } from 'react-hot-toast';
+import { useAuth } from './AuthContext';
 
 interface SocketContextType {
   socket: Socket | null;
@@ -22,10 +23,20 @@ interface SocketProviderProps {
 }
 
 export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
+  const { user } = useAuth();
   const [socket, setSocket] = useState<Socket | null>(null);
   const [connected, setConnected] = useState(false);
+  const token = user?.token;
 
   useEffect(() => {
+    // the gateway rejects unauthenticated sockets; without a token there is
+    // nothing to connect (login/register issue one)
+    if (!token) {
+      setSocket(null);
+      setConnected(false);
+      return;
+    }
+
     // Harness override: ?ws=<url> routes the socket through an impairment
     // proxy during measurement runs; inert unless the query param is present.
     const wsOverride = new URLSearchParams(window.location.search).get('ws');
@@ -35,6 +46,7 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
 
     const socketInstance = io(wsUrl, {
       transports: ['websocket', 'polling'],
+      auth: { token },
       reconnection: true,
       reconnectionAttempts: 5,
       reconnectionDelay: 1000,
@@ -52,6 +64,10 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
       toast.error('Disconnected from sync server');
     });
 
+    socketInstance.on('connect_error', (error: Error) => {
+      console.error('Socket connect error:', error.message);
+    });
+
     socketInstance.on('error', (error: any) => {
       console.error('Socket error:', error);
       toast.error(error.message || 'Connection error');
@@ -62,7 +78,7 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
     return () => {
       socketInstance.disconnect();
     };
-  }, []);
+  }, [token]);
 
   return (
     <SocketContext.Provider value={{ socket, connected }}>


### PR DESCRIPTION
The backend half of the sync overhaul, landed **additively** — the legacy protocol keeps serving the current frontend until M4 switches over, so `main` stays working throughout.

## What's new
- **Server-authoritative timeline** behind a `RoomStateStore` seam (in-memory now; the Redis/Lua implementation swaps in at M6 without touching engine logic). Room state is a projectable function with `(storeEpoch, seq)` ordering, hydrated **paused** from persistence (P5).
- **`sync:control` → restamp → `sync:timeline` to the whole room** — wait-for-broadcast semantics: the commander converges from the same message as everyone else, which is what makes the baseline's echo storms structurally impossible. Per-socket token bucket (5/s, burst 10) with typed rejections.
- **`sync:clock` ack fast-path** — t1/t2 stamped with zero awaits, the substrate for the client's NTP-style estimator.
- **10s snapshot sweep** re-anchors playing rooms as the repair channel for lost broadcasts.
- **Socket identity**: JWT issued at login/register, verified by connection middleware on both namespaces (`/` and `/voice`); `socket.data` is the only identity source — client-asserted userIds are dead *including in the legacy handlers*.
- **P3 succession**: controller disconnect promotes the longest-connected participant; the creator reclaims on return. Fixes the permanently-uncontrollable-room bug.
- **Baseline bug fixed**: the silent control-drop closure (`onStateChange` freezing a `connected=false` closure) — broadcasts now read live refs. Two-browser legacy sync verified working again, now with auth enforced.

## Verification
- **8 socket-level proofs** (`sync-harness/src/verify-m3.ts`, all passing against a live backend): unauthenticated + invalid-token sockets rejected; forged identity blocked on the new *and* legacy control paths; causally-ordered clock ack; commander-included broadcast; **mid-play joiner projected to within tens of ms (measured 103.03s vs expected ~103s)**; control flood rate-limited (15/25 rejected).
- 42 backend unit tests green (10 new for TimelineService: identity, rate limit, succession, sweep, persistence).
- Legacy 2-tab smoke green end-to-end through real browsers with the auth handshake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure JWT authentication for real-time video and voice connections.
  * Added authoritative room timelines with synchronized playback, clock checks, controller succession, and rate limiting.
  * Registration and login now provide authentication tokens.
  * Added support for joining rooms mid-playback with the current timeline.

* **Bug Fixes**
  * Improved playback state broadcasting across socket connections and reconnects.
  * Prevented unauthenticated or invalid socket connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->