### PR TITLE
chore: untrack the compiled relay-go binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ formal/tools/
 # way to lose a real source folder later.
 /states/
 /formal/states/
+
+# relay-go build output: a ~10MB platform-specific Mach-O/ELF binary. It was
+# tracked, making it the largest file in the repo and producing a 10MB diff
+# on every rebuild. Build it with `cd relay-go && go build` instead.
+/relay-go/relay-go


### PR DESCRIPTION
`relay-go/relay-go` was tracked: a 10MB Mach-O arm64 executable. It is the
largest file in the repo by 8× and the only tracked build output.

Two concrete problems: it is platform-specific, so it is dead weight for
anyone not on Apple Silicon, and because Git stores each version whole, every
rebuild rewrote all 10MB — a binary blob landing in the diff of otherwise
unrelated PRs. It showed up in the diff of the audit PR that preceded this
one, which is how I noticed it.

Untracked and gitignored. `docs/RELAY.md` already documents the build
(`cd relay-go && go build ./...`); I verified that regenerates the identical
10,207,106-byte binary from source, so nothing is lost.

History is not rewritten — the existing blobs remain in past commits, and no
force-push is involved. This only stops the repo accumulating new copies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added version-control exclusions for the generated `relay-go` build binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->