### PR TITLE
docs: the S2 exhibit is an override, not a late-caught failure

### DIFF
--- a/docs/SYNC_DESIGN.md
+++ b/docs/SYNC_DESIGN.md
@@ -174,12 +174,17 @@ an nginx-stream proxy container with `tc netem` inside for true packet loss
 (one root qdisc impairs both legs: `delay X` ⇒ +2X RTT, stated per scenario).
 YouTube CDN traffic never crosses a proxy. Steady-state windows exclude 15s
 warmup and 5s after control events; all-time numbers are also reported.
-Runs are health-gated. A failure caught after capture is kept as a labeled
-exhibit rather than discarded (S2 baseline); a failure caught by the gate
-*before* capture aborts the run and writes nothing, so those scenarios have
-no artifact and are reported as aborted rather than as a result. CI runs a 10-bot tripwire on every push (P95 < 250ms, bounded
-growth, seq integrity) — deliberately loose for shared runners; headline
-numbers come from local, hardware-documented runs.
+Runs are health-gated: every client must reach PLAYING before capture
+begins. A gate failure normally retries once and then aborts, writing
+nothing — which is why S3/S5/S6 have no baseline artifact. Setting
+`HARNESS_ALLOW_UNHEALTHY=1` instead captures the run anyway and stamps
+`INVALID per health gate …` into its `notes`, which is how the S2 baseline
+exhibit exists. So the difference between an exhibit and a missing run is
+not *when* the failure was caught — the gate always runs before capture —
+but whether that override was set. CI runs a 10-bot tripwire on every pull
+request and every push to `main` (P95 < 250ms, bounded growth, seq
+integrity) — deliberately loose for shared runners; headline numbers come
+from local, hardware-documented runs.
 
 ## 8. Results
 

--- a/docs/SYNC_DESIGN.md
+++ b/docs/SYNC_DESIGN.md
@@ -174,14 +174,16 @@ an nginx-stream proxy container with `tc netem` inside for true packet loss
 (one root qdisc impairs both legs: `delay X` ⇒ +2X RTT, stated per scenario).
 YouTube CDN traffic never crosses a proxy. Steady-state windows exclude 15s
 warmup and 5s after control events; all-time numbers are also reported.
-Runs are health-gated: every client must reach PLAYING before capture
-begins. A gate failure normally retries once and then aborts, writing
-nothing — which is why S3/S5/S6 have no baseline artifact. Setting
-`HARNESS_ALLOW_UNHEALTHY=1` instead captures the run anyway and stamps
-`INVALID per health gate …` into its `notes`, which is how the S2 baseline
-exhibit exists. So the difference between an exhibit and a missing run is
-not *when* the failure was caught — the gate always runs before capture —
-but whether that override was set. CI runs a 10-bot tripwire on every pull
+Runs are health-gated: every client must reach PLAYING or the run is not
+accepted. Sample collection starts first and the gate runs against it, so
+the boundary the gate controls is **whether an artifact is written**, not
+whether capture happens. A gate failure normally retries once and then
+aborts, writing nothing — which is why S3/S5/S6 have no baseline artifact.
+Setting `HARNESS_ALLOW_UNHEALTHY=1` instead writes the run anyway and
+stamps `INVALID per health gate …` into its `notes`, which is how the S2
+baseline exhibit exists. So the difference between an exhibit and a missing
+run is not *when* the failure was caught — the gate sits at the same place
+either way — but whether that override was set. CI runs a 10-bot tripwire on every pull
 request and every push to `main` (P95 < 250ms, bounded growth, seq
 integrity) — deliberately loose for shared runners; headline numbers come
 from local, hardware-documented runs.

--- a/docs/measurements/baseline/README.md
+++ b/docs/measurements/baseline/README.md
@@ -14,7 +14,7 @@ explicitly in the table below rather than quietly folded in.
 |----------|--------|----------|
 | S0 clean loopback | P50 pairwise drift **363ms**, P95 **255.3s**, no control event ever converged | `S0-baseline-mscjatn1/` |
 | S2 +150ms each way | **Total failure** — the host plays; followers never start | `S2-baseline-mscjtbgk/` (exhibit) |
-| S3 jitter / S5 loss / S6 asym | Aborted before measurement: the player-health gate FAILED both attempts, the same signature as S2 (followers never started) | **none** — the run aborts before writing a directory |
+| S3 jitter / S5 loss / S6 asym | Discarded: the player-health gate FAILED both attempts, the same signature as S2 (followers never started) | **none** — the run is abandoned without writing a directory |
 
 The S3/S5/S6 row is an observation, not a measurement. The harness retries a
 run whose players fail the health check and then aborts it, so nothing was

--- a/docs/measurements/baseline/README.md
+++ b/docs/measurements/baseline/README.md
@@ -16,9 +16,11 @@ explicitly in the table below rather than quietly folded in.
 | S2 +150ms each way | **Total failure** — the host plays; followers never start | `S2-baseline-mscjtbgk/` (exhibit) |
 | S3 jitter / S5 loss / S6 asym | Aborted before measurement: the player-health gate FAILED both attempts, the same signature as S2 (followers never started) | **none** — the run aborts before writing a directory |
 
-The S3/S5/S6 row is an observation, not a measurement. The harness aborts a
-run whose players fail the health check, so nothing was written and there is
-nothing to cite; `compare.ts`, which reads only committed directories,
+The S3/S5/S6 row is an observation, not a measurement. The harness retries a
+run whose players fail the health check and then aborts it, so nothing was
+written and there is nothing to cite (S2 exists only because it was re-run
+with `HARNESS_ALLOW_UNHEALTHY=1`, which captures a failing run as a labeled
+exhibit instead of discarding it); `compare.ts`, which reads only committed directories,
 correctly reports those scenarios as "not measured". They are listed here
 because what happened is informative, and omitted from any published number
 because an uncommitted observation is not evidence. The overhaul's numbers


### PR DESCRIPTION
CodeRabbit caught this on #20 after I had already merged, and it is right.

The methodology section claimed the S2 baseline survived as an exhibit because
its failure was "caught after capture", while S3/S5/S6 were "caught by the gate
*before* capture" and so wrote nothing. The harness makes no such distinction.

`sync-harness/src/run-scenario.ts:127` runs `waitForPlaying` before capture in
every case. What actually differs is `HARNESS_ALLOW_UNHEALTHY=1`: with it, the
runner captures the failing run anyway and stamps `INVALID per health gate …`
into `notes`; without it, it retries once and aborts. The S2 baseline's
`meta.json` carries precisely that note. An exhibit is a deliberate override,
not a different failure timing.

This matters because that paragraph exists to explain why one failed scenario
has an artifact and three do not. The wrong explanation makes the missing three
look like an accident of timing rather than a flag nobody set.

The sentence was introduced by the commit that was itself fixing inaccurate
provenance claims, which is a fair reminder that the honesty pass needs the same
verification as everything else.

Also corrects "on every push" to "on every pull request and every push to
`main`" — what `ci.yml` actually triggers on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified measurement requirements, including client readiness and health-check handling.
  * Documented retry and abort behavior when health checks fail.
  * Added guidance for explicitly allowing unhealthy captures and labeling invalid runs.
  * Clarified baseline status for S2, S3, S5, and S6 observations.
  * Updated CI coverage documentation to include pull requests and pushes to `main`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->