### PR TITLE
M4: client sync engine + legacy protocol retirement

### DIFF
--- a/video-sync-backend/src/sync/sync.gateway.ts
+++ b/video-sync-backend/src/sync/sync.gateway.ts
@@ -21,13 +21,6 @@ import {
 import { TimelineService } from './timeline.service';
 import { AuthedSocketData, wsAuthMiddleware } from './ws-auth';
 
-interface VideoState {
-  currentTime: number;
-  isPlaying: boolean;
-  timestamp?: number;
-  latency?: number; // Track sync latency
-}
-
 interface RoomData {
   roomCode: string;
   userId: string;
@@ -48,7 +41,6 @@ export class SyncGateway
   @WebSocketServer()
   server: Server;
 
-  private roomStates: Map<string, VideoState> = new Map();
   private userRooms: Map<string, string> = new Map();
   private roomHosts: Map<string, string> = new Map(); // Track room hosts
   private socketToUser: Map<string, string> = new Map(); // Map socket.id to userId
@@ -195,12 +187,6 @@ export class SyncGateway
         },
       });
 
-      const currentState = this.roomStates.get(data.roomCode) || {
-        currentTime: room.currentTime,
-        isPlaying: room.isPlaying,
-        timestamp: Date.now(),
-      };
-
       // Calculate join latency
       const joinLatency = Date.now() - joinStartTime;
 
@@ -213,7 +199,6 @@ export class SyncGateway
           videoUrl: room.videoUrl,
           creatorId: room.creatorId,
         },
-        state: currentState,
         timeline,
         participants: updatedParticipants.map((p) => ({
           id: p.user.id,
@@ -290,87 +275,6 @@ export class SyncGateway
     }
   }
 
-  @SubscribeMessage('video-state')
-  async handleVideoState(
-    @ConnectedSocket() client: Socket,
-    @MessageBody()
-    data: {
-      roomCode: string;
-      state: VideoState;
-      action?: string;
-      clientTimestamp?: number;
-    },
-  ) {
-    try {
-      const { roomCode, state, action, clientTimestamp } = data;
-      const userId = this.socketToUser.get(client.id);
-
-      // Check if user is the host (creator) of the room or if guest control is allowed
-      const room = await this.database.room.findUnique({
-        where: { code: roomCode },
-        select: { creatorId: true, allowGuestControl: true },
-      });
-
-      if (!room) {
-        client.emit('error', { message: 'Room not found' });
-        return;
-      }
-
-      // Check permissions
-      if (!room.allowGuestControl && room.creatorId !== userId) {
-        client.emit('error', {
-          message: 'Only the host can control video playback',
-        });
-        return;
-      }
-
-      console.log(
-        `Video ${action || 'state'} update in room ${roomCode}:`,
-        state,
-      );
-
-      // Update stored state
-      this.roomStates.set(roomCode, state);
-
-      // Calculate sync latency if client timestamp provided
-      const syncLatency = clientTimestamp
-        ? Date.now() - clientTimestamp
-        : undefined;
-
-      // Broadcast to other users with action type and latency
-      client.to(roomCode).emit('video-state-update', {
-        ...state,
-        action,
-        latency: syncLatency,
-        serverTimestamp: Date.now(),
-      });
-
-      // Log high latency
-      if (syncLatency && syncLatency > 500) {
-        console.warn(
-          `⚠️ High sync latency: ${syncLatency}ms for room ${roomCode}`,
-        );
-      }
-
-      // Schedule database update (debounced)
-      this.scheduleDatabaseUpdate(roomCode, state);
-    } catch (error) {
-      console.error('Error syncing video state:', error);
-    }
-  }
-
-  @SubscribeMessage('ping')
-  handlePing(
-    @ConnectedSocket() client: Socket,
-    @MessageBody() data: { timestamp: number },
-  ) {
-    // Immediately respond with pong for latency measurement
-    client.emit('pong', {
-      clientTimestamp: data.timestamp,
-      serverTimestamp: Date.now(),
-    });
-  }
-
   @SubscribeMessage(SYNC_EVENTS.clock)
   handleSyncClock(@MessageBody() data: ClockPing): ClockPong {
     // ack fast-path: stamp immediately, no awaits before t1/t2
@@ -423,177 +327,6 @@ export class SyncGateway
       } catch (error) {
         console.error(`sweep failed for ${roomCode}:`, error);
       }
-    }
-  }
-
-  @SubscribeMessage('sync-check')
-  handleSyncCheck(
-    @ConnectedSocket() client: Socket,
-    @MessageBody()
-    data: {
-      roomCode: string;
-      currentTime: number;
-      isPlaying: boolean;
-      clientTimestamp?: number;
-    },
-  ) {
-    try {
-      // This is for periodic sync checks
-      // Only update if there's a significant difference
-      const roomState = this.roomStates.get(data.roomCode);
-      if (roomState) {
-        const timeDiff = Math.abs(roomState.currentTime - data.currentTime);
-        if (timeDiff > 3) {
-          // Only sync if difference is more than 3 seconds
-          const latency = data.clientTimestamp
-            ? Date.now() - data.clientTimestamp
-            : undefined;
-          client.emit('video-state-update', {
-            ...roomState,
-            action: 'sync-check',
-            latency,
-            serverTimestamp: Date.now(),
-          });
-        }
-      }
-    } catch (error) {
-      console.error('Error handling sync check:', error);
-    }
-  }
-
-  @SubscribeMessage('play-video')
-  async handlePlayVideo(
-    @ConnectedSocket() client: Socket,
-    @MessageBody() data: { roomCode: string; time?: number },
-  ) {
-    try {
-      const userId = this.socketToUser.get(client.id);
-
-      // Check if user is the host (creator) of the room or if guest control is allowed
-      const room = await this.database.room.findUnique({
-        where: { code: data.roomCode },
-        select: { creatorId: true, allowGuestControl: true },
-      });
-
-      if (!room) {
-        client.emit('error', { message: 'Room not found' });
-        return;
-      }
-
-      // Check permissions
-      if (!room.allowGuestControl && room.creatorId !== userId) {
-        client.emit('error', {
-          message: 'Only the host can control video playback',
-        });
-        return;
-      }
-
-      const state: VideoState = {
-        currentTime: data.time || 0,
-        isPlaying: true,
-        timestamp: Date.now(),
-      };
-
-      this.roomStates.set(data.roomCode, state);
-      client.to(data.roomCode).emit('video-state-update', {
-        ...state,
-        action: 'play',
-      });
-
-      console.log(`Play video in room ${data.roomCode} at ${data.time}s`);
-    } catch (error) {
-      console.error('Error handling play video:', error);
-    }
-  }
-
-  @SubscribeMessage('pause-video')
-  async handlePauseVideo(
-    @ConnectedSocket() client: Socket,
-    @MessageBody() data: { roomCode: string; time?: number },
-  ) {
-    try {
-      const userId = this.socketToUser.get(client.id);
-
-      // Check if user is the host (creator) of the room or if guest control is allowed
-      const room = await this.database.room.findUnique({
-        where: { code: data.roomCode },
-        select: { creatorId: true, allowGuestControl: true },
-      });
-
-      if (!room) {
-        client.emit('error', { message: 'Room not found' });
-        return;
-      }
-
-      // Check permissions
-      if (!room.allowGuestControl && room.creatorId !== userId) {
-        client.emit('error', {
-          message: 'Only the host can control video playback',
-        });
-        return;
-      }
-
-      const state: VideoState = {
-        currentTime: data.time || 0,
-        isPlaying: false,
-        timestamp: Date.now(),
-      };
-
-      this.roomStates.set(data.roomCode, state);
-      client.to(data.roomCode).emit('video-state-update', {
-        ...state,
-        action: 'pause',
-      });
-
-      console.log(`Pause video in room ${data.roomCode} at ${data.time}s`);
-    } catch (error) {
-      console.error('Error handling pause video:', error);
-    }
-  }
-
-  @SubscribeMessage('seek-video')
-  async handleSeekVideo(
-    @ConnectedSocket() client: Socket,
-    @MessageBody() data: { roomCode: string; time: number },
-  ) {
-    try {
-      const userId = this.socketToUser.get(client.id);
-
-      // Check if user is the host (creator) of the room or if guest control is allowed
-      const room = await this.database.room.findUnique({
-        where: { code: data.roomCode },
-        select: { creatorId: true, allowGuestControl: true },
-      });
-
-      if (!room) {
-        client.emit('error', { message: 'Room not found' });
-        return;
-      }
-
-      // Check permissions
-      if (!room.allowGuestControl && room.creatorId !== userId) {
-        client.emit('error', {
-          message: 'Only the host can control video playback',
-        });
-        return;
-      }
-
-      const roomState = this.roomStates.get(data.roomCode);
-      const state: VideoState = {
-        currentTime: data.time,
-        isPlaying: roomState?.isPlaying || false,
-        timestamp: Date.now(),
-      };
-
-      this.roomStates.set(data.roomCode, state);
-      client.to(data.roomCode).emit('video-state-update', {
-        ...state,
-        action: 'seek',
-      });
-
-      console.log(`Seek video in room ${data.roomCode} to ${data.time}s`);
-    } catch (error) {
-      console.error('Error handling seek video:', error);
     }
   }
 
@@ -707,7 +440,6 @@ export class SyncGateway
       const roomSockets = await this.server.in(roomCode).fetchSockets();
       if (roomSockets.length === 0) {
         this.roomHosts.delete(roomCode);
-        this.roomStates.delete(roomCode);
         await this.timeline.releaseRoom(roomCode);
       } else if (userId) {
         // P3: if a controller left, promote the longest-connected participant
@@ -790,30 +522,5 @@ export class SyncGateway
     } catch (error) {
       console.error('Error handling leave room:', error);
     }
-  }
-
-  private updateTimers: Map<string, NodeJS.Timeout> = new Map();
-
-  private scheduleDatabaseUpdate(roomCode: string, state: VideoState) {
-    const existingTimer = this.updateTimers.get(roomCode);
-    if (existingTimer) {
-      clearTimeout(existingTimer);
-    }
-
-    const timer = setTimeout(() => {
-      this.updateTimers.delete(roomCode);
-      this.database.room
-        .update({
-          where: { code: roomCode },
-          data: {
-            currentTime: state.currentTime,
-            isPlaying: state.isPlaying,
-            lastSyncAt: new Date(),
-          },
-        })
-        .catch((error) => console.error('Error updating room state:', error));
-    }, 5000); // Update database every 5 seconds
-
-    this.updateTimers.set(roomCode, timer);
   }
 }

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -2,6 +2,10 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useSocket } from '../contexts/SocketContext';
 import styled from '@emotion/styled';
 import { toast } from 'react-hot-toast';
+import { SyncEngine, type EngineStatus } from '../sync/SyncEngine';
+import { YouTubeAdapter } from '../sync/YouTubeAdapter';
+import { SYNC_EVENTS } from '../shared/sync-protocol';
+import { SyncHud } from './SyncHud';
 
 const PlayerContainer = styled.div`
   width: 100%;
@@ -29,32 +33,26 @@ const PlayerDiv = styled.div`
   height: 100%;
 `;
 
-const LatencyBadge = styled.div<{ latency: number }>`
+const GestureChip = styled.button`
   position: absolute;
-  top: 20px;
-  right: 20px;
-  background: ${props =>
-    props.latency < 100 ? '#10b981' :
-    props.latency < 300 ? '#f59e0b' :
-    props.latency < 500 ? '#f97316' :
-    '#f87171'
-  };
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 105;
+  background: rgba(15, 23, 42, 0.9);
   color: white;
-  padding: 8px 16px;
-  border-radius: 20px;
-  font-size: 12px;
+  border: none;
+  padding: 14px 28px;
+  border-radius: 24px;
+  font-size: 15px;
   font-weight: 600;
-  backdrop-filter: blur(10px);
-  z-index: 100;
+  cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 6px;
-  animation: fadeIn 0.3s ease;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  gap: 8px;
 
-  @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(-10px); }
-    to { opacity: 1; transform: translateY(0); }
+  &:hover {
+    background: rgba(15, 23, 42, 1);
   }
 `;
 
@@ -208,18 +206,12 @@ const StatusDot = styled.div<{ color: string }>`
   }
 `;
 
-const ControlButton = styled.button<{ active?: boolean; variant?: 'primary' | 'secondary' }>`
-  background: ${props =>
-    props.variant === 'primary'
-      ? '#6366f1'
-      : props.active
-        ? 'rgba(99, 102, 241, 0.1)'
-        : '#ffffff'
-  };
+const ControlButton = styled.button<{ active?: boolean }>`
+  background: ${props => props.active ? 'rgba(99, 102, 241, 0.1)' : '#ffffff'};
   border: 1px solid ${props =>
     props.active ? 'rgba(99, 102, 241, 0.3)' : '#e2e8f0'
   };
-  color: ${props => props.variant === 'primary' ? 'white' : '#2d3748'};
+  color: #2d3748;
   padding: 8px 16px;
   border-radius: 8px;
   cursor: pointer;
@@ -233,12 +225,7 @@ const ControlButton = styled.button<{ active?: boolean; variant?: 'primary' | 's
 
   &:hover {
     background: ${props =>
-      props.variant === 'primary'
-        ? '#5558e3'
-        : props.active
-          ? 'rgba(99, 102, 241, 0.15)'
-          : '#f8fafc'
-    };
+      props.active ? 'rgba(99, 102, 241, 0.15)' : '#f8fafc'};
     transform: translateY(-1px);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.07);
   }
@@ -271,6 +258,22 @@ interface VideoPlayerProps {
   allowGuestControl?: boolean;
 }
 
+const EMPTY_STATUS: EngineStatus = {
+  timeline: null,
+  roomPlaying: false,
+  projectedS: 0,
+  durationS: 0,
+  driftMs: 0,
+  offsetMs: 0,
+  uncertaintyMs: Infinity,
+  rttMs: NaN,
+  ctrlState: 'LOCKED',
+  seq: -1,
+  fractionalRateOK: false,
+  needsGesture: false,
+  seeksIssued: 0,
+};
+
 export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
   videoUrl,
   roomCode,
@@ -278,73 +281,18 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
   allowGuestControl = false
 }) => {
   const { socket, connected } = useSocket();
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [currentTime, setCurrentTime] = useState(0);
-  const [duration, setDuration] = useState(0);
-  const [isReady, setIsReady] = useState(false);
   const [videoId, setVideoId] = useState<string | null>(null);
+  const [isReady, setIsReady] = useState(false);
   const [syncEnabled, setSyncEnabled] = useState(true);
-  const [latency, setLatency] = useState(0);
-  const [showLatency, setShowLatency] = useState(false);
+  const [status, setStatus] = useState<EngineStatus>(EMPTY_STATUS);
+  const [showHud, setShowHud] = useState(
+    () => new URLSearchParams(window.location.search).get('debug') === '1',
+  );
 
-  const playerRef = useRef<any>(null);
+  const playerRef = useRef<YTPlayer | null>(null);
+  const engineRef = useRef<SyncEngine | null>(null);
+  const adapterRef = useRef<YouTubeAdapter | null>(null);
   const canControl = isHost || allowGuestControl;
-
-  const latencyRef = useRef(0);
-  useEffect(() => {
-    latencyRef.current = latency;
-  }, [latency]);
-
-  // The YT player registers onStateChange once at init, freezing whatever
-  // render's closures it saw. Reading socket/connected through refs keeps
-  // broadcasts working when the socket connects (or reconnects) after the
-  // player initialized - the baseline's silent-drop bug.
-  const socketRef = useRef(socket);
-  const connectedRef = useRef(connected);
-  useEffect(() => {
-    socketRef.current = socket;
-    connectedRef.current = connected;
-  }, [socket, connected]);
-
-  // Baseline telemetry shim: a read-only observer polled by sync-harness via
-  // window.__mustardSync. Samples the player at 20Hz; never calls a mutating
-  // player API, so measured runs exercise the app exactly as shipped.
-  useEffect(() => {
-    if (!isReady) return;
-    let base = 0;
-    const MAX = 6000;
-    const buf: Array<{
-      tLocal: number;
-      playerTime: number;
-      playerState: number;
-      rtt: number;
-    }> = [];
-    const iv = setInterval(() => {
-      const p = playerRef.current;
-      if (!p?.getCurrentTime) return;
-      buf.push({
-        tLocal: Date.now(),
-        playerTime: p.getCurrentTime(),
-        playerState: p.getPlayerState ? p.getPlayerState() : -1,
-        rtt: latencyRef.current,
-      });
-      if (buf.length > MAX) {
-        base += buf.length - MAX;
-        buf.splice(0, buf.length - MAX);
-      }
-    }, 50);
-    (window as any).__mustardSync = {
-      version: 'baseline-1',
-      getSamplesSince: (abs: number) => {
-        const start = Math.max(0, abs - base);
-        return { next: base + buf.length, samples: buf.slice(start) };
-      },
-    };
-    return () => {
-      clearInterval(iv);
-      delete (window as any).__mustardSync;
-    };
-  }, [isReady]);
 
   // Extract YouTube video ID
   const getYouTubeId = useCallback((url: string): string | null => {
@@ -361,241 +309,136 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
       const match = url.match(pattern);
       if (match?.[1]) return match[1];
     }
-
     return null;
   }, []);
 
-  // Load YouTube IFrame API
+  // Engine lifecycle: starts with the socket (before the player is ready, so
+  // no room-joined timeline is ever missed) and adopts the adapter later.
+  useEffect(() => {
+    if (!socket) return;
+    const engine = new SyncEngine(socket, roomCode);
+    engineRef.current = engine;
+    engine.start();
+    const unsubscribe = engine.onStatus(setStatus);
+
+    const onRejected = (r: { reason: string }) => {
+      if (r.reason === 'not-controller') {
+        toast.error('Only the host can control video playback', {
+          icon: '👑',
+          duration: 2000,
+        });
+      }
+    };
+    socket.on(SYNC_EVENTS.controlRejected, onRejected);
+
+    return () => {
+      socket.off(SYNC_EVENTS.controlRejected, onRejected);
+      unsubscribe();
+      engine.dispose();
+      engineRef.current = null;
+      adapterRef.current = null;
+    };
+  }, [socket, roomCode]);
+
+  // HUD toggle on backtick
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === '`') setShowHud((v) => !v);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  // Player bootstrap
   useEffect(() => {
     const id = getYouTubeId(videoUrl);
     setVideoId(id);
-
     if (!id) return;
+
+    const initializePlayer = (vid: string) => {
+      playerRef.current = new window.YT.Player('youtube-player', {
+        videoId: vid,
+        playerVars: {
+          autoplay: 0,
+          controls: 0,
+          disablekb: 1,
+          modestbranding: 1,
+          rel: 0,
+          iv_load_policy: 3,
+          enablejsapi: 1,
+          origin: window.location.origin,
+          playsinline: 1,
+        },
+        events: {
+          onReady: (event) => {
+            playerRef.current = event.target;
+            setIsReady(true);
+            const adapter = new YouTubeAdapter(event.target);
+            adapterRef.current = adapter;
+            engineRef.current?.attachAdapter(adapter);
+          },
+        },
+      });
+    };
 
     if (window.YT?.Player) {
       initializePlayer(id);
-      return;
+    } else {
+      const tag = document.createElement('script');
+      tag.src = 'https://www.youtube.com/iframe_api';
+      document.head.appendChild(tag);
+      window.onYouTubeIframeAPIReady = () => initializePlayer(id);
     }
-
-    const tag = document.createElement('script');
-    tag.src = 'https://www.youtube.com/iframe_api';
-    document.head.appendChild(tag);
-
-    window.onYouTubeIframeAPIReady = () => initializePlayer(id);
 
     return () => {
       playerRef.current?.destroy?.();
+      setIsReady(false);
     };
     // intentional: the player re-initializes only when the video changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [videoUrl]);
 
-  const initializePlayer = (videoId: string) => {
-    new window.YT.Player('youtube-player', {
-      height: '100%',
-      width: '100%',
-      videoId,
-      playerVars: {
-        autoplay: 0,
-        controls: 0,
-        disablekb: 1,
-        modestbranding: 1,
-        rel: 0,
-        showinfo: 0,
-        iv_load_policy: 3,
-        enablejsapi: 1,
-        origin: window.location.origin,
-        playsinline: 1
-      },
-      events: {
-        onReady: (event: any) => {
-          playerRef.current = event.target;
-          setIsReady(true);
-          setDuration(event.target.getDuration());
-        },
-        onStateChange: (event: any) => {
-          if (event.data === window.YT.PlayerState.PLAYING) {
-            setIsPlaying(true);
-            if (canControl) {
-              broadcastState('play');
-            }
-          } else if (event.data === window.YT.PlayerState.PAUSED) {
-            setIsPlaying(false);
-            if (canControl) {
-              broadcastState('pause');
-            }
-          }
-        }
-      }
-    });
-  };
-
-  const broadcastState = useCallback((action: string) => {
-    const liveSocket = socketRef.current;
-    if (!liveSocket || !connectedRef.current || !canControl) return;
-
-    const state = {
-      currentTime: playerRef.current?.getCurrentTime() || 0,
-      isPlaying: action === 'play',
-      clientTimestamp: Date.now()
-    };
-
-    liveSocket.emit('video-state', {
-      roomCode,
-      state,
-      action,
-      clientTimestamp: Date.now()
-    });
-  }, [canControl, roomCode]);
-
-  // Socket event listeners
-  useEffect(() => {
-    if (!socket) return;
-
-    const handleRoomJoined = (data: any) => {
-      if (data.latency) {
-        setLatency(data.latency);
-        setShowLatency(true);
-        setTimeout(() => setShowLatency(false), 3000);
-      }
-
-      if (data.state && playerRef.current) {
-        const { currentTime, isPlaying } = data.state;
-        playerRef.current.seekTo(currentTime, true);
-        if (isPlaying) {
-          playerRef.current.playVideo();
-        } else {
-          playerRef.current.pauseVideo();
-        }
-      }
-    };
-
-    const handleVideoStateUpdate = (data: any) => {
-      if (!syncEnabled || !playerRef.current) return;
-
-      if (data.latency) {
-        setLatency(data.latency);
-        setShowLatency(true);
-        setTimeout(() => setShowLatency(false), 3000);
-      }
-
-      const { currentTime, isPlaying, action } = data;
-
-      if (action === 'seek') {
-        playerRef.current.seekTo(currentTime, true);
-      }
-
-      if (isPlaying && playerRef.current.getPlayerState() !== window.YT.PlayerState.PLAYING) {
-        playerRef.current.playVideo();
-      } else if (!isPlaying && playerRef.current.getPlayerState() === window.YT.PlayerState.PLAYING) {
-        playerRef.current.pauseVideo();
-      }
-    };
-
-    const handleError = (data: { message: string }) => {
-      if (data.message.includes('Only the host')) {
-        toast.error(data.message, {
-          icon: '🔒',
-          duration: 3000
-        });
-      }
-    };
-
-    socket.on('room-joined', handleRoomJoined);
-    socket.on('video-state-update', handleVideoStateUpdate);
-    socket.on('error', handleError);
-
-    return () => {
-      socket.off('room-joined', handleRoomJoined);
-      socket.off('video-state-update', handleVideoStateUpdate);
-      socket.off('error', handleError);
-    };
-  }, [socket, syncEnabled]);
-
-  // Update current time
-  useEffect(() => {
-    if (!playerRef.current || !isReady) return;
-
-    const interval = setInterval(() => {
-      if (playerRef.current?.getCurrentTime) {
-        setCurrentTime(playerRef.current.getCurrentTime());
-      }
-    }, 100);
-
-    return () => clearInterval(interval);
-  }, [isReady]);
-
-  // Periodic latency measurement
-  useEffect(() => {
-    if (!socket || !roomCode) return;
-
-    const measureLatency = () => {
-      const timestamp = Date.now();
-      socket.emit('ping', { timestamp });
-    };
-
-    // Measure latency every 5 seconds
-    const latencyInterval = setInterval(measureLatency, 5000);
-
-    // Initial measurement
-    measureLatency();
-
-    // Handle pong response
-    const handlePong = (data: { clientTimestamp: number; serverTimestamp: number }) => {
-      const roundTripTime = Date.now() - data.clientTimestamp;
-      const estimatedLatency = Math.round(roundTripTime / 2);
-      setLatency(estimatedLatency);
-      setShowLatency(true);
-
-      // Always show latency badge, but auto-hide if very good
-      if (estimatedLatency < 50) {
-        setTimeout(() => setShowLatency(false), 3000);
-      }
-    };
-
-    socket.on('pong', handlePong);
-
-    return () => {
-      clearInterval(latencyInterval);
-      socket.off('pong', handlePong);
-    };
-  }, [socket, roomCode]);
-
+  // ---- gesture-only intents (wait-for-broadcast: the player is never
+  // touched here; everyone converges from the sync:timeline broadcast) ----
   const handlePlayPause = () => {
-    if (!playerRef.current || !canControl) {
-      if (!canControl) {
-        toast.error('Only the host can control video playback', {
-          icon: '👑',
-          duration: 2000
-        });
-      }
+    if (!canControl) {
+      toast.error('Only the host can control video playback', {
+        icon: '👑',
+        duration: 2000
+      });
       return;
     }
-
-    if (isPlaying) {
-      playerRef.current.pauseVideo();
+    const engine = engineRef.current;
+    const adapter = adapterRef.current;
+    if (!engine || !adapter) return;
+    if (status.roomPlaying) {
+      // P4: pause freezes at the frame the presser saw
+      engine.sendIntent('pause', adapter.getPlayerTime());
     } else {
-      playerRef.current.playVideo();
+      const from = status.timeline ? status.projectedS : adapter.getPlayerTime();
+      engine.sendIntent('play', from);
     }
   };
 
   const handleProgressClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (!playerRef.current || !duration || !canControl) {
-      if (!canControl) {
-        toast.error('Only the host can seek the video', {
-          icon: '👑',
-          duration: 2000
-        });
-      }
+    if (!canControl) {
+      toast.error('Only the host can seek the video', {
+        icon: '👑',
+        duration: 2000
+      });
       return;
     }
-
+    const engine = engineRef.current;
+    if (!engine || !status.durationS) return;
     const rect = e.currentTarget.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const clickedTime = (x / rect.width) * duration;
+    const fraction = (e.clientX - rect.left) / rect.width;
+    engine.sendIntent('seek', fraction * status.durationS);
+  };
 
-    playerRef.current.seekTo(clickedTime, true);
-    broadcastState('seek');
+  const handleSyncToggle = () => {
+    const next = !syncEnabled;
+    setSyncEnabled(next);
+    engineRef.current?.setEnabled(next);
   };
 
   const formatTime = (seconds: number) => {
@@ -617,16 +460,20 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
     );
   }
 
+  const shownTime = status.roomPlaying
+    ? status.projectedS
+    : status.timeline?.mediaTime ?? 0;
+
   return (
     <PlayerContainer>
       <VideoWrapper>
         <PlayerDiv id="youtube-player" />
-        {showLatency && (
-          <LatencyBadge latency={latency}>
-            <span>⚡</span>
-            <span>{latency}ms</span>
-          </LatencyBadge>
+        {status.needsGesture && (
+          <GestureChip onClick={() => engineRef.current?.resumeFromGesture()}>
+            ▶ Click to join playback
+          </GestureChip>
         )}
+        {showHud && <SyncHud status={status} />}
       </VideoWrapper>
 
       <Controls>
@@ -637,8 +484,8 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
             canControl={canControl}
             disabled={!isReady}
           >
-            {isPlaying ? '⏸' : '▶'}
-            {isPlaying ? 'Pause' : 'Play'}
+            {status.roomPlaying ? '⏸' : '▶'}
+            {status.roomPlaying ? 'Pause' : 'Play'}
           </PlayButton>
 
           <ProgressContainer>
@@ -647,12 +494,18 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
               onClick={handleProgressClick}
               canControl={canControl}
             >
-              <ProgressFill progress={duration > 0 ? (currentTime / duration) * 100 : 0} />
+              <ProgressFill
+                progress={
+                  status.durationS > 0
+                    ? Math.min(100, (shownTime / status.durationS) * 100)
+                    : 0
+                }
+              />
             </ProgressBar>
           </ProgressContainer>
 
           <TimeDisplay>
-            {formatTime(currentTime)} / {formatTime(duration)}
+            {formatTime(shownTime)} / {formatTime(status.durationS)}
           </TimeDisplay>
         </ControlRow>
 
@@ -669,21 +522,12 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
           </StatusGroup>
 
           <StatusGroup>
-            <ControlButton
-              active={syncEnabled}
-              onClick={() => setSyncEnabled(!syncEnabled)}
-            >
+            <StatusItem type="info">
+              {Number.isFinite(status.rttMs) ? `${Math.round(status.rttMs)}ms` : '—'}
+            </StatusItem>
+            <ControlButton active={syncEnabled} onClick={handleSyncToggle}>
               🔗 Sync {syncEnabled ? 'ON' : 'OFF'}
             </ControlButton>
-
-            {isHost && (
-              <ControlButton
-                variant="primary"
-                onClick={() => broadcastState('force-sync')}
-              >
-                ⚡ Force Sync
-              </ControlButton>
-            )}
           </StatusGroup>
         </StatusRow>
       </Controls>

--- a/video-sync-frontend/src/components/SyncHud.tsx
+++ b/video-sync-frontend/src/components/SyncHud.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import type { EngineStatus } from '../sync/SyncEngine';
+
+const Hud = styled.div`
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 110;
+  background: rgba(15, 23, 42, 0.85);
+  color: #e2e8f0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  padding: 10px 12px;
+  border-radius: 8px;
+  pointer-events: none;
+  white-space: pre;
+`;
+
+const fmt = (n: number, digits = 0): string =>
+  Number.isFinite(n) ? n.toFixed(digits) : '—';
+
+/**
+ * Debug overlay (toggled with backtick or ?debug=1). Instrumentation, not
+ * chrome: everything shown comes straight from the engine's telemetry.
+ */
+export const SyncHud: React.FC<{ status: EngineStatus }> = ({ status }) => (
+  <Hud>
+    {[
+      `state  ${status.ctrlState}${status.roomPlaying ? '' : ' (room paused)'}`,
+      `drift  ${fmt(status.driftMs)}ms`,
+      `θ      ${fmt(status.offsetMs, 1)}ms ±${fmt(status.uncertaintyMs, 1)}`,
+      `rtt    ${fmt(status.rttMs)}ms`,
+      `seq    ${status.seq}  seeks ${status.seeksIssued}`,
+      `rate   ${status.fractionalRateOK ? 'fractional OK' : 'snapped (seek mode)'}`,
+    ].join('\n')}
+  </Hud>
+);

--- a/video-sync-frontend/src/contexts/SocketContext.tsx
+++ b/video-sync-frontend/src/contexts/SocketContext.tsx
@@ -48,8 +48,10 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
       transports: ['websocket', 'polling'],
       auth: { token },
       reconnection: true,
-      reconnectionAttempts: 5,
+      // never give up: a >30s outage used to permanently kill the session
+      reconnectionAttempts: Infinity,
       reconnectionDelay: 1000,
+      reconnectionDelayMax: 10000,
     });
 
     socketInstance.on('connect', () => {

--- a/video-sync-frontend/src/sync/SyncEngine.ts
+++ b/video-sync-frontend/src/sync/SyncEngine.ts
@@ -1,0 +1,269 @@
+import type { Socket } from 'socket.io-client';
+import {
+  ClockPong,
+  ControlIntent,
+  SYNC_EVENTS,
+  Timeline,
+} from '../shared/sync-protocol';
+import { ClockEstimator } from '../shared/sync-core/clock-estimator';
+import {
+  DriftController,
+  type ControllerAction,
+} from '../shared/sync-core/drift-controller';
+import { isNewer, projectMediaTime } from '../shared/sync-core/timeline';
+import { TelemetryRing } from './telemetry';
+import type { YouTubeAdapter } from './YouTubeAdapter';
+
+export interface EngineStatus {
+  timeline: Timeline | null;
+  roomPlaying: boolean;
+  /** projected room position at "now", seconds (UI progress bar) */
+  projectedS: number;
+  durationS: number;
+  driftMs: number;
+  offsetMs: number;
+  uncertaintyMs: number;
+  rttMs: number;
+  ctrlState: string;
+  seq: number;
+  fractionalRateOK: boolean;
+  /** autoplay/ad interference: playback needs a user gesture to proceed */
+  needsGesture: boolean;
+  seeksIssued: number;
+}
+
+const CLOCK_BURST_COUNT = 8;
+const CLOCK_BURST_SPACING_MS = 150;
+const CLOCK_STEADY_MS = 2000;
+const CTRL_TICK_MS = 250;
+/** room playing but the player refuses to start after this many play actions */
+const GESTURE_CHIP_THRESHOLD = 3;
+
+export class SyncEngine {
+  private estimator = new ClockEstimator();
+  private controller = new DriftController();
+  private telemetry = new TelemetryRing();
+  private timeline: Timeline | null = null;
+  private adapter: YouTubeAdapter | null = null;
+  private fractionalRateOK = false;
+  private enabled = true;
+  private needsGesture = false;
+  private playAttempts = 0;
+  private clockTimer: ReturnType<typeof setInterval> | null = null;
+  private ctrlTimer: ReturnType<typeof setInterval> | null = null;
+  private listeners = new Set<(s: EngineStatus) => void>();
+  private disposed = false;
+
+  constructor(
+    private socket: Socket,
+    private roomCode: string,
+  ) {}
+
+  start(): void {
+    this.telemetry.install();
+
+    this.socket.on(SYNC_EVENTS.timeline, this.onTimeline);
+    this.socket.on('room-joined', this.onRoomJoined);
+    this.socket.on('connect', this.onReconnect);
+    document.addEventListener('visibilitychange', this.onVisibility);
+
+    this.burst(CLOCK_BURST_COUNT);
+    this.clockTimer = setInterval(() => {
+      if (!document.hidden) this.ping();
+    }, CLOCK_STEADY_MS);
+
+    this.ctrlTimer = setInterval(() => this.tick(), CTRL_TICK_MS);
+  }
+
+  attachAdapter(adapter: YouTubeAdapter): void {
+    this.adapter = adapter;
+    void adapter.probeFractionalRate().then((ok) => {
+      this.fractionalRateOK = ok;
+    });
+  }
+
+  /** Explicit user gesture: play/pause/scrub. Wait-for-broadcast — the
+   * player is NOT touched here; everyone converges from sync:timeline. */
+  sendIntent(intent: ControlIntent, mediaTime: number): void {
+    this.socket.emit(SYNC_EVENTS.control, {
+      v: 1,
+      roomCode: this.roomCode,
+      intent,
+      mediaTime: Math.max(0, mediaTime),
+    });
+  }
+
+  /** The needs-gesture chip was clicked: a real user activation exists. */
+  resumeFromGesture(): void {
+    this.needsGesture = false;
+    this.playAttempts = 0;
+    this.adapter?.play();
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+    if (enabled) this.controller.resume();
+    else this.controller.suspend();
+  }
+
+  onStatus(listener: (s: EngineStatus) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private onTimeline = (tl: Timeline): void => {
+    if (isNewer(tl, this.timeline)) this.timeline = tl;
+  };
+
+  private onRoomJoined = (payload: { timeline?: Timeline }): void => {
+    if (payload.timeline && isNewer(payload.timeline, this.timeline)) {
+      this.timeline = payload.timeline;
+    }
+  };
+
+  private onReconnect = (): void => {
+    // fresh path, fresh clock: drop history and re-burst; the page re-joins
+    // the room and room-joined delivers a fresh timeline
+    this.estimator.reset();
+    this.burst(CLOCK_BURST_COUNT);
+    this.controller.resume();
+  };
+
+  private onVisibility = (): void => {
+    if (document.hidden) {
+      // throttled timers produce garbage clock samples; stand down
+      this.controller.suspend();
+    } else {
+      this.burst(4);
+      if (this.enabled) this.controller.resume();
+    }
+  };
+
+  private burst(count: number): void {
+    for (let i = 0; i < count; i++) {
+      setTimeout(() => this.ping(), i * CLOCK_BURST_SPACING_MS);
+    }
+  }
+
+  private ping(): void {
+    if (this.disposed || !this.socket.connected) return;
+    const t0 = Date.now();
+    this.socket.emit(SYNC_EVENTS.clock, { t0 }, (pong: ClockPong) => {
+      this.estimator.addSample({ ...pong, t3: Date.now() });
+    });
+  }
+
+  private tick(): void {
+    const tLocal = Date.now();
+    this.estimator.tick(tLocal);
+    const adapter = this.adapter;
+    if (!adapter || !this.estimator.hasEstimate()) {
+      this.emitStatus(tLocal);
+      return;
+    }
+
+    const lifecycle = adapter.getLifecycle();
+    const action = this.controller.evaluate({
+      tLocal,
+      serverNow: this.estimator.serverNow(tLocal),
+      playerTime: adapter.getPlayerTime(),
+      playerState: lifecycle,
+      timeline: this.timeline,
+      fractionalRateOK: this.fractionalRateOK,
+    });
+    this.execute(action, adapter);
+
+    // autoplay/ad interference detector: the room is playing but repeated
+    // play commands don't stick — stop fighting, ask for one gesture
+    if (lifecycle === 'playing') {
+      this.playAttempts = 0;
+      this.needsGesture = false;
+    }
+
+    const est = this.estimator.getEstimate();
+    const status = this.controller.getStatus();
+    this.telemetry.push({
+      tLocal,
+      playerTime: adapter.getPlayerTime(),
+      playerState: adapter.getRawState(),
+      rtt: est.lastRttMs,
+      driftMs: status.lastDriftS * 1000,
+      offsetMs: est.offsetMs,
+      uncertaintyMs: est.uncertaintyMs,
+      ctrlState: status.state,
+      seq: this.timeline?.seq ?? -1,
+      fractionalRateOK: this.fractionalRateOK,
+    });
+    this.emitStatus(tLocal);
+  }
+
+  private execute(action: ControllerAction, adapter: YouTubeAdapter): void {
+    switch (action.type) {
+      case 'seek':
+        adapter.seekTo(action.toMediaTime);
+        break;
+      case 'play':
+        this.playAttempts += 1;
+        if (this.playAttempts > GESTURE_CHIP_THRESHOLD) {
+          this.needsGesture = true;
+        } else {
+          adapter.play();
+        }
+        break;
+      case 'pause':
+        adapter.pause();
+        break;
+      case 'set-rate': {
+        const applied = adapter.setRate(action.rate);
+        if (Math.abs(applied - action.rate) > 0.001) {
+          // the probe lied for this video; fall back to SEEK mode
+          this.fractionalRateOK = false;
+        }
+        break;
+      }
+      case 'clear-rate':
+        adapter.setRate(1);
+        break;
+      case 'none':
+        break;
+    }
+  }
+
+  private emitStatus(tLocal: number): void {
+    if (this.listeners.size === 0) return;
+    const est = this.estimator.getEstimate();
+    const ctrl = this.controller.getStatus();
+    const serverNow = this.estimator.serverNow(tLocal);
+    const status: EngineStatus = {
+      timeline: this.timeline,
+      roomPlaying: this.timeline?.isPlaying ?? false,
+      projectedS: this.timeline
+        ? projectMediaTime(this.timeline, serverNow)
+        : 0,
+      durationS: this.adapter?.getDuration() ?? 0,
+      driftMs: ctrl.lastDriftS * 1000,
+      offsetMs: est.offsetMs,
+      uncertaintyMs: est.uncertaintyMs,
+      rttMs: est.lastRttMs,
+      ctrlState: ctrl.state,
+      seq: this.timeline?.seq ?? -1,
+      fractionalRateOK: this.fractionalRateOK,
+      needsGesture: this.needsGesture,
+      seeksIssued: ctrl.seeksIssued,
+    };
+    this.listeners.forEach((l) => l(status));
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    if (this.clockTimer) clearInterval(this.clockTimer);
+    if (this.ctrlTimer) clearInterval(this.ctrlTimer);
+    this.socket.off(SYNC_EVENTS.timeline, this.onTimeline);
+    this.socket.off('room-joined', this.onRoomJoined);
+    this.socket.off('connect', this.onReconnect);
+    document.removeEventListener('visibilitychange', this.onVisibility);
+    this.adapter?.dispose();
+    this.telemetry.uninstall();
+    this.listeners.clear();
+  }
+}

--- a/video-sync-frontend/src/sync/YouTubeAdapter.ts
+++ b/video-sync-frontend/src/sync/YouTubeAdapter.ts
@@ -1,0 +1,146 @@
+import { PlayerLifecycle } from '../shared/sync-core/drift-controller';
+import { PlayerAdapter } from '../shared/sync-core/player-adapter';
+
+/**
+ * Wraps the YouTube IFrame player behind the shared PlayerAdapter surface.
+ *
+ * getCurrentTime() is quantized/steppy, so the playhead is reconstructed
+ * from value-change edges sampled at 20Hz: between edges the position is
+ * extrapolated at the playback rate, capped so stalls don't extrapolate
+ * into fiction. The M1 baseline measured this readout's noise floor; the
+ * controller's deadband respects it.
+ */
+export class YouTubeAdapter implements PlayerAdapter {
+  private lastRaw = 0;
+  private edge: { tLocal: number; value: number } | null = null;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private lastCommandAt = 0;
+  private rate = 1;
+
+  constructor(private player: YTPlayer) {
+    this.pollTimer = setInterval(() => {
+      try {
+        const raw = this.player.getCurrentTime();
+        if (raw !== this.lastRaw) {
+          this.edge = { tLocal: Date.now(), value: raw };
+          this.lastRaw = raw;
+        }
+      } catch {
+        // player is tearing down; dispose() follows
+      }
+    }, 50);
+  }
+
+  getPlayerTime(): number {
+    const now = Date.now();
+    if (
+      this.getLifecycle() === 'playing' &&
+      this.edge &&
+      now - this.edge.tLocal < 800
+    ) {
+      return this.edge.value + ((now - this.edge.tLocal) / 1000) * this.rate;
+    }
+    return this.lastRaw;
+  }
+
+  getLifecycle(): PlayerLifecycle {
+    try {
+      switch (this.player.getPlayerState()) {
+        case window.YT.PlayerState.PLAYING:
+          return 'playing';
+        case window.YT.PlayerState.PAUSED:
+          return 'paused';
+        case window.YT.PlayerState.BUFFERING:
+          return 'buffering';
+        case window.YT.PlayerState.ENDED:
+          return 'ended';
+        case window.YT.PlayerState.CUED:
+          return 'cued';
+        default:
+          return 'unstarted';
+      }
+    } catch {
+      return 'unstarted';
+    }
+  }
+
+  /** Raw numeric YT state for telemetry (harness compatibility). */
+  getRawState(): number {
+    try {
+      return this.player.getPlayerState();
+    } catch {
+      return -1;
+    }
+  }
+
+  getDuration(): number {
+    try {
+      return this.player.getDuration();
+    } catch {
+      return 0;
+    }
+  }
+
+  seekTo(mediaTime: number): void {
+    this.lastCommandAt = Date.now();
+    this.edge = null; // the old edge is meaningless across a seek
+    this.player.seekTo(mediaTime, true);
+  }
+
+  play(): void {
+    this.lastCommandAt = Date.now();
+    this.player.playVideo();
+  }
+
+  pause(): void {
+    this.lastCommandAt = Date.now();
+    this.player.pauseVideo();
+  }
+
+  setRate(rate: number): number {
+    this.lastCommandAt = Date.now();
+    this.player.setPlaybackRate(rate);
+    const applied = this.player.getPlaybackRate();
+    this.rate = applied;
+    return applied;
+  }
+
+  /**
+   * Empirical fractional-rate probe, run while CUED/paused so it is
+   * inaudible. The official API rounds unsupported rates toward 1, so the
+   * expected result on most videos is false — SEEK mode is the design
+   * center, RATE mode the opportunistic upgrade.
+   */
+  async probeFractionalRate(): Promise<boolean> {
+    try {
+      this.player.setPlaybackRate(1.05);
+      for (let i = 0; i < 5; i++) {
+        await new Promise((r) => setTimeout(r, 100));
+        const applied = this.player.getPlaybackRate();
+        if (Math.abs(applied - 1.05) < 0.001) {
+          this.player.setPlaybackRate(1);
+          return true;
+        }
+      }
+      return false;
+    } catch {
+      return false;
+    } finally {
+      try {
+        this.player.setPlaybackRate(1);
+      } catch {
+        /* teardown race */
+      }
+    }
+  }
+
+  /** True when a recent programmatic command explains a state transition. */
+  wasRecentlyCommanded(windowMs = 1500): boolean {
+    return Date.now() - this.lastCommandAt < windowMs;
+  }
+
+  dispose(): void {
+    if (this.pollTimer) clearInterval(this.pollTimer);
+    this.pollTimer = null;
+  }
+}

--- a/video-sync-frontend/src/sync/telemetry.ts
+++ b/video-sync-frontend/src/sync/telemetry.ts
@@ -1,0 +1,52 @@
+/**
+ * Telemetry ring exposed at window.__mustardSync for the measurement
+ * harness. The contract (getSamplesSince with absolute indices) is
+ * unchanged from the baseline shim so old and new engines are measured
+ * identically; the sample is a superset of the baseline's fields.
+ */
+export interface EngineTelemetrySample {
+  tLocal: number;
+  playerTime: number;
+  /** raw numeric YT state (1 = PLAYING) — harness compatibility */
+  playerState: number;
+  /** estimator RTT, ms */
+  rtt: number;
+  driftMs: number;
+  offsetMs: number;
+  uncertaintyMs: number;
+  ctrlState: string;
+  seq: number;
+  fractionalRateOK: boolean;
+}
+
+const MAX = 6000;
+
+export class TelemetryRing {
+  private base = 0;
+  private buf: EngineTelemetrySample[] = [];
+
+  push(sample: EngineTelemetrySample): void {
+    this.buf.push(sample);
+    if (this.buf.length > MAX) {
+      this.base += this.buf.length - MAX;
+      this.buf.splice(0, this.buf.length - MAX);
+    }
+  }
+
+  install(): void {
+    (window as any).__mustardSync = {
+      version: 'engine-2',
+      getSamplesSince: (abs: number) => {
+        const start = Math.max(0, abs - this.base);
+        return {
+          next: this.base + this.buf.length,
+          samples: this.buf.slice(start),
+        };
+      },
+    };
+  }
+
+  uninstall(): void {
+    delete (window as any).__mustardSync;
+  }
+}


### PR DESCRIPTION
The frontend half of the engine, then the clean break: the legacy sync protocol is gone.

## Engine
- **SyncEngine**: clock burst (8×150ms) on connect/reconnect/visibility-restore, 1 ping/2s steady (suspended while hidden), 4Hz control loop feeding the shared SEEK-first controller with the projected timeline; actions executed through the adapter.
- **YouTubeAdapter**: 20Hz edge-reconstruction de-quantizes `getCurrentTime`; per-video fractional-rate probe (expected false — the API rounds toward 1; a lying probe self-corrects from the applied rate).
- **Gesture-only, wait-for-broadcast control**: buttons emit `sync:control`; nobody — including the commander — touches the player until `sync:timeline` returns. Echo storms are structurally impossible. Mid-play join needs zero special-case code (room playing + player cued → play → buffer → catch-up seek with adaptive lead).
- **Resilience**: infinite reconnection with capped backoff (a >30s outage used to kill the session permanently), rejoin + clock re-burst on reconnect, autoplay/ad interference surfaces a click-to-join chip instead of a fight.
- **SyncHud** (backtick / `?debug=1`): live state/drift/θ±uncertainty/RTT/seq/probe result.

## Retirement
`video-state`, `ping`/`pong`, `sync-check`, `play/pause/seek-video`, the frozen-scalar `roomStates`, and the 5s debounced persistence are deleted. The sync plane is exactly five events.

## Measured (same S0 scenario, same hardware as the committed baseline)
| | baseline | new engine |
|---|---|---|
| pairwise drift P50 | 363ms | **33ms** |
| pairwise drift P95 | 255.3s | **102ms** |
| convergence after play/seek | never | **1.5s / 0.75s** |
| hard seeks/min (steady) | — | **0** |

Run dir committed with SHA + hardware; reproduce with `HARNESS_ENGINE=overhauled npm run scenario -- S0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved synchronized YouTube playback using shared room timelines, drift correction, and reliable play, pause, and seek controls.
  * Added playback status and synchronization metrics through an optional debug overlay.
  * Added gesture prompts when browser restrictions require user interaction to resume playback.
* **Improvements**
  * Playback synchronization now recovers across visibility changes and reconnections.
  * Reconnection attempts continue automatically with a capped retry delay.
* **Bug Fixes**
  * Improved handling of player command failures and teardown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->