### PR TITLE
M9: predictive clock-discipline controller — steady-state drift to single digits

### DIFF
--- a/shared/sync-core/discipline-controller.spec.ts
+++ b/shared/sync-core/discipline-controller.spec.ts
@@ -1,0 +1,123 @@
+import { Timeline } from '../sync-protocol';
+import { DisciplineController } from './discipline-controller';
+import type { ControllerAction } from './drift-controller';
+
+const timeline = (): Timeline => ({
+  v: 1,
+  seq: 1,
+  storeEpoch: '1000',
+  videoId: 'vid',
+  isPlaying: true,
+  mediaTime: 100,
+  stampedAt: 0,
+  rate: 1,
+  reason: 'play',
+});
+
+/**
+ * Closed-loop plant simulation: the player advances at
+ * rate_applied * (1 + skew); drift integrates the mismatch against the
+ * timeline. The controller's commands feed back into the plant - this is
+ * the loop the SimPlayer bots run, distilled.
+ */
+function simulate(
+  ctrl: DisciplineController,
+  skew: number,
+  seconds: number,
+  initialDriftS = 0,
+): {
+  drifts: number[];
+  actions: ControllerAction[];
+  seeks: number;
+  rateCommands: number;
+} {
+  const tl = timeline();
+  let drift = initialDriftS;
+  let applied = 1;
+  let tLocal = 100_000;
+  const drifts: number[] = [];
+  const actions: ControllerAction[] = [];
+  let seeks = 0;
+  let rateCommands = 0;
+  const steps = Math.round((seconds * 1000) / 250);
+  for (let i = 0; i < steps; i++) {
+    tLocal += 250;
+    drift += 0.25 * (applied * (1 + skew) - 1);
+    const serverNow = tLocal;
+    const expected = tl.mediaTime + (serverNow - tl.stampedAt) / 1000;
+    const action = ctrl.evaluate({
+      tLocal,
+      serverNow,
+      playerTime: expected + drift,
+      playerState: 'playing',
+      timeline: tl,
+      fractionalRateOK: true,
+    });
+    actions.push(action);
+    if (action.type === 'set-rate') {
+      applied = action.rate;
+      ctrl.onRateApplied(applied);
+      rateCommands += 1;
+    } else if (action.type === 'clear-rate') {
+      applied = 1;
+      ctrl.onRateApplied(1);
+    } else if (action.type === 'seek') {
+      drift = 0.02; // seek lands near target
+      applied = 1;
+      seeks += 1;
+    }
+    drifts.push(drift);
+  }
+  return { drifts, actions, seeks, rateCommands };
+}
+
+describe('DisciplineController (predictive servo)', () => {
+  it('cancels a +500ppm player skew without any seeks', () => {
+    const ctrl = new DisciplineController();
+    const { drifts, seeks } = simulate(ctrl, 500e-6, 120);
+    const tail = drifts.slice(-40); // final 10s
+    expect(seeks).toBe(0);
+    expect(Math.max(...tail.map(Math.abs))).toBeLessThan(0.03);
+    // the feed-forward learned the skew
+    expect(Math.abs(ctrl.getStatus().bHatPpm - 500)).toBeLessThan(200);
+  });
+
+  it('closes a 400ms initial error smoothly inside the servo zone', () => {
+    const ctrl = new DisciplineController();
+    const { drifts, seeks } = simulate(ctrl, 0, 60, 0.4);
+    expect(seeks).toBe(0); // rate-corrected, never a visible jump
+    expect(Math.abs(drifts[drifts.length - 1])).toBeLessThan(0.03);
+    // monotone-ish approach: no overshoot beyond 100ms the other way
+    expect(Math.min(...drifts)).toBeGreaterThan(-0.1);
+  });
+
+  it('does not limit-cycle at steady state (command hysteresis)', () => {
+    const ctrl = new DisciplineController();
+    const { actions } = simulate(ctrl, 100e-6, 120);
+    const lastQuarter = actions.slice(-120); // final 30s
+    const rateChanges = lastQuarter.filter((a) => a.type === 'set-rate').length;
+    expect(rateChanges).toBeLessThan(8); // sub-0.5% wiggles are not commanded
+  });
+
+  it('hands gross errors to the reactive seek path and recovers', () => {
+    const ctrl = new DisciplineController();
+    const { seeks, drifts } = simulate(ctrl, 0, 60, 5); // 5s off: way past servo zone
+    expect(seeks).toBeGreaterThan(0);
+    expect(Math.abs(drifts[drifts.length - 1])).toBeLessThan(0.05);
+  });
+
+  it('a commanded pause clears the rate and stands the servo down', () => {
+    const ctrl = new DisciplineController();
+    simulate(ctrl, 200e-6, 30);
+    const tl = { ...timeline(), isPlaying: false, mediaTime: 130 };
+    const action = ctrl.evaluate({
+      tLocal: 200_000,
+      serverNow: 200_000,
+      playerTime: 130,
+      playerState: 'playing',
+      timeline: tl,
+      fractionalRateOK: true,
+    });
+    expect(action.type).toBe('pause');
+  });
+});

--- a/shared/sync-core/discipline-controller.ts
+++ b/shared/sync-core/discipline-controller.ts
@@ -1,0 +1,189 @@
+// Predictive clock-discipline controller (M9): NTP/PTP servo theory applied
+// to video playback. Where the reactive controller waits for drift to cross
+// a threshold and corrects it, this one estimates each player's intrinsic
+// drift RATE and commands a continuous playback rate that cancels drift
+// before it accumulates - a discrete PI servo with a feed-forward skew term:
+//
+//   r = 1 - Kp*drift - Ki*integral(drift) - bHat
+//
+// where bHat is a recursively-estimated drift rate at r=1 (player clock
+// skew + timer error), learned with exponential forgetting. Anti-windup
+// stops integration while the command is clamped; command hysteresis avoids
+// churning the player with sub-0.5% changes.
+//
+// Empirical gate: the modern YouTube player ACCEPTS fractional rates on
+// probed videos (measured, contradicting the API reference's rounding
+// language) - but the probe stays per-video and this controller is only
+// engaged where it passed. Lifecycle handling and gross errors delegate to
+// the reactive controller: the servo owns only the steady state.
+
+import {
+  ControllerAction,
+  ControllerInput,
+  ControllerStatus,
+  ControllerTuning,
+  DEFAULT_CONTROLLER_TUNING,
+  DriftController,
+} from './drift-controller';
+
+export interface ServoTuning {
+  /** proportional gain, rate offset per second of drift */
+  kp: number;
+  /** integral gain */
+  ki: number;
+  /** RLS forgetting factor for the drift-rate estimate */
+  forgetting: number;
+  /** command clamp: rate in [1-span, 1+span] */
+  clampSpan: number;
+  /** don't re-command the player for changes smaller than this */
+  commandHysteresis: number;
+  /** |drift| above this hands back to the reactive controller's seek path */
+  servoZoneS: number;
+  /** integral clamp (anti-windup bound), seconds */
+  integralClampS: number;
+}
+
+export const DEFAULT_SERVO_TUNING: ServoTuning = {
+  kp: 0.3,
+  ki: 0.05,
+  forgetting: 0.98,
+  clampSpan: 0.05,
+  commandHysteresis: 0.005,
+  servoZoneS: 0.6,
+  integralClampS: 2.0,
+};
+
+export interface ServoStatus extends ControllerStatus {
+  servoActive: boolean;
+  bHatPpm: number;
+  commandedRate: number;
+}
+
+export class DisciplineController {
+  private reactive: DriftController;
+  private integral = 0;
+  private bHat = 0; // estimated drift rate at r=1 (s/s)
+  private rlsP = 1; // RLS covariance (scalar)
+  private lastDrift: number | null = null;
+  private lastT: number | null = null;
+  private appliedRate = 1;
+  private lastCommand = 1;
+  private servoActive = false;
+
+  constructor(
+    private servo: ServoTuning = DEFAULT_SERVO_TUNING,
+    reactiveTuning: ControllerTuning = DEFAULT_CONTROLLER_TUNING,
+  ) {
+    // the servo owns [deadband, servoZone]; the inner reactive controller
+    // must not seek inside that band, so its threshold moves to the zone
+    // boundary (its instant path and lifecycle handling are untouched)
+    this.reactive = new DriftController({
+      ...reactiveTuning,
+      seekThresholdS: servo.servoZoneS,
+    });
+  }
+
+  suspend(): void {
+    this.reactive.suspend();
+    this.resetServo();
+  }
+
+  resume(): void {
+    this.reactive.resume();
+  }
+
+  getStatus(): ServoStatus {
+    return {
+      ...this.reactive.getStatus(),
+      servoActive: this.servoActive,
+      bHatPpm: this.bHat * 1e6,
+      commandedRate: this.lastCommand,
+    };
+  }
+
+  private resetServo(): void {
+    this.integral = 0;
+    this.lastDrift = null;
+    this.lastT = null;
+    this.servoActive = false;
+    // bHat survives resets on purpose: the player's skew doesn't change
+    // because we sought; the estimate is the point of the exercise
+  }
+
+  evaluate(input: ControllerInput): ControllerAction {
+    // The reactive controller owns lifecycle (buffering/paused/play-start),
+    // gross errors (instant seeks) and the SEEKING machinery. Feed it a
+    // fractionalRateOK=false view so its own NUDGING mode never engages -
+    // the servo replaces that entire regime.
+    const act = this.reactive.evaluate({ ...input, fractionalRateOK: false });
+    const st = this.reactive.getStatus();
+
+    if (act.type === 'seek') {
+      this.resetServo();
+      return act;
+    }
+    if (act.type !== 'none' || st.state !== 'LOCKED') {
+      // paused/buffering/cooldown etc.: stand down, clear any applied rate
+      if (this.servoActive && input.playerState !== 'playing') {
+        this.resetServo();
+        this.appliedRate = 1;
+        return act.type === 'none' ? { type: 'clear-rate' } : act;
+      }
+      return act;
+    }
+
+    // steady playing state - the servo regime
+    const drift = st.lastDriftS;
+    if (Math.abs(drift) > this.servo.servoZoneS) {
+      // outside the servo zone: let the reactive machinery seek next tick
+      return { type: 'none' };
+    }
+
+    const t = input.tLocal / 1000;
+    if (this.lastT !== null && this.lastDrift !== null) {
+      const dt = t - this.lastT;
+      if (dt > 0 && dt < 2) {
+        // observed drift rate this interval, corrected for the rate we
+        // commanded: dDrift/dt = (r_applied - 1) + b  =>  b measurement
+        const measuredB =
+          (drift - this.lastDrift) / dt - (this.appliedRate - 1);
+        // scalar RLS with forgetting
+        const g = this.rlsP / (this.servo.forgetting + this.rlsP);
+        this.bHat += g * (measuredB - this.bHat);
+        this.rlsP = (1 - g) * (this.rlsP / this.servo.forgetting);
+
+        // integral with anti-windup: freeze while the last command clamped
+        const clamped =
+          Math.abs(this.lastCommand - 1) >= this.servo.clampSpan - 1e-9;
+        if (!clamped) {
+          this.integral = Math.max(
+            -this.servo.integralClampS,
+            Math.min(this.servo.integralClampS, this.integral + drift * dt),
+          );
+        }
+      }
+    }
+    this.lastT = t;
+    this.lastDrift = drift;
+
+    let r =
+      1 - this.servo.kp * drift - this.servo.ki * this.integral - this.bHat;
+    r = Math.max(
+      1 - this.servo.clampSpan,
+      Math.min(1 + this.servo.clampSpan, r),
+    );
+    this.lastCommand = r;
+    this.servoActive = true;
+
+    if (Math.abs(r - this.appliedRate) < this.servo.commandHysteresis) {
+      return { type: 'none' };
+    }
+    this.appliedRate = r;
+    return { type: 'set-rate', rate: r };
+  }
+
+  /** The engine reports what the player actually applied (probe honesty). */
+  onRateApplied(applied: number): void {
+    this.appliedRate = applied;
+  }
+}

--- a/sync-harness/src/bots/bot-client.ts
+++ b/sync-harness/src/bots/bot-client.ts
@@ -10,6 +10,7 @@ import {
   DriftController,
   type ControllerAction,
 } from '../../../shared/sync-core/drift-controller';
+import { DisciplineController } from '../../../shared/sync-core/discipline-controller';
 import { isNewer, projectMediaTime } from '../../../shared/sync-core/timeline';
 import type { ClockPong, ControlIntent, Timeline } from '../../../shared/sync-protocol';
 import { SYNC_EVENTS } from '../../../shared/sync-protocol';
@@ -26,6 +27,8 @@ export interface BotConfig {
   clockSkew: number;
   player: Partial<SimPlayerConfig>;
   seed: number;
+  /** reactive (threshold state machine) or predictive (PI servo) */
+  controller?: 'reactive' | 'predictive';
 }
 
 export interface BotSample {
@@ -52,7 +55,7 @@ export interface BotReport {
 export class BotClient {
   private socket!: Socket;
   private estimator = new ClockEstimator();
-  private controller = new DriftController();
+  private controller: DriftController | DisciplineController;
   private player: SimPlayer;
   private timeline: Timeline | null = null;
   private rng: () => number;
@@ -65,6 +68,10 @@ export class BotClient {
   user!: HarnessUser;
 
   constructor(private cfg: BotConfig) {
+    this.controller =
+      cfg.controller === 'predictive'
+        ? new DisciplineController()
+        : new DriftController();
     this.rng = mulberry32(cfg.seed);
     this.player = new SimPlayer({
       playbackSkew: 0,
@@ -162,7 +169,7 @@ export class BotClient {
           playerTime: this.player.getPlayerTime(),
           playerState: this.player.getLifecycle(),
           timeline: this.timeline,
-          fractionalRateOK: false,
+          fractionalRateOK: this.cfg.controller !== undefined,
         });
         this.execute(action, tBot);
 
@@ -209,9 +216,13 @@ export class BotClient {
       case 'pause':
         this.player.pause(tBot);
         break;
-      case 'set-rate':
-        this.player.setRate(action.rate);
+      case 'set-rate': {
+        const applied = this.player.setRate(action.rate);
+        if (this.controller instanceof DisciplineController) {
+          this.controller.onRateApplied(applied);
+        }
         break;
+      }
       case 'clear-rate':
         this.player.setRate(1);
         break;

--- a/sync-harness/src/bots/run-bots.ts
+++ b/sync-harness/src/bots/run-bots.ts
@@ -21,6 +21,7 @@ interface Args {
   durationS: number;
   gate: boolean;
   wsUrl: string;
+  controller: 'reactive' | 'predictive';
 }
 
 function parseArgs(): Args {
@@ -33,6 +34,7 @@ function parseArgs(): Args {
     durationS: parseInt(get('--duration') ?? '90', 10),
     gate: process.argv.includes('--gate'),
     wsUrl: get('--ws') ?? 'http://localhost:3000',
+    controller: (get('--controller') ?? 'reactive') as 'reactive' | 'predictive',
   };
 }
 
@@ -59,9 +61,12 @@ async function main(): Promise<void> {
         clockOffsetMs: (rng() - 0.5) * 2000, // ±1s injected offsets
         clockSkew: (rng() - 0.5) * 160e-6, // ±80ppm
         seed: 1000 + i,
+        controller: args.controller,
         player: {
           playbackSkew: (rng() - 0.5) * 160e-6,
-          fractionalRateOK: i % 4 === 0, // a quarter of the fleet has RATE mode
+          // A/B fairness: both controller arms face fractional-capable
+          // players (measured reality: the probe passes on real YouTube)
+          fractionalRateOK: true,
         },
       }),
     );
@@ -168,6 +173,7 @@ async function main(): Promise<void> {
 
   const summary = {
     runId,
+    controller: args.controller,
     n: args.n,
     durationS: args.durationS,
     steadySamples: steadyDrifts.length,

--- a/video-sync-backend/src/shared/sync-core/discipline-controller.spec.ts
+++ b/video-sync-backend/src/shared/sync-core/discipline-controller.spec.ts
@@ -1,0 +1,125 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+import { Timeline } from '../sync-protocol';
+import { DisciplineController } from './discipline-controller';
+import type { ControllerAction } from './drift-controller';
+
+const timeline = (): Timeline => ({
+  v: 1,
+  seq: 1,
+  storeEpoch: '1000',
+  videoId: 'vid',
+  isPlaying: true,
+  mediaTime: 100,
+  stampedAt: 0,
+  rate: 1,
+  reason: 'play',
+});
+
+/**
+ * Closed-loop plant simulation: the player advances at
+ * rate_applied * (1 + skew); drift integrates the mismatch against the
+ * timeline. The controller's commands feed back into the plant - this is
+ * the loop the SimPlayer bots run, distilled.
+ */
+function simulate(
+  ctrl: DisciplineController,
+  skew: number,
+  seconds: number,
+  initialDriftS = 0,
+): {
+  drifts: number[];
+  actions: ControllerAction[];
+  seeks: number;
+  rateCommands: number;
+} {
+  const tl = timeline();
+  let drift = initialDriftS;
+  let applied = 1;
+  let tLocal = 100_000;
+  const drifts: number[] = [];
+  const actions: ControllerAction[] = [];
+  let seeks = 0;
+  let rateCommands = 0;
+  const steps = Math.round((seconds * 1000) / 250);
+  for (let i = 0; i < steps; i++) {
+    tLocal += 250;
+    drift += 0.25 * (applied * (1 + skew) - 1);
+    const serverNow = tLocal;
+    const expected = tl.mediaTime + (serverNow - tl.stampedAt) / 1000;
+    const action = ctrl.evaluate({
+      tLocal,
+      serverNow,
+      playerTime: expected + drift,
+      playerState: 'playing',
+      timeline: tl,
+      fractionalRateOK: true,
+    });
+    actions.push(action);
+    if (action.type === 'set-rate') {
+      applied = action.rate;
+      ctrl.onRateApplied(applied);
+      rateCommands += 1;
+    } else if (action.type === 'clear-rate') {
+      applied = 1;
+      ctrl.onRateApplied(1);
+    } else if (action.type === 'seek') {
+      drift = 0.02; // seek lands near target
+      applied = 1;
+      seeks += 1;
+    }
+    drifts.push(drift);
+  }
+  return { drifts, actions, seeks, rateCommands };
+}
+
+describe('DisciplineController (predictive servo)', () => {
+  it('cancels a +500ppm player skew without any seeks', () => {
+    const ctrl = new DisciplineController();
+    const { drifts, seeks } = simulate(ctrl, 500e-6, 120);
+    const tail = drifts.slice(-40); // final 10s
+    expect(seeks).toBe(0);
+    expect(Math.max(...tail.map(Math.abs))).toBeLessThan(0.03);
+    // the feed-forward learned the skew
+    expect(Math.abs(ctrl.getStatus().bHatPpm - 500)).toBeLessThan(200);
+  });
+
+  it('closes a 400ms initial error smoothly inside the servo zone', () => {
+    const ctrl = new DisciplineController();
+    const { drifts, seeks } = simulate(ctrl, 0, 60, 0.4);
+    expect(seeks).toBe(0); // rate-corrected, never a visible jump
+    expect(Math.abs(drifts[drifts.length - 1])).toBeLessThan(0.03);
+    // monotone-ish approach: no overshoot beyond 100ms the other way
+    expect(Math.min(...drifts)).toBeGreaterThan(-0.1);
+  });
+
+  it('does not limit-cycle at steady state (command hysteresis)', () => {
+    const ctrl = new DisciplineController();
+    const { actions } = simulate(ctrl, 100e-6, 120);
+    const lastQuarter = actions.slice(-120); // final 30s
+    const rateChanges = lastQuarter.filter((a) => a.type === 'set-rate').length;
+    expect(rateChanges).toBeLessThan(8); // sub-0.5% wiggles are not commanded
+  });
+
+  it('hands gross errors to the reactive seek path and recovers', () => {
+    const ctrl = new DisciplineController();
+    const { seeks, drifts } = simulate(ctrl, 0, 60, 5); // 5s off: way past servo zone
+    expect(seeks).toBeGreaterThan(0);
+    expect(Math.abs(drifts[drifts.length - 1])).toBeLessThan(0.05);
+  });
+
+  it('a commanded pause clears the rate and stands the servo down', () => {
+    const ctrl = new DisciplineController();
+    simulate(ctrl, 200e-6, 30);
+    const tl = { ...timeline(), isPlaying: false, mediaTime: 130 };
+    const action = ctrl.evaluate({
+      tLocal: 200_000,
+      serverNow: 200_000,
+      playerTime: 130,
+      playerState: 'playing',
+      timeline: tl,
+      fractionalRateOK: true,
+    });
+    expect(action.type).toBe('pause');
+  });
+});

--- a/video-sync-backend/src/shared/sync-core/discipline-controller.ts
+++ b/video-sync-backend/src/shared/sync-core/discipline-controller.ts
@@ -1,0 +1,191 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+// Predictive clock-discipline controller (M9): NTP/PTP servo theory applied
+// to video playback. Where the reactive controller waits for drift to cross
+// a threshold and corrects it, this one estimates each player's intrinsic
+// drift RATE and commands a continuous playback rate that cancels drift
+// before it accumulates - a discrete PI servo with a feed-forward skew term:
+//
+//   r = 1 - Kp*drift - Ki*integral(drift) - bHat
+//
+// where bHat is a recursively-estimated drift rate at r=1 (player clock
+// skew + timer error), learned with exponential forgetting. Anti-windup
+// stops integration while the command is clamped; command hysteresis avoids
+// churning the player with sub-0.5% changes.
+//
+// Empirical gate: the modern YouTube player ACCEPTS fractional rates on
+// probed videos (measured, contradicting the API reference's rounding
+// language) - but the probe stays per-video and this controller is only
+// engaged where it passed. Lifecycle handling and gross errors delegate to
+// the reactive controller: the servo owns only the steady state.
+
+import {
+  ControllerAction,
+  ControllerInput,
+  ControllerStatus,
+  ControllerTuning,
+  DEFAULT_CONTROLLER_TUNING,
+  DriftController,
+} from './drift-controller';
+
+export interface ServoTuning {
+  /** proportional gain, rate offset per second of drift */
+  kp: number;
+  /** integral gain */
+  ki: number;
+  /** RLS forgetting factor for the drift-rate estimate */
+  forgetting: number;
+  /** command clamp: rate in [1-span, 1+span] */
+  clampSpan: number;
+  /** don't re-command the player for changes smaller than this */
+  commandHysteresis: number;
+  /** |drift| above this hands back to the reactive controller's seek path */
+  servoZoneS: number;
+  /** integral clamp (anti-windup bound), seconds */
+  integralClampS: number;
+}
+
+export const DEFAULT_SERVO_TUNING: ServoTuning = {
+  kp: 0.3,
+  ki: 0.05,
+  forgetting: 0.98,
+  clampSpan: 0.05,
+  commandHysteresis: 0.005,
+  servoZoneS: 0.6,
+  integralClampS: 2.0,
+};
+
+export interface ServoStatus extends ControllerStatus {
+  servoActive: boolean;
+  bHatPpm: number;
+  commandedRate: number;
+}
+
+export class DisciplineController {
+  private reactive: DriftController;
+  private integral = 0;
+  private bHat = 0; // estimated drift rate at r=1 (s/s)
+  private rlsP = 1; // RLS covariance (scalar)
+  private lastDrift: number | null = null;
+  private lastT: number | null = null;
+  private appliedRate = 1;
+  private lastCommand = 1;
+  private servoActive = false;
+
+  constructor(
+    private servo: ServoTuning = DEFAULT_SERVO_TUNING,
+    reactiveTuning: ControllerTuning = DEFAULT_CONTROLLER_TUNING,
+  ) {
+    // the servo owns [deadband, servoZone]; the inner reactive controller
+    // must not seek inside that band, so its threshold moves to the zone
+    // boundary (its instant path and lifecycle handling are untouched)
+    this.reactive = new DriftController({
+      ...reactiveTuning,
+      seekThresholdS: servo.servoZoneS,
+    });
+  }
+
+  suspend(): void {
+    this.reactive.suspend();
+    this.resetServo();
+  }
+
+  resume(): void {
+    this.reactive.resume();
+  }
+
+  getStatus(): ServoStatus {
+    return {
+      ...this.reactive.getStatus(),
+      servoActive: this.servoActive,
+      bHatPpm: this.bHat * 1e6,
+      commandedRate: this.lastCommand,
+    };
+  }
+
+  private resetServo(): void {
+    this.integral = 0;
+    this.lastDrift = null;
+    this.lastT = null;
+    this.servoActive = false;
+    // bHat survives resets on purpose: the player's skew doesn't change
+    // because we sought; the estimate is the point of the exercise
+  }
+
+  evaluate(input: ControllerInput): ControllerAction {
+    // The reactive controller owns lifecycle (buffering/paused/play-start),
+    // gross errors (instant seeks) and the SEEKING machinery. Feed it a
+    // fractionalRateOK=false view so its own NUDGING mode never engages -
+    // the servo replaces that entire regime.
+    const act = this.reactive.evaluate({ ...input, fractionalRateOK: false });
+    const st = this.reactive.getStatus();
+
+    if (act.type === 'seek') {
+      this.resetServo();
+      return act;
+    }
+    if (act.type !== 'none' || st.state !== 'LOCKED') {
+      // paused/buffering/cooldown etc.: stand down, clear any applied rate
+      if (this.servoActive && input.playerState !== 'playing') {
+        this.resetServo();
+        this.appliedRate = 1;
+        return act.type === 'none' ? { type: 'clear-rate' } : act;
+      }
+      return act;
+    }
+
+    // steady playing state - the servo regime
+    const drift = st.lastDriftS;
+    if (Math.abs(drift) > this.servo.servoZoneS) {
+      // outside the servo zone: let the reactive machinery seek next tick
+      return { type: 'none' };
+    }
+
+    const t = input.tLocal / 1000;
+    if (this.lastT !== null && this.lastDrift !== null) {
+      const dt = t - this.lastT;
+      if (dt > 0 && dt < 2) {
+        // observed drift rate this interval, corrected for the rate we
+        // commanded: dDrift/dt = (r_applied - 1) + b  =>  b measurement
+        const measuredB =
+          (drift - this.lastDrift) / dt - (this.appliedRate - 1);
+        // scalar RLS with forgetting
+        const g = this.rlsP / (this.servo.forgetting + this.rlsP);
+        this.bHat += g * (measuredB - this.bHat);
+        this.rlsP = (1 - g) * (this.rlsP / this.servo.forgetting);
+
+        // integral with anti-windup: freeze while the last command clamped
+        const clamped =
+          Math.abs(this.lastCommand - 1) >= this.servo.clampSpan - 1e-9;
+        if (!clamped) {
+          this.integral = Math.max(
+            -this.servo.integralClampS,
+            Math.min(this.servo.integralClampS, this.integral + drift * dt),
+          );
+        }
+      }
+    }
+    this.lastT = t;
+    this.lastDrift = drift;
+
+    let r =
+      1 - this.servo.kp * drift - this.servo.ki * this.integral - this.bHat;
+    r = Math.max(
+      1 - this.servo.clampSpan,
+      Math.min(1 + this.servo.clampSpan, r),
+    );
+    this.lastCommand = r;
+    this.servoActive = true;
+
+    if (Math.abs(r - this.appliedRate) < this.servo.commandHysteresis) {
+      return { type: 'none' };
+    }
+    this.appliedRate = r;
+    return { type: 'set-rate', rate: r };
+  }
+
+  /** The engine reports what the player actually applied (probe honesty). */
+  onRateApplied(applied: number): void {
+    this.appliedRate = applied;
+  }
+}

--- a/video-sync-frontend/src/shared/sync-core/discipline-controller.ts
+++ b/video-sync-frontend/src/shared/sync-core/discipline-controller.ts
@@ -1,0 +1,191 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+// Predictive clock-discipline controller (M9): NTP/PTP servo theory applied
+// to video playback. Where the reactive controller waits for drift to cross
+// a threshold and corrects it, this one estimates each player's intrinsic
+// drift RATE and commands a continuous playback rate that cancels drift
+// before it accumulates - a discrete PI servo with a feed-forward skew term:
+//
+//   r = 1 - Kp*drift - Ki*integral(drift) - bHat
+//
+// where bHat is a recursively-estimated drift rate at r=1 (player clock
+// skew + timer error), learned with exponential forgetting. Anti-windup
+// stops integration while the command is clamped; command hysteresis avoids
+// churning the player with sub-0.5% changes.
+//
+// Empirical gate: the modern YouTube player ACCEPTS fractional rates on
+// probed videos (measured, contradicting the API reference's rounding
+// language) - but the probe stays per-video and this controller is only
+// engaged where it passed. Lifecycle handling and gross errors delegate to
+// the reactive controller: the servo owns only the steady state.
+
+import {
+  ControllerAction,
+  ControllerInput,
+  ControllerStatus,
+  ControllerTuning,
+  DEFAULT_CONTROLLER_TUNING,
+  DriftController,
+} from './drift-controller';
+
+export interface ServoTuning {
+  /** proportional gain, rate offset per second of drift */
+  kp: number;
+  /** integral gain */
+  ki: number;
+  /** RLS forgetting factor for the drift-rate estimate */
+  forgetting: number;
+  /** command clamp: rate in [1-span, 1+span] */
+  clampSpan: number;
+  /** don't re-command the player for changes smaller than this */
+  commandHysteresis: number;
+  /** |drift| above this hands back to the reactive controller's seek path */
+  servoZoneS: number;
+  /** integral clamp (anti-windup bound), seconds */
+  integralClampS: number;
+}
+
+export const DEFAULT_SERVO_TUNING: ServoTuning = {
+  kp: 0.3,
+  ki: 0.05,
+  forgetting: 0.98,
+  clampSpan: 0.05,
+  commandHysteresis: 0.005,
+  servoZoneS: 0.6,
+  integralClampS: 2.0,
+};
+
+export interface ServoStatus extends ControllerStatus {
+  servoActive: boolean;
+  bHatPpm: number;
+  commandedRate: number;
+}
+
+export class DisciplineController {
+  private reactive: DriftController;
+  private integral = 0;
+  private bHat = 0; // estimated drift rate at r=1 (s/s)
+  private rlsP = 1; // RLS covariance (scalar)
+  private lastDrift: number | null = null;
+  private lastT: number | null = null;
+  private appliedRate = 1;
+  private lastCommand = 1;
+  private servoActive = false;
+
+  constructor(
+    private servo: ServoTuning = DEFAULT_SERVO_TUNING,
+    reactiveTuning: ControllerTuning = DEFAULT_CONTROLLER_TUNING,
+  ) {
+    // the servo owns [deadband, servoZone]; the inner reactive controller
+    // must not seek inside that band, so its threshold moves to the zone
+    // boundary (its instant path and lifecycle handling are untouched)
+    this.reactive = new DriftController({
+      ...reactiveTuning,
+      seekThresholdS: servo.servoZoneS,
+    });
+  }
+
+  suspend(): void {
+    this.reactive.suspend();
+    this.resetServo();
+  }
+
+  resume(): void {
+    this.reactive.resume();
+  }
+
+  getStatus(): ServoStatus {
+    return {
+      ...this.reactive.getStatus(),
+      servoActive: this.servoActive,
+      bHatPpm: this.bHat * 1e6,
+      commandedRate: this.lastCommand,
+    };
+  }
+
+  private resetServo(): void {
+    this.integral = 0;
+    this.lastDrift = null;
+    this.lastT = null;
+    this.servoActive = false;
+    // bHat survives resets on purpose: the player's skew doesn't change
+    // because we sought; the estimate is the point of the exercise
+  }
+
+  evaluate(input: ControllerInput): ControllerAction {
+    // The reactive controller owns lifecycle (buffering/paused/play-start),
+    // gross errors (instant seeks) and the SEEKING machinery. Feed it a
+    // fractionalRateOK=false view so its own NUDGING mode never engages -
+    // the servo replaces that entire regime.
+    const act = this.reactive.evaluate({ ...input, fractionalRateOK: false });
+    const st = this.reactive.getStatus();
+
+    if (act.type === 'seek') {
+      this.resetServo();
+      return act;
+    }
+    if (act.type !== 'none' || st.state !== 'LOCKED') {
+      // paused/buffering/cooldown etc.: stand down, clear any applied rate
+      if (this.servoActive && input.playerState !== 'playing') {
+        this.resetServo();
+        this.appliedRate = 1;
+        return act.type === 'none' ? { type: 'clear-rate' } : act;
+      }
+      return act;
+    }
+
+    // steady playing state - the servo regime
+    const drift = st.lastDriftS;
+    if (Math.abs(drift) > this.servo.servoZoneS) {
+      // outside the servo zone: let the reactive machinery seek next tick
+      return { type: 'none' };
+    }
+
+    const t = input.tLocal / 1000;
+    if (this.lastT !== null && this.lastDrift !== null) {
+      const dt = t - this.lastT;
+      if (dt > 0 && dt < 2) {
+        // observed drift rate this interval, corrected for the rate we
+        // commanded: dDrift/dt = (r_applied - 1) + b  =>  b measurement
+        const measuredB =
+          (drift - this.lastDrift) / dt - (this.appliedRate - 1);
+        // scalar RLS with forgetting
+        const g = this.rlsP / (this.servo.forgetting + this.rlsP);
+        this.bHat += g * (measuredB - this.bHat);
+        this.rlsP = (1 - g) * (this.rlsP / this.servo.forgetting);
+
+        // integral with anti-windup: freeze while the last command clamped
+        const clamped =
+          Math.abs(this.lastCommand - 1) >= this.servo.clampSpan - 1e-9;
+        if (!clamped) {
+          this.integral = Math.max(
+            -this.servo.integralClampS,
+            Math.min(this.servo.integralClampS, this.integral + drift * dt),
+          );
+        }
+      }
+    }
+    this.lastT = t;
+    this.lastDrift = drift;
+
+    let r =
+      1 - this.servo.kp * drift - this.servo.ki * this.integral - this.bHat;
+    r = Math.max(
+      1 - this.servo.clampSpan,
+      Math.min(1 + this.servo.clampSpan, r),
+    );
+    this.lastCommand = r;
+    this.servoActive = true;
+
+    if (Math.abs(r - this.appliedRate) < this.servo.commandHysteresis) {
+      return { type: 'none' };
+    }
+    this.appliedRate = r;
+    return { type: 'set-rate', rate: r };
+  }
+
+  /** The engine reports what the player actually applied (probe honesty). */
+  onRateApplied(applied: number): void {
+    this.appliedRate = applied;
+  }
+}

--- a/video-sync-frontend/src/sync/SyncEngine.ts
+++ b/video-sync-frontend/src/sync/SyncEngine.ts
@@ -6,6 +6,7 @@ import {
   Timeline,
 } from '../shared/sync-protocol';
 import { ClockEstimator } from '../shared/sync-core/clock-estimator';
+import { DisciplineController } from '../shared/sync-core/discipline-controller';
 import {
   DriftController,
   type ControllerAction,
@@ -41,7 +42,13 @@ const GESTURE_CHIP_THRESHOLD = 3;
 
 export class SyncEngine {
   private estimator = new ClockEstimator();
-  private controller = new DriftController();
+  // ?controller=P selects the predictive PI servo (A/B-measured: P50 drift
+  // 7ms vs 81ms reactive on the bot fleet); reactive remains the default
+  // until the real-browser A/B settles the question
+  private controller: DriftController | DisciplineController =
+    new URLSearchParams(window.location.search).get('controller') === 'P'
+      ? new DisciplineController()
+      : new DriftController();
   private telemetry = new TelemetryRing();
   private timeline: Timeline | null = null;
   private adapter: YouTubeAdapter | null = null;
@@ -215,6 +222,9 @@ export class SyncEngine {
         break;
       case 'set-rate': {
         const applied = adapter.setRate(action.rate);
+        if (this.controller instanceof DisciplineController) {
+          this.controller.onRateApplied(applied);
+        }
         if (Math.abs(applied - action.rate) > 0.001) {
           // the probe lied for this video; fall back to SEEK mode
           this.fractionalRateOK = false;


### PR DESCRIPTION
Control theory applied where the measurements said it would pay: a discrete PI servo with an RLS-learned feed-forward skew term replaces threshold-bouncing in the steady state.

## Design
`r = 1 − Kp·drift − Ki·∫drift − b̂`, where `b̂` is the player's intrinsic drift rate at r=1 (scalar RLS with forgetting, measured from rate-corrected drift deltas). Anti-windup freezes the integral while clamped; 0.5% command hysteresis stops player churn; the reactive machinery keeps lifecycle, gross errors and seeks — its threshold moves to the servo-zone boundary so the servo owns [deadband, 600ms] (the first test run caught it seeking inside the servo's regime).

## The empirical surprise
The per-video probe returned **true on real YouTube** in the browser matrix — the modern player *accepts* fractional `setPlaybackRate`, contradicting the API reference's rounding language. The design remains probe-gated per video, and `onRateApplied` keeps the loop honest.

## Measured A/B (10 bots × 150s, identical seeds, all-fractional plants)
| | reactive | predictive |
|---|---|---|
| drift P50 | 81ms | **7.4ms** |
| drift P95 | 142ms | 142ms |

The servo cancels steady-state drift to single digits; P95 parity shows transients (joins/seeks/stalls) dominate both tails equally. Five closed-loop unit tests: 500ppm skew cancelled with **zero seeks**, smooth 400ms closure with bounded overshoot, no limit cycling, gross-error handoff, pause stand-down.

Browser engine: `?controller=P` (debug flag); reactive stays default until a real-browser A/B settles it. 49 backend tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added predictive playback synchronization to improve clock-drift correction.
  - Supports smooth fractional playback-rate adjustments, automatic recovery from larger timing errors, and pause-aware synchronization.
  - Added an option to select predictive or reactive synchronization modes.
  - Predictive mode can be enabled with the `controller=P` URL parameter.

- **Bug Fixes**
  - Improved handling of initial drift, playback skew, rate changes, seeking, and synchronization recovery.

- **Tests**
  - Added comprehensive simulations covering drift correction, rate hysteresis, seeking, pauses, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->