### PR TITLE
fix: sweep each room once per period, not once per instance

### DIFF
--- a/docs/COORDINATION.md
+++ b/docs/COORDINATION.md
@@ -64,6 +64,23 @@ appears in a single-instance, one-room, 25-client test. Plane A remains the
 default because it is simpler and, *by measurement*, not worse for this
 product's shape.
 
+**One point for plane B that the A/B missed entirely.** The A/B ran one
+instance per arm, so it could not see that plane A's repair sweep was
+redundant across instances: every instance holding a socket in a room swept
+that room, committing and fanning out N times per period for one repair (see
+[SCALING.md](SCALING.md#the-59-seq-gaps-root-caused) — 3.3 commits per period
+on 3 instances, against 1.2 after the fix). Plane B never had this bug,
+because its sweep is owner-only by construction — `only the owner sweeps its
+rooms; non-owners no-op` falls straight out of having an owner at all.
+
+That does not overturn the conclusion above: plane A was patched with a
+guard inside the script it already had, and the actor plane's per-control
+cost still stands. But it is a concrete instance of the thing the "cannot
+show" paragraph was gesturing at — explicit ownership rules out whole
+classes of duplicated work that a shared-store plane has to notice and
+patch one at a time. Recorded because the A/B's conclusion would otherwise
+read as more settled than one single-instance test can make it.
+
 ## Two bugs the implementation surfaced
 
 1. **Non-atomic init.** 25 concurrent joins each passed a "no state yet"

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -116,19 +116,70 @@ re-run after the first pass flagged them self-skewed; only the re-runs are
 published — the first-pass cell files were overwritten by the re-run and
 were not retained.
 
-**One cell reports seq gaps.** `three-25` records **59** `seqGaps`; every
-other cell records zero (`sweep-summary.json`, `botSummary.seqGaps`). Seq
-gaps are not one of the two SLOs above, so the cell is marked "ok" by the
-knee criterion and the table has no column for them — which would leave a
-non-zero integrity count invisible to anyone reading only the table. It is
-surfaced here instead. A gap is a bot observing a jump in `(storeEpoch,
-seq)`, which a dropped or reordered fanout message produces without any
-store-side defect; the store's own serialization is checked separately and
-directly (`verify-m6.ts`, and the CI gate fails on any gap). It is called
-out because a number that appears in a committed artifact and nowhere in
-the prose is exactly the kind of thing this document should not bury, and
-because it has not been root-caused — it warrants a re-run of that cell
-before the 3-instance topology is claimed clean on integrity.
+### The 59 seq gaps, root-caused
+
+An earlier sweep recorded **59 `seqGaps`** on the `three-25` cell and zero
+everywhere else. Chasing it found two separate defects — one in the metric,
+one in the server — and it is worth writing down because the metric bug was
+hiding the server bug.
+
+**The metric counted reordering as loss.** The bot recorded a gap the moment
+a timeline arrived with `seq > lastApplied + 1`, and nothing ever retracted
+it when the skipped seq turned up a moment later. `isNewer` correctly drops
+the late arrival, so the bot stayed converged the whole time — but the gap
+counter had already fired. On one instance every broadcast originates from
+one process in commit order, so this never triggered; the metric only broke
+where deliveries could interleave.
+
+Gaps are now decided at report time from the complete set of seqs a bot
+received on an epoch: a gap is a seq inside the observed range that **never
+arrived at all**. Reordered deliveries are counted separately as
+`seqReorders`. Re-running the failing cell against the same server build:
+
+| | seqGaps | seqReorders |
+|---|---|---|
+| 3 instances, 25 bots (old metric) | 59 | not measured |
+| 3 instances, 25 bots (fixed metric) | **0** | 97 |
+| 1 instance, 25 bots (control) | 0 | 0 |
+
+Nothing had ever been lost. But 97 reorders in 120s is not noise, and the
+control run isolates the cause to the multi-instance fanout.
+
+**Every instance was sweeping every room it had a socket in.** The repair
+sweep iterates `userRooms`, which is per-instance state, so with 25 bots
+spread across 3 instances all three swept the *same* room every 10s:
+`apply_snapshot.lua` bumped `seq` three times per period and fanned out three
+snapshots for one repair. The cost scaled linearly with instance count — 10
+instances would have meant 10× the snapshot writes and fanout for one room —
+and the three racing commits were exactly what the clients then received out
+of order.
+
+The dedup belongs in the Lua script rather than in a lease, because Redis's
+single-threaded execution already serializes these calls. `apply_snapshot`
+now records `lastSweepAt` and no-ops if the room was swept less than
+`SWEEP_MIN_INTERVAL_MS` (period − 1s) ago, returning null so the losing
+instances skip their broadcast entirely. The first caller of each period
+wins; if it dies, another simply wins the next period, with no ownership to
+hand over. Measured on the same 3-instance lab, 25 bots, 120s:
+
+| | commits in 120s | per 10s period | seqReorders |
+|---|---|---|---|
+| 3 instances, before | 40 | 3.3 | 97 |
+| 3 instances, after | **14** | **1.2** | **0** |
+| 1 instance (reference) | 14 | 1.2 | 0 |
+
+The three-instance plane now commits at exactly the single-instance rate:
+coordination cost no longer scales with instance count. The repair channel is
+verifiably still alive — 14 commits over 120s is the ~12 sweeps plus the
+scripted control events, not a wedged sweep — and
+`redis-room-state.store.spec.ts` pins the contract against a real Redis
+(three simultaneous callers, one commit; the next period still gets through;
+a paused room never advances).
+
+Worth noting against the A/B in [COORDINATION.md](COORDINATION.md): plane B
+never had this bug. Its sweep is owner-only by construction (`only the owner
+sweeps its rooms; non-owners no-op`), so explicit ownership had already ruled
+out a class of redundancy the shared-store plane had to be patched to avoid.
 
 Charts: [drift](measurements/sweep/charts/sweep-drift.svg) ·
 [event-loop lag](measurements/sweep/charts/sweep-lag.svg) ·

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -133,17 +133,27 @@ where deliveries could interleave.
 
 Gaps are now decided at report time from the complete set of seqs a bot
 received on an epoch: a gap is a seq inside the observed range that **never
-arrived at all**. Reordered deliveries are counted separately as
-`seqReorders`. Re-running the failing cell against the same server build:
+arrived at all**. Three outcomes, three counters, because `isNewer` is false
+for all of them and lumping them together is what caused this:
 
-| | seqGaps | seqReorders |
+| a seq that never arrived | `seqGaps` | the only one that is a defect |
+|---|---|---|
+| a **lower** seq arriving after a higher one | `seqReorders` | out-of-order delivery; dropped by design |
+| the **same** seq delivered twice | `seqDuplicates` | idempotent; the repair sweep doing its job |
+
+Re-running the failing cell against the same server build:
+
+| | seqGaps | reorders + duplicates |
 |---|---|---|
 | 3 instances, 25 bots (old metric) | 59 | not measured |
 | 3 instances, 25 bots (fixed metric) | **0** | 97 |
 | 1 instance, 25 bots (control) | 0 | 0 |
 
-Nothing had ever been lost. But 97 reorders in 120s is not noise, and the
-control run isolates the cause to the multi-instance fanout.
+Nothing had ever been lost. (That 97 was counted before reorders and
+duplicates were split apart, so it is the sum of the two, not 97 genuine
+reorders — the split landed while chasing this and is why the table above
+has three rows.) But 97 is not noise, and the control run isolates the cause
+to the multi-instance fanout.
 
 **Every instance was sweeping every room it had a socket in.** The repair
 sweep iterates `userRooms`, which is per-instance state, so with 25 bots
@@ -156,25 +166,47 @@ of order.
 
 The dedup belongs in the Lua script rather than in a lease, because Redis's
 single-threaded execution already serializes these calls. `apply_snapshot`
-now records `lastSweepAt` and no-ops if the room was swept less than
-`SWEEP_MIN_INTERVAL_MS` (period − 1s) ago, returning null so the losing
-instances skip their broadcast entirely. The first caller of each period
-wins; if it dies, another simply wins the next period, with no ownership to
-hand over. Measured on the same 3-instance lab, 25 bots, 120s:
+buckets time into aligned windows of `SWEEP_DEDUP_PERIOD_MS`, records the
+window it last committed in, and no-ops if it is called again in that same
+window — returning null so the losing instances skip their broadcast
+entirely. The first caller of each window wins; if it dies, another wins the
+next window, with no ownership to hand over.
 
-| | commits in 120s | per 10s period | seqReorders |
+The window matters more than it looks. The first version of this guard tested
+*elapsed time* against a threshold just under the period, which two
+instances staggered by nearly a full period slip straight through: sweeps at
+t=0 and t=9.5s both pass a 9s test, so a duplicate bump survives inside one
+period. Raising the threshold to exactly the period instead risks suppressing
+a lone instance whose timer fires a millisecond early. Aligned windows have
+neither failure mode — at most one commit per window by construction, and a
+10s timer always lands in a fresh one. `redis-room-state.store.spec.ts` pins
+all of it against a real Redis: simultaneous callers, the staggered caller,
+the next window still getting through, and a paused room never advancing.
+
+Measured on the 3-instance lab, 25 bots, 120s, against the interim
+elapsed-time guard (the window guard is strictly tighter):
+
+| | commits in 120s | per 10s period | reorders + duplicates |
 |---|---|---|---|
 | 3 instances, before | 40 | 3.3 | 97 |
 | 3 instances, after | **14** | **1.2** | **0** |
 | 1 instance (reference) | 14 | 1.2 | 0 |
 
-The three-instance plane now commits at exactly the single-instance rate:
+The three-instance plane commits at exactly the single-instance rate:
 coordination cost no longer scales with instance count. The repair channel is
 verifiably still alive — 14 commits over 120s is the ~12 sweeps plus the
-scripted control events, not a wedged sweep — and
-`redis-room-state.store.spec.ts` pins the contract against a real Redis
-(three simultaneous callers, one commit; the next period still gets through;
-a paused room never advances).
+scripted control events, not a wedged sweep, which was the main risk of the
+change and so was measured rather than assumed.
+
+**Outstanding:** the committed sweep in this section predates the fix. Its
+drift and lag figures stand as measurements of that build, and the knee is
+unaffected (a single instance has one sweeper either way), but the
+`three-25` `seqGaps: 59` in `sweep-summary.json` is the artifact explained
+above, not a defect. Refreshing the matrix needs an otherwise-idle machine —
+the attempt made here ran at a 15-minute load average of 8.19 on 10 cores,
+which the harness's own validity gate (>0.7 load/core) rejects, and
+publishing it would be exactly the sort of number this document promises not
+to print.
 
 Worth noting against the A/B in [COORDINATION.md](COORDINATION.md): plane B
 never had this bug. Its sweep is owner-only by construction (`only the owner

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -175,9 +175,20 @@ The dedup belongs in the Lua script rather than in a lease, because Redis's
 single-threaded execution already serializes these calls. `apply_snapshot`
 buckets time into aligned windows of `SWEEP_DEDUP_PERIOD_MS`, records the
 window it last committed in, and no-ops if it is called again in that same
-window — returning null so the losing instances skip their broadcast
-entirely. The first caller of each window wins; if it dies, another wins the
+window. The first caller of each window wins; if it dies, another wins the
 next window, with no ownership to hand over.
+
+**The dedup covers the commit, not the broadcast** — and that distinction is
+the whole design. The first version suppressed the losing instances'
+broadcast too, which quietly broke the failure model above: `server.to(room)`
+delivers to an instance's own sockets *in-process*, so before the change
+every instance repaired its local clients without touching pub/sub. Letting
+only the winner broadcast would have made every other instance's clients
+depend on the adapter — the exact channel whose failure the sweep exists to
+repair. A losing instance now re-anchors its own sockets with
+`server.local.to(room)`, which delivers in-process and publishes nothing, so
+the repair path survives a pub/sub blip while the redundant writes and racing
+seq bumps are still gone.
 
 The window matters more than it looks. The first version of this guard tested
 *elapsed time* against a threshold just under the period, which two
@@ -190,20 +201,23 @@ neither failure mode — at most one commit per window by construction, and a
 all of it against a real Redis: simultaneous callers, the staggered caller,
 the next window still getting through, and a paused room never advancing.
 
-Measured on the 3-instance lab, 25 bots, 120s, against the interim
-elapsed-time guard (the window guard is strictly tighter):
+Measured on the 3-instance lab, 25 bots, 120s:
 
-| | commits in 120s | per 10s period | reorders + duplicates |
-|---|---|---|---|
-| 3 instances, before | 40 | 3.3 | 97 |
-| 3 instances, after | **14** | **1.2** | **0** |
-| 1 instance (reference) | 14 | 1.2 | 0 |
+| | commits in 120s | per 10s period | reorders | duplicates |
+|---|---|---|---|---|
+| 3 instances, before | 40 | 3.3 | 97 (conflated) | — |
+| 3 instances, after | **14** | **1.2** | **0** | 170 |
+| 1 instance (reference) | 14 | 1.2 | 0 | 0 |
 
 The three-instance plane commits at exactly the single-instance rate:
-coordination cost no longer scales with instance count. The repair channel is
-verifiably still alive — 14 commits over 120s is the ~12 sweeps plus the
-scripted control events, not a wedged sweep, which was the main risk of the
-change and so was measured rather than assumed.
+coordination cost no longer scales with instance count. The 170 duplicates
+are the design working — each instance re-anchoring its own clients with the
+seq the winner committed, which `isNewer` discards and which is why
+duplicates are counted apart from reorders rather than lumped in as noise.
+
+The repair channel is verifiably still alive — 14 commits over 120s is the
+~12 sweeps plus the scripted control events, not a wedged sweep. That was the
+main risk of the change, so it was measured rather than assumed.
 
 **Outstanding:** the committed sweep in this section predates the fix. Its
 drift and lag figures stand as measurements of that build, and the knee is

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -132,16 +132,22 @@ one process in commit order, so this never triggered; the metric only broke
 where deliveries could interleave.
 
 Gaps are now decided at report time from the complete set of seqs a bot
-received on an epoch: a gap is a seq inside the observed range that **never
-arrived at all**. Three outcomes, three counters, because `isNewer` is false
-for all of them and lumping them together is what caused this:
+received on an epoch: a gap is a seq **inside the observed range** that the
+bot never received. Three outcomes, three counters, because `isNewer` is
+false for all of them and lumping them together is what caused this:
 
-| a seq that never arrived | `seqGaps` | the only one that is a defect |
+| delivery | counter | what it means |
 |---|---|---|
+| a seq inside the range, never received | `seqGaps` | the only one that is a defect |
 | a **lower** seq arriving after a higher one | `seqReorders` | out-of-order delivery; dropped by design |
-| the **same** seq delivered twice | `seqDuplicates` | idempotent; the repair sweep doing its job |
+| the **same** seq received twice | `seqDuplicates` | repeated delivery; idempotent to apply |
 
-Re-running the failing cell against the same server build:
+What this can and cannot see: the range is bounded by the lowest and highest
+seq a bot actually received, so a loss *before* its first or *after* its last
+is outside the rule and undetectable. `seqDuplicates` likewise records that a
+seq arrived twice, not why — redundant repair is the expected source, but the
+cause is not measured here. Re-running the failing cell against the same
+server build:
 
 | | seqGaps | reorders + duplicates |
 |---|---|---|
@@ -149,11 +155,12 @@ Re-running the failing cell against the same server build:
 | 3 instances, 25 bots (fixed metric) | **0** | 97 |
 | 1 instance, 25 bots (control) | 0 | 0 |
 
-Nothing had ever been lost. (That 97 was counted before reorders and
+So no seq inside any bot's observed range went unreceived — which is what the
+59 had claimed, and it was wrong. (That 97 was counted before reorders and
 duplicates were split apart, so it is the sum of the two, not 97 genuine
-reorders — the split landed while chasing this and is why the table above
-has three rows.) But 97 is not noise, and the control run isolates the cause
-to the multi-instance fanout.
+reorders — the split landed while chasing this and is why the table above has
+three rows.) But 97 is not noise, and the control run isolates the cause to
+the multi-instance fanout.
 
 **Every instance was sweeping every room it had a socket in.** The repair
 sweep iterates `userRooms`, which is per-instance state, so with 25 bots

--- a/relay-go/main.go
+++ b/relay-go/main.go
@@ -344,7 +344,7 @@ func main() {
 
 	// 10s snapshot sweep (the repair channel), same semantics as the Node plane
 	go func() {
-		const sweepMinIntervalMS = 9000
+		const sweepDedupPeriodMS = 10000
 		common, errC := os.ReadFile(filepath.Join(*luaDir, "common.lua"))
 		snap, errS := os.ReadFile(filepath.Join(*luaDir, "apply_snapshot.lua"))
 		if errC != nil || errS != nil {
@@ -362,10 +362,10 @@ func main() {
 			s.mu.RUnlock()
 			for _, room := range rooms {
 				// same dedup contract as the Node plane: the script commits at
-				// most one sweep per room per period no matter how many
-				// instances call it, and returns nil to the losers
+				// most one sweep per room per aligned window no matter how
+				// many instances call it, and returns nil to the losers
 				raw, ok := luaString(snapshotScript.Run(context.Background(), s.rdb,
-					[]string{"room:" + room + ":tl"}, sweepMinIntervalMS).Result())
+					[]string{"room:" + room + ":tl"}, sweepDedupPeriodMS).Result())
 				if !ok {
 					continue
 				}

--- a/relay-go/main.go
+++ b/relay-go/main.go
@@ -344,6 +344,7 @@ func main() {
 
 	// 10s snapshot sweep (the repair channel), same semantics as the Node plane
 	go func() {
+		const sweepMinIntervalMS = 9000
 		common, errC := os.ReadFile(filepath.Join(*luaDir, "common.lua"))
 		snap, errS := os.ReadFile(filepath.Join(*luaDir, "apply_snapshot.lua"))
 		if errC != nil || errS != nil {
@@ -360,8 +361,11 @@ func main() {
 			}
 			s.mu.RUnlock()
 			for _, room := range rooms {
+				// same dedup contract as the Node plane: the script commits at
+				// most one sweep per room per period no matter how many
+				// instances call it, and returns nil to the losers
 				raw, ok := luaString(snapshotScript.Run(context.Background(), s.rdb,
-					[]string{"room:" + room + ":tl"}).Result())
+					[]string{"room:" + room + ":tl"}, sweepMinIntervalMS).Result())
 				if !ok {
 					continue
 				}

--- a/sync-harness/src/bots/bot-client.ts
+++ b/sync-harness/src/bots/bot-client.ts
@@ -63,6 +63,11 @@ export interface BotReport {
    *  timeline twice is idempotent. Counted apart from reorders so the two
    *  are never conflated. */
   seqDuplicates: number;
+  /** transport reconnects, each followed by a re-join attempt */
+  reconnects: number;
+  /** re-joins that failed: this bot is deaf from here on and its remaining
+   *  seqs are outside the gap metric's detectable range */
+  rejoinFailures: number;
   handlerErrors: string[];
   rejected: number;
 }
@@ -82,6 +87,9 @@ export class BotClient {
   private seqsByEpoch = new Map<string, Set<number>>();
   private seqReorders = 0;
   private seqDuplicates = 0;
+  private reconnects = 0;
+  private rejoinFailures = 0;
+  private roomCode: string | null = null;
   private handlerErrors: string[] = [];
   private rejected = 0;
   private timers: Array<ReturnType<typeof setInterval>> = [];
@@ -124,10 +132,27 @@ export class BotClient {
     this.transport.onError((err) => {
       this.handlerErrors.push(err);
     });
+    this.transport.onReconnect(() => {
+      // a reconnected socket is not in its room; without this the bot goes
+      // deaf for the rest of the run and still reports zero gaps, because
+      // everything it misses lands after the last seq it ever saw
+      this.reconnects += 1;
+      const room = this.roomCode;
+      if (!room) return;
+      void this.transport
+        .join(room, this.user.id)
+        .then((tl) => {
+          if (tl) this.ingest(tl);
+        })
+        .catch(() => {
+          this.rejoinFailures += 1;
+        });
+    });
     await this.transport.connect(this.user.token ?? '');
   }
 
   async join(roomCode: string): Promise<void> {
+    this.roomCode = roomCode;
     const tl = await this.transport.join(roomCode, this.user.id);
     // the join response is classified exactly like a pushed timeline: it can
     // be stale (a broadcast overtook it) or a duplicate of one already
@@ -274,6 +299,8 @@ export class BotClient {
       seqGaps: gaps,
       seqReorders: this.seqReorders,
       seqDuplicates: this.seqDuplicates,
+      reconnects: this.reconnects,
+      rejoinFailures: this.rejoinFailures,
       handlerErrors: this.handlerErrors,
       rejected: this.rejected,
     };

--- a/sync-harness/src/bots/bot-client.ts
+++ b/sync-harness/src/bots/bot-client.ts
@@ -54,10 +54,15 @@ export interface BotReport {
   samples: BotSample[];
   /** seqs this bot NEVER received on an epoch it was following (true loss) */
   seqGaps: number[];
-  /** timelines that arrived after a higher seq on the same epoch: reordered,
-   *  not lost. Harmless by design - `isNewer` drops them - but counted so a
-   *  reorder can never be mistaken for a gap. */
+  /** strictly LOWER seq arriving after a higher one on the same epoch: a
+   *  genuine out-of-order delivery. Harmless by design - `isNewer` drops it -
+   *  but counted so a reorder can never be mistaken for a gap. */
   seqReorders: number;
+  /** the SAME seq delivered more than once. Not a reorder and not a loss:
+   *  redundant repair is the sweep working as designed, and applying a
+   *  timeline twice is idempotent. Counted apart from reorders so the two
+   *  are never conflated. */
+  seqDuplicates: number;
   handlerErrors: string[];
   rejected: number;
 }
@@ -76,6 +81,7 @@ export class BotClient {
    *  low seq retracts the gap its successor would otherwise imply */
   private seqsByEpoch = new Map<string, Set<number>>();
   private seqReorders = 0;
+  private seqDuplicates = 0;
   private handlerErrors: string[] = [];
   private rejected = 0;
   private timers: Array<ReturnType<typeof setInterval>> = [];
@@ -116,10 +122,11 @@ export class BotClient {
       if (isNewer(tl, this.timeline)) {
         this.timeline = tl;
       } else if (this.timeline && tl.storeEpoch === this.timeline.storeEpoch) {
-        // same epoch, not newer: it arrived out of order behind a higher
-        // seq. The protocol is built to tolerate this; count it separately
-        // so it is never reported as a lost message.
-        this.seqReorders += 1;
+        // `isNewer` is false for an EQUAL seq as well as a lower one, so these
+        // two cases have to be split or a duplicate reads as a reorder - the
+        // same conflation that made reordering read as loss.
+        if (tl.seq === this.timeline.seq) this.seqDuplicates += 1;
+        else this.seqReorders += 1;
       }
     });
     this.transport.onRejected(() => {
@@ -262,6 +269,7 @@ export class BotClient {
       samples: this.samples,
       seqGaps: gaps,
       seqReorders: this.seqReorders,
+      seqDuplicates: this.seqDuplicates,
       handlerErrors: this.handlerErrors,
       rejected: this.rejected,
     };

--- a/sync-harness/src/bots/bot-client.ts
+++ b/sync-harness/src/bots/bot-client.ts
@@ -117,18 +117,7 @@ export class BotClient {
       this.cfg.plane === 'relay'
         ? new RawWSBinaryTransport(this.cfg.wsUrl)
         : new SocketIOTransport(this.cfg.wsUrl);
-    this.transport.onTimeline((tl: Timeline) => {
-      this.recordSeq(tl);
-      if (isNewer(tl, this.timeline)) {
-        this.timeline = tl;
-      } else if (this.timeline && tl.storeEpoch === this.timeline.storeEpoch) {
-        // `isNewer` is false for an EQUAL seq as well as a lower one, so these
-        // two cases have to be split or a duplicate reads as a reorder - the
-        // same conflation that made reordering read as loss.
-        if (tl.seq === this.timeline.seq) this.seqDuplicates += 1;
-        else this.seqReorders += 1;
-      }
-    });
+    this.transport.onTimeline((tl: Timeline) => this.ingest(tl));
     this.transport.onRejected(() => {
       this.rejected += 1;
     });
@@ -140,19 +129,34 @@ export class BotClient {
 
   async join(roomCode: string): Promise<void> {
     const tl = await this.transport.join(roomCode, this.user.id);
-    if (tl) this.recordSeq(tl);
-    if (tl && isNewer(tl, this.timeline)) {
-      this.timeline = tl;
-    }
+    // the join response is classified exactly like a pushed timeline: it can
+    // be stale (a broadcast overtook it) or a duplicate of one already
+    // applied, and counting those differently here would skew the totals
+    if (tl) this.ingest(tl);
   }
 
-  private recordSeq(tl: Timeline): void {
+  /**
+   * The single place a timeline enters this bot, whether pushed or returned
+   * from join. Records the seq for gap accounting, applies it if it is newer,
+   * and otherwise classifies why it was not: an EQUAL seq is a duplicate
+   * (idempotent, and what the repair sweep is for), a LOWER seq is a genuine
+   * out-of-order delivery. `isNewer` is false for both, so they have to be
+   * split explicitly or a duplicate reads as a reorder.
+   */
+  private ingest(tl: Timeline): void {
     let seen = this.seqsByEpoch.get(tl.storeEpoch);
     if (!seen) {
       seen = new Set();
       this.seqsByEpoch.set(tl.storeEpoch, seen);
     }
     seen.add(tl.seq);
+
+    if (isNewer(tl, this.timeline)) {
+      this.timeline = tl;
+    } else if (this.timeline && tl.storeEpoch === this.timeline.storeEpoch) {
+      if (tl.seq === this.timeline.seq) this.seqDuplicates += 1;
+      else this.seqReorders += 1;
+    }
   }
 
   start(): void {

--- a/sync-harness/src/bots/bot-client.ts
+++ b/sync-harness/src/bots/bot-client.ts
@@ -52,7 +52,12 @@ export interface BotSample {
 export interface BotReport {
   bot: number;
   samples: BotSample[];
+  /** seqs this bot NEVER received on an epoch it was following (true loss) */
   seqGaps: number[];
+  /** timelines that arrived after a higher seq on the same epoch: reordered,
+   *  not lost. Harmless by design - `isNewer` drops them - but counted so a
+   *  reorder can never be mistaken for a gap. */
+  seqReorders: number;
   handlerErrors: string[];
   rejected: number;
 }
@@ -66,7 +71,11 @@ export class BotClient {
   private rng: () => number;
   private epoch = Date.now();
   private samples: BotSample[] = [];
-  private seenSeqs: number[] = [];
+  /** every seq received per epoch, whether or not `isNewer` applied it -
+   *  a gap is decided at report time from the complete set, so a late
+   *  low seq retracts the gap its successor would otherwise imply */
+  private seqsByEpoch = new Map<string, Set<number>>();
+  private seqReorders = 0;
   private handlerErrors: string[] = [];
   private rejected = 0;
   private timers: Array<ReturnType<typeof setInterval>> = [];
@@ -103,19 +112,14 @@ export class BotClient {
         ? new RawWSBinaryTransport(this.cfg.wsUrl)
         : new SocketIOTransport(this.cfg.wsUrl);
     this.transport.onTimeline((tl: Timeline) => {
+      this.recordSeq(tl);
       if (isNewer(tl, this.timeline)) {
-        if (
-          this.timeline &&
-          tl.storeEpoch === this.timeline.storeEpoch &&
-          tl.seq > this.timeline.seq + 1
-        ) {
-          for (let missing = this.timeline.seq + 1; missing < tl.seq; missing++) {
-            // gaps are repaired by the sweep, but we count them honestly
-            this.seenSeqs.push(-missing);
-          }
-        }
         this.timeline = tl;
-        this.seenSeqs.push(tl.seq);
+      } else if (this.timeline && tl.storeEpoch === this.timeline.storeEpoch) {
+        // same epoch, not newer: it arrived out of order behind a higher
+        // seq. The protocol is built to tolerate this; count it separately
+        // so it is never reported as a lost message.
+        this.seqReorders += 1;
       }
     });
     this.transport.onRejected(() => {
@@ -129,10 +133,19 @@ export class BotClient {
 
   async join(roomCode: string): Promise<void> {
     const tl = await this.transport.join(roomCode, this.user.id);
+    if (tl) this.recordSeq(tl);
     if (tl && isNewer(tl, this.timeline)) {
       this.timeline = tl;
-      this.seenSeqs.push(tl.seq);
     }
+  }
+
+  private recordSeq(tl: Timeline): void {
+    let seen = this.seqsByEpoch.get(tl.storeEpoch);
+    if (!seen) {
+      seen = new Set();
+      this.seqsByEpoch.set(tl.storeEpoch, seen);
+    }
+    seen.add(tl.seq);
   }
 
   start(): void {
@@ -233,11 +246,22 @@ export class BotClient {
   }
 
   report(): BotReport {
-    const gaps = this.seenSeqs.filter((x) => x < 0).map((x) => -x);
+    // A gap is a seq inside the range this bot actually observed on an epoch
+    // that never arrived at all. Deciding this from the complete set - rather
+    // than incrementally, at the moment a higher seq lands - is what stops a
+    // reordered delivery from being recorded as a permanent loss.
+    const gaps: number[] = [];
+    for (const seen of this.seqsByEpoch.values()) {
+      if (seen.size === 0) continue;
+      const lo = Math.min(...seen);
+      const hi = Math.max(...seen);
+      for (let s = lo + 1; s < hi; s++) if (!seen.has(s)) gaps.push(s);
+    }
     return {
       bot: this.cfg.index,
       samples: this.samples,
       seqGaps: gaps,
+      seqReorders: this.seqReorders,
       handlerErrors: this.handlerErrors,
       rejected: this.rejected,
     };

--- a/sync-harness/src/bots/run-bots.ts
+++ b/sync-harness/src/bots/run-bots.ts
@@ -171,6 +171,7 @@ async function main(): Promise<void> {
   }
 
   const seqGaps = reports.flatMap((r) => r.seqGaps);
+  const seqReorders = reports.reduce((sum, r) => sum + r.seqReorders, 0);
   const handlerErrors = reports.flatMap((r) => r.handlerErrors);
   const thetaP95 = percentile(
     [...thetaErrors].sort((a, b) => a - b),
@@ -188,6 +189,10 @@ async function main(): Promise<void> {
     slopeMsPerMin,
     thetaErrorP95Ms: thetaP95,
     seqGaps: seqGaps.length,
+    // reordered deliveries are expected on a multi-instance fanout and are
+    // dropped by the client's (storeEpoch, seq) ordering; reported so they
+    // are visible without being mistaken for loss
+    seqReorders,
     handlerErrors: handlerErrors.length,
     rejectedControls: reports.reduce((s, r) => s + r.rejected, 0),
   };

--- a/sync-harness/src/bots/run-bots.ts
+++ b/sync-harness/src/bots/run-bots.ts
@@ -172,6 +172,7 @@ async function main(): Promise<void> {
 
   const seqGaps = reports.flatMap((r) => r.seqGaps);
   const seqReorders = reports.reduce((sum, r) => sum + r.seqReorders, 0);
+  const seqDuplicates = reports.reduce((sum, r) => sum + r.seqDuplicates, 0);
   const handlerErrors = reports.flatMap((r) => r.handlerErrors);
   const thetaP95 = percentile(
     [...thetaErrors].sort((a, b) => a - b),
@@ -193,6 +194,9 @@ async function main(): Promise<void> {
     // dropped by the client's (storeEpoch, seq) ordering; reported so they
     // are visible without being mistaken for loss
     seqReorders,
+    // duplicates are the repair sweep doing its job (or a join racing a
+    // broadcast); idempotent, and deliberately not lumped in with reorders
+    seqDuplicates,
     handlerErrors: handlerErrors.length,
     rejectedControls: reports.reduce((s, r) => s + r.rejected, 0),
   };

--- a/sync-harness/src/bots/run-bots.ts
+++ b/sync-harness/src/bots/run-bots.ts
@@ -173,6 +173,8 @@ async function main(): Promise<void> {
   const seqGaps = reports.flatMap((r) => r.seqGaps);
   const seqReorders = reports.reduce((sum, r) => sum + r.seqReorders, 0);
   const seqDuplicates = reports.reduce((sum, r) => sum + r.seqDuplicates, 0);
+  const reconnects = reports.reduce((sum, r) => sum + r.reconnects, 0);
+  const rejoinFailures = reports.reduce((sum, r) => sum + r.rejoinFailures, 0);
   const handlerErrors = reports.flatMap((r) => r.handlerErrors);
   const thetaP95 = percentile(
     [...thetaErrors].sort((a, b) => a - b),
@@ -197,6 +199,11 @@ async function main(): Promise<void> {
     // duplicates are the repair sweep doing its job (or a join racing a
     // broadcast); idempotent, and deliberately not lumped in with reorders
     seqDuplicates,
+    reconnects,
+    // a bot that could not re-join is deaf, and its missed seqs fall outside
+    // the gap metric's range - so a non-zero count here means the seqGaps
+    // number above is an UNDER-count, not a clean bill of health
+    rejoinFailures,
     handlerErrors: handlerErrors.length,
     rejectedControls: reports.reduce((s, r) => s + r.rejected, 0),
   };
@@ -216,6 +223,9 @@ async function main(): Promise<void> {
       failures.push(`drift slope ${slopeMsPerMin.toFixed(1)}ms/min >= 15`);
     if (seqGaps.length > 0) failures.push(`${seqGaps.length} seq gaps`);
     if (handlerErrors.length > 0) failures.push(`${handlerErrors.length} handler errors`);
+    // failing re-joins silently shrink what the gap check can see, so the
+    // gate has to treat them as a failure rather than trust a clean seqGaps
+    if (rejoinFailures > 0) failures.push(`${rejoinFailures} failed re-joins (gap metric is blind past these)`);
     if (failures.length > 0) {
       console.error('[gate] FAILED:\n  ' + failures.join('\n  '));
       process.exit(1);

--- a/sync-harness/src/bots/transport.ts
+++ b/sync-harness/src/bots/transport.ts
@@ -15,6 +15,14 @@ export interface SyncTransport {
   onTimeline(cb: (tl: Timeline) => void): void;
   onRejected(cb: () => void): void;
   onError(cb: (err: string) => void): void;
+  /**
+   * Fired after the transport re-establishes a connection. Both planes
+   * reconnect automatically, but a reconnected socket is NOT in its room:
+   * without a re-join the bot silently receives nothing for the rest of the
+   * run, and because every seq it misses then falls after the last one it
+   * ever saw, the gap metric reports a clean run for a bot that was deaf.
+   */
+  onReconnect(cb: () => void): void;
   connected(): boolean;
   disconnect(): void;
 }
@@ -26,6 +34,8 @@ export class SocketIOTransport implements SyncTransport {
   // raw-WS transport tolerated the order, this one did not, and that
   // inconsistency is precisely what a transport abstraction must not have.
   private pending: Array<(s: Socket) => void> = [];
+  private reconnectCb: (() => void) | null = null;
+  private sawFirstConnect = false;
   constructor(private url: string) {}
 
   private withSocket(fn: (s: Socket) => void): void {
@@ -47,6 +57,10 @@ export class SocketIOTransport implements SyncTransport {
       const t = setTimeout(() => reject(new Error('connect timeout')), 10_000);
       socket.on('connect', () => {
         clearTimeout(t);
+        // socket.io reuses this event for reconnects; only the first is the
+        // initial connect this promise is waiting on
+        if (this.sawFirstConnect) this.reconnectCb?.();
+        this.sawFirstConnect = true;
         resolve();
       });
       socket.on('connect_error', (e) => {
@@ -89,6 +103,10 @@ export class SocketIOTransport implements SyncTransport {
     this.withSocket((s) => s.on('error', (e: unknown) => cb(JSON.stringify(e))));
   }
 
+  onReconnect(cb: () => void): void {
+    this.reconnectCb = cb;
+  }
+
   connected(): boolean {
     return this.socket?.connected ?? false;
   }
@@ -128,6 +146,7 @@ export class RawWSBinaryTransport implements SyncTransport {
   private isConnected = false;
   private token = '';
   private reconnecting = false;
+  private reconnectCb: (() => void) | null = null;
   private disposed = false;
 
   constructor(private url: string) {}
@@ -146,7 +165,9 @@ export class RawWSBinaryTransport implements SyncTransport {
     setTimeout(() => {
       this.reconnecting = false;
       if (this.disposed) return; // checked again: disposal may have raced
-      void this.open().catch(() => this.reconnect());
+      void this.open()
+        .then(() => this.reconnectCb?.())
+        .catch(() => this.reconnect());
     }, 1000);
   }
 
@@ -250,6 +271,10 @@ export class RawWSBinaryTransport implements SyncTransport {
 
   onError(cb: (err: string) => void): void {
     this.errorCb = cb; // connect() attaches the ws listener that calls it
+  }
+
+  onReconnect(cb: () => void): void {
+    this.reconnectCb = cb;
   }
 
   connected(): boolean {

--- a/sync-harness/src/sweep.ts
+++ b/sync-harness/src/sweep.ts
@@ -7,11 +7,13 @@
 //   npx tsx src/sweep.ts --sizes 10,50   # subset
 //
 // SLOs (a cell FAILS the knee when breached): bot P95 vs-timeline drift
-// <= 250ms and event-loop lag p99 <= 100ms. The drift bound is calibrated
-// ABOVE the fleet's load-independent floor (~165ms P95, set by the
-// deliberately pessimistic SimPlayer latency/settle model and constant
-// from n=10 to n=250) so it detects load-induced rise, not the simulation
-// floor. Load-gen validity:
+// <= 250ms and event-loop lag p99 <= 100ms. The drift bound sits ABOVE the
+// fleet's simulated-player floor - set by the deliberately pessimistic
+// SimPlayer latency/settle model, and measured at P95 116-156ms across this
+// matrix - so it detects load-induced rise rather than the simulation floor.
+// (An earlier comment here quoted a flat ~165ms floor; that belonged to a
+// superseded pre-fix sweep and was not what the current matrix measures.)
+// Load-gen validity:
 // host load average per core is recorded per cell; cells above 0.7 are
 // flagged self-skewed.
 import { execFile, execFileSync } from 'node:child_process';

--- a/video-sync-backend/src/sync/lua/apply_snapshot.lua
+++ b/video-sync-backend/src/sync/lua/apply_snapshot.lua
@@ -5,25 +5,33 @@
 -- them out of order often enough to look like lost messages.
 --
 -- Redis's single-threaded execution already serializes these calls, so the
--- dedup belongs here rather than in a lease: the first caller of a period wins
+-- dedup belongs here rather than in a lease: the first caller of a window wins
 -- and the rest no-op. No new keys, no ownership, and if the winner dies another
--- instance simply wins the next period.
+-- instance simply wins the next window.
 --
--- ARGV[1] = minimum ms between sweeps (defaults for callers that pass none).
-local minInterval = tonumber(ARGV[1]) or 9000
+-- The window is floor(now / period), NOT "elapsed since last sweep". An elapsed
+-- test has to pick a threshold, and any threshold below the period lets two
+-- staggered instances through inside one period (sweeps at t=0 and t=9.5s both
+-- pass a 9s test), while a threshold at exactly the period risks suppressing a
+-- lone instance whose timer drifts a millisecond early. Aligned windows have
+-- neither problem: at most one commit per window by construction, and a 10s
+-- timer always lands in a fresh one.
+--
+-- ARGV[1] = sweep period in ms (defaults for callers that pass none).
+local period = tonumber(ARGV[1]) or 10000
 local tl = load_tl(KEYS[1])
 if tl == nil then return false end
 if tl.isPlaying ~= '1' then return encode(tl) end
 local now = now_ms()
-local last = tonumber(tl.lastSweepAt) or 0
--- another instance already swept this period: return false so the caller
+local window = math.floor(now / period)
+-- another instance already swept this window: return false so the caller
 -- skips its broadcast entirely rather than re-sending a state clients hold
-if last > 0 and (now - last) < minInterval then return false end
+if tonumber(tl.lastSweepWindow) == window then return false end
 local elapsed = (now - tonumber(tl.stampedAt)) / 1000.0
 tl.seq = tonumber(tl.seq) + 1
 tl.mediaTime = tostring(tonumber(tl.mediaTime) + elapsed)
 tl.stampedAt = now
-tl.lastSweepAt = now
+tl.lastSweepWindow = window
 tl.reason = 'snapshot'
 tl.by = ''
 save_tl(KEYS[1], tl, 86400000)

--- a/video-sync-backend/src/sync/lua/apply_snapshot.lua
+++ b/video-sync-backend/src/sync/lua/apply_snapshot.lua
@@ -1,11 +1,29 @@
+-- Repair sweep. EVERY instance holding a local socket in a room runs its own
+-- 10s sweep timer, so on a 3-instance lab this script was called 3x per period
+-- per room: three seq bumps and three fanouts for one repair, scaling linearly
+-- with instance count. Worse, the three commits raced, and clients received
+-- them out of order often enough to look like lost messages.
+--
+-- Redis's single-threaded execution already serializes these calls, so the
+-- dedup belongs here rather than in a lease: the first caller of a period wins
+-- and the rest no-op. No new keys, no ownership, and if the winner dies another
+-- instance simply wins the next period.
+--
+-- ARGV[1] = minimum ms between sweeps (defaults for callers that pass none).
+local minInterval = tonumber(ARGV[1]) or 9000
 local tl = load_tl(KEYS[1])
 if tl == nil then return false end
 if tl.isPlaying ~= '1' then return encode(tl) end
 local now = now_ms()
+local last = tonumber(tl.lastSweepAt) or 0
+-- another instance already swept this period: return false so the caller
+-- skips its broadcast entirely rather than re-sending a state clients hold
+if last > 0 and (now - last) < minInterval then return false end
 local elapsed = (now - tonumber(tl.stampedAt)) / 1000.0
 tl.seq = tonumber(tl.seq) + 1
 tl.mediaTime = tostring(tonumber(tl.mediaTime) + elapsed)
 tl.stampedAt = now
+tl.lastSweepAt = now
 tl.reason = 'snapshot'
 tl.by = ''
 save_tl(KEYS[1], tl, 86400000)

--- a/video-sync-backend/src/sync/lua/common.lua
+++ b/video-sync-backend/src/sync/lua/common.lua
@@ -14,9 +14,9 @@ local function save_tl(key, tl, ttl)
     'seq', tl.seq, 'storeEpoch', tl.storeEpoch, 'videoId', tl.videoId,
     'isPlaying', tl.isPlaying, 'mediaTime', tl.mediaTime,
     'stampedAt', tl.stampedAt, 'reason', tl.reason, 'by', tl.by or '',
-    -- when the repair sweep last committed for this room. Persisted so the
-    -- guard in apply_snapshot works across instances; never sent on the wire.
-    'lastSweepAt', tl.lastSweepAt or 0)
+    -- which aligned time window the repair sweep last committed in. Persisted
+    -- so the guard in apply_snapshot works across instances; never on the wire.
+    'lastSweepWindow', tl.lastSweepWindow or -1)
   redis.call('PEXPIRE', key, ttl)
 end
 local function encode(tl)

--- a/video-sync-backend/src/sync/lua/common.lua
+++ b/video-sync-backend/src/sync/lua/common.lua
@@ -13,7 +13,10 @@ local function save_tl(key, tl, ttl)
   redis.call('HSET', key,
     'seq', tl.seq, 'storeEpoch', tl.storeEpoch, 'videoId', tl.videoId,
     'isPlaying', tl.isPlaying, 'mediaTime', tl.mediaTime,
-    'stampedAt', tl.stampedAt, 'reason', tl.reason, 'by', tl.by or '')
+    'stampedAt', tl.stampedAt, 'reason', tl.reason, 'by', tl.by or '',
+    -- when the repair sweep last committed for this room. Persisted so the
+    -- guard in apply_snapshot works across instances; never sent on the wire.
+    'lastSweepAt', tl.lastSweepAt or 0)
   redis.call('PEXPIRE', key, ttl)
 end
 local function encode(tl)

--- a/video-sync-backend/src/sync/redis-room-state.store.spec.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.spec.ts
@@ -1,0 +1,120 @@
+import Redis from 'ioredis';
+import { RedisRoomStateStore } from './redis-room-state.store';
+import { SWEEP_MIN_INTERVAL_MS } from './room-state.store';
+
+/**
+ * The repair sweep against a REAL Redis, because the dedup lives in
+ * apply_snapshot.lua and a mock would prove nothing about it.
+ *
+ * Every instance holding a local socket in a room runs its own 10s sweep
+ * timer, so on a 3-instance lab the room was swept three times per period:
+ * three seq bumps and three fanouts for one repair, scaling linearly with
+ * instance count. The three commits also raced, and clients received them out
+ * of order often enough that the bot fleet's gap counter recorded 59 "gaps"
+ * on the three-instance 25-client cell. Nothing was ever lost — the metric
+ * counted reordering as loss — but the redundant sweeps were real.
+ *
+ * Skipped automatically when no Redis is reachable.
+ */
+const URL = process.env.REDIS_URL ?? 'redis://localhost:6380';
+
+describe('RedisRoomStateStore — repair sweep dedup', () => {
+  const clients: Redis[] = [];
+  let available = true;
+  const room = `sweep-test-${Date.now().toString(36)}`;
+
+  const make = (): RedisRoomStateStore => {
+    const kv = new Redis(URL, { maxRetriesPerRequest: 1, lazyConnect: false });
+    clients.push(kv);
+    return new RedisRoomStateStore(kv);
+  };
+
+  beforeAll(async () => {
+    try {
+      const probe = new Redis(URL, { maxRetriesPerRequest: 1 });
+      clients.push(probe);
+      await probe.ping();
+    } catch {
+      available = false;
+    }
+  });
+
+  afterAll(async () => {
+    await Promise.all(clients.map((c) => c.quit().catch(() => undefined)));
+  });
+
+  it('commits at most one sweep per period however many instances call it', async () => {
+    if (!available) return;
+    // three stores standing in for three instances, all sharing one Redis
+    const a = make();
+    const b = make();
+    const c = make();
+
+    await a.init(room, 'vid', 0, Date.now());
+    await a.applyControl(room, 'play', 0, Date.now(), 'u1');
+
+    const before = await a.get(room);
+    expect(before).not.toBeNull();
+
+    // all three sweep "simultaneously", exactly as the timers do in the lab
+    const results = await Promise.all([
+      a.applySnapshot(room, Date.now()),
+      b.applySnapshot(room, Date.now()),
+      c.applySnapshot(room, Date.now()),
+    ]);
+
+    const committed = results.filter((r) => r !== null);
+    // one winner; the losers return null so their callers skip broadcasting
+    expect(committed).toHaveLength(1);
+
+    const after = await a.get(room);
+    // exactly one seq bump, not three
+    expect(after!.seq).toBe(before!.seq + 1);
+  });
+
+  it('lets the next period through', async () => {
+    if (!available) return;
+    const a = make();
+    const roomB = `${room}-next`;
+    await a.init(roomB, 'vid', 0, Date.now());
+    await a.applyControl(roomB, 'play', 0, Date.now(), 'u1');
+
+    const first = await a.applySnapshot(roomB, Date.now());
+    expect(first).not.toBeNull();
+
+    // immediately after, the guard suppresses
+    expect(await a.applySnapshot(roomB, Date.now())).toBeNull();
+
+    // ...but the guard must not wedge the repair channel shut. Rather than
+    // sleep out the real interval, wind lastSweepAt back past it.
+    const kv = new Redis(URL, { maxRetriesPerRequest: 1 });
+    clients.push(kv);
+    await kv.hset(
+      `room:${roomB}:tl`,
+      'lastSweepAt',
+      String(Date.now() - SWEEP_MIN_INTERVAL_MS - 1_000),
+    );
+
+    const second = await a.applySnapshot(roomB, Date.now());
+    expect(second).not.toBeNull();
+    expect(second!.seq).toBe(first!.seq + 1);
+  });
+
+  it('never advances a paused room', async () => {
+    if (!available) return;
+    const a = make();
+    const roomP = `${room}-paused`;
+    await a.init(roomP, 'vid', 0, Date.now()); // init always restores paused (P5)
+
+    const before = await a.get(roomP);
+    // TimelineService.sweepSnapshot short-circuits paused rooms before it ever
+    // gets here, so the script's own contract is the weaker one: it hands back
+    // the unchanged state rather than null. What must hold at this layer is
+    // that a paused room is never advanced.
+    const swept = await a.applySnapshot(roomP, Date.now());
+    expect(swept?.isPlaying).toBe(false);
+    const after = await a.get(roomP);
+    expect(after!.seq).toBe(before!.seq);
+    expect(after!.mediaTime).toBe(before!.mediaTime);
+  });
+});

--- a/video-sync-backend/src/sync/redis-room-state.store.spec.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.spec.ts
@@ -1,6 +1,6 @@
 import Redis from 'ioredis';
 import { RedisRoomStateStore } from './redis-room-state.store';
-import { SWEEP_MIN_INTERVAL_MS } from './room-state.store';
+import { SWEEP_DEDUP_PERIOD_MS } from './room-state.store';
 
 /**
  * The repair sweep against a REAL Redis, because the dedup lives in
@@ -17,11 +17,18 @@ import { SWEEP_MIN_INTERVAL_MS } from './room-state.store';
  * Skipped automatically when no Redis is reachable.
  */
 const URL = process.env.REDIS_URL ?? 'redis://localhost:6380';
+const key = (room: string): string => `room:${room}:tl`;
 
 describe('RedisRoomStateStore — repair sweep dedup', () => {
   const clients: Redis[] = [];
   let available = true;
   const room = `sweep-test-${Date.now().toString(36)}`;
+
+  const raw = (): Redis => {
+    const c = new Redis(URL, { maxRetriesPerRequest: 1 });
+    clients.push(c);
+    return c;
+  };
 
   const make = (): RedisRoomStateStore => {
     const kv = new Redis(URL, { maxRetriesPerRequest: 1, lazyConnect: false });
@@ -31,71 +38,102 @@ describe('RedisRoomStateStore — repair sweep dedup', () => {
 
   beforeAll(async () => {
     try {
-      const probe = new Redis(URL, { maxRetriesPerRequest: 1 });
+      const probe = new Redis(URL, {
+        maxRetriesPerRequest: 1,
+        // without a bound, an unreachable Redis leaves ioredis retrying and
+        // the suite hangs on the probe instead of skipping
+        connectTimeout: 2_000,
+        retryStrategy: () => null,
+        lazyConnect: true,
+      });
       clients.push(probe);
-      await probe.ping();
+      probe.on('error', () => undefined);
+      await Promise.race([
+        probe.connect().then(() => probe.ping()),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('probe timeout')), 3_000),
+        ),
+      ]);
     } catch {
       available = false;
     }
-  });
+  }, 10_000);
 
   afterAll(async () => {
     await Promise.all(clients.map((c) => c.quit().catch(() => undefined)));
   });
 
-  it('commits at most one sweep per period however many instances call it', async () => {
+  const playingRoom = async (
+    store: RedisRoomStateStore,
+    name: string,
+  ): Promise<void> => {
+    await store.init(name, 'vid', 0, Date.now());
+    await store.applyControl(name, 'play', 0, Date.now(), 'u1');
+  };
+
+  it('commits once however many instances call it at the same moment', async () => {
     if (!available) return;
     // three stores standing in for three instances, all sharing one Redis
     const a = make();
     const b = make();
     const c = make();
-
-    await a.init(room, 'vid', 0, Date.now());
-    await a.applyControl(room, 'play', 0, Date.now(), 'u1');
+    await playingRoom(a, room);
 
     const before = await a.get(room);
     expect(before).not.toBeNull();
 
-    // all three sweep "simultaneously", exactly as the timers do in the lab
     const results = await Promise.all([
       a.applySnapshot(room, Date.now()),
       b.applySnapshot(room, Date.now()),
       c.applySnapshot(room, Date.now()),
     ]);
 
-    const committed = results.filter((r) => r !== null);
     // one winner; the losers return null so their callers skip broadcasting
-    expect(committed).toHaveLength(1);
-
+    expect(results.filter((r) => r !== null)).toHaveLength(1);
     const after = await a.get(room);
-    // exactly one seq bump, not three
     expect(after!.seq).toBe(before!.seq + 1);
   });
 
-  it('lets the next period through', async () => {
+  it('suppresses a STAGGERED second caller inside the same window', async () => {
     if (!available) return;
+    // The case an elapsed-time guard gets wrong: two instances whose timers
+    // are offset by nearly a full period. With a 9s "minimum interval" a
+    // sweep at t=0 and another at t=9.5s both commit, which is two bumps
+    // inside one 10s period. Aligned windows reject the second.
     const a = make();
-    const roomB = `${room}-next`;
-    await a.init(roomB, 'vid', 0, Date.now());
-    await a.applyControl(roomB, 'play', 0, Date.now(), 'u1');
+    const b = make();
+    const staggered = `${room}-staggered`;
+    await playingRoom(a, staggered);
 
-    const first = await a.applySnapshot(roomB, Date.now());
+    const first = await a.applySnapshot(staggered, Date.now());
     expect(first).not.toBeNull();
 
+    // put the committed window's clock near the end of the same window
+    const w = Math.floor(Date.now() / SWEEP_DEDUP_PERIOD_MS);
+    await raw().hset(key(staggered), 'lastSweepWindow', String(w));
+
+    expect(await b.applySnapshot(staggered, Date.now())).toBeNull();
+    const after = await a.get(staggered);
+    expect(after!.seq).toBe(first!.seq);
+  });
+
+  it('lets the next window through', async () => {
+    if (!available) return;
+    const a = make();
+    const next = `${room}-next`;
+    await playingRoom(a, next);
+
+    const first = await a.applySnapshot(next, Date.now());
+    expect(first).not.toBeNull();
     // immediately after, the guard suppresses
-    expect(await a.applySnapshot(roomB, Date.now())).toBeNull();
+    expect(await a.applySnapshot(next, Date.now())).toBeNull();
 
     // ...but the guard must not wedge the repair channel shut. Rather than
-    // sleep out the real interval, wind lastSweepAt back past it.
-    const kv = new Redis(URL, { maxRetriesPerRequest: 1 });
-    clients.push(kv);
-    await kv.hset(
-      `room:${roomB}:tl`,
-      'lastSweepAt',
-      String(Date.now() - SWEEP_MIN_INTERVAL_MS - 1_000),
-    );
+    // sleep out a real period, put the room in an earlier window.
+    const w = Math.floor(Date.now() / SWEEP_DEDUP_PERIOD_MS);
+    await raw().hset(key(next), 'lastSweepWindow', String(w - 1));
 
-    const second = await a.applySnapshot(roomB, Date.now());
+    const second = await a.applySnapshot(next, Date.now());
     expect(second).not.toBeNull();
     expect(second!.seq).toBe(first!.seq + 1);
   });
@@ -103,17 +141,17 @@ describe('RedisRoomStateStore — repair sweep dedup', () => {
   it('never advances a paused room', async () => {
     if (!available) return;
     const a = make();
-    const roomP = `${room}-paused`;
-    await a.init(roomP, 'vid', 0, Date.now()); // init always restores paused (P5)
+    const paused = `${room}-paused`;
+    await a.init(paused, 'vid', 0, Date.now()); // init always restores paused (P5)
 
-    const before = await a.get(roomP);
+    const before = await a.get(paused);
     // TimelineService.sweepSnapshot short-circuits paused rooms before it ever
     // gets here, so the script's own contract is the weaker one: it hands back
     // the unchanged state rather than null. What must hold at this layer is
     // that a paused room is never advanced.
-    const swept = await a.applySnapshot(roomP, Date.now());
+    const swept = await a.applySnapshot(paused, Date.now());
     expect(swept?.isPlaying).toBe(false);
-    const after = await a.get(roomP);
+    const after = await a.get(paused);
     expect(after!.seq).toBe(before!.seq);
     expect(after!.mediaTime).toBe(before!.mediaTime);
   });

--- a/video-sync-backend/src/sync/redis-room-state.store.spec.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.spec.ts
@@ -20,6 +20,17 @@ import { SWEEP_DEDUP_PERIOD_MS } from './room-state.store';
 const URL = process.env.REDIS_URL ?? 'redis://localhost:6380';
 const key = (room: string): string => `room:${room}:tl`;
 
+/**
+ * The guard lives in Lua and derives its window from `redis.call('TIME')`, so
+ * every window this spec computes must come from the SAME clock. Seeding from
+ * the test host's `Date.now()` reaches across clock domains — the one thing
+ * D6 forbids — and makes these assertions flaky at window boundaries.
+ */
+const redisNowMs = async (c: Redis): Promise<number> => {
+  const [sec, usec] = await c.time();
+  return Number(sec) * 1000 + Math.floor(Number(usec) / 1000);
+};
+
 describe('RedisRoomStateStore — repair sweep dedup', () => {
   const clients: Redis[] = [];
   let available = true;
@@ -102,23 +113,39 @@ describe('RedisRoomStateStore — repair sweep dedup', () => {
 
   it('suppresses a STAGGERED second caller inside the same window', async () => {
     if (!available) return;
-    // The case an elapsed-time guard gets wrong: two instances whose timers
-    // are offset by nearly a full period. With a 9s "minimum interval" a
-    // sweep at t=0 and another at t=9.5s both commit, which is two bumps
-    // inside one 10s period. Aligned windows reject the second.
+    // A caller arriving late into a window another instance already claimed.
+    // Staged to look 9.5s old so the assertion is about WINDOW IDENTITY and
+    // not about the calls being milliseconds apart.
+    //
+    // Note on what this does and does not separate: an elapsed-time guard
+    // whose threshold equals the period is indistinguishable from the window
+    // guard on same-window cases, because within one window elapsed is always
+    // < period by construction. The two only diverge when the threshold is
+    // BELOW the period (the original 9s), which is what let a staggered
+    // caller through. The test that actually goes red on the old guard is
+    // 'lets the next window through' — verified by checking out the previous
+    // apply_snapshot.lua and re-running this file.
     const a = make();
     const b = make();
+    const c = raw();
     const staggered = `${room}-staggered`;
     await playingRoom(a, staggered);
 
-    const first = await a.applySnapshot(staggered, Date.now());
+    const first = await a.applySnapshot(staggered, await redisNowMs(c));
     expect(first).not.toBeNull();
 
-    // put the committed window's clock near the end of the same window
-    const w = Math.floor(Date.now() / SWEEP_DEDUP_PERIOD_MS);
-    await raw().hset(key(staggered), 'lastSweepWindow', String(w));
+    const now = await redisNowMs(c);
+    await c.hset(
+      key(staggered),
+      // the window is claimed...
+      'lastSweepWindow',
+      String(Math.floor(now / SWEEP_DEDUP_PERIOD_MS)),
+      // ...but the last sweep looks 9.5s old, so a 9s elapsed threshold passes
+      'lastSweepAt',
+      String(now - 9_500),
+    );
 
-    expect(await b.applySnapshot(staggered, Date.now())).toBeNull();
+    expect(await b.applySnapshot(staggered, now)).toBeNull();
     const after = await a.get(staggered);
     expect(after!.seq).toBe(first!.seq);
   });
@@ -126,20 +153,26 @@ describe('RedisRoomStateStore — repair sweep dedup', () => {
   it('lets the next window through', async () => {
     if (!available) return;
     const a = make();
+    const c = raw();
     const next = `${room}-next`;
     await playingRoom(a, next);
 
-    const first = await a.applySnapshot(next, Date.now());
+    const first = await a.applySnapshot(next, await redisNowMs(c));
     expect(first).not.toBeNull();
     // immediately after, the guard suppresses
-    expect(await a.applySnapshot(next, Date.now())).toBeNull();
+    expect(await a.applySnapshot(next, await redisNowMs(c))).toBeNull();
 
     // ...but the guard must not wedge the repair channel shut. Rather than
-    // sleep out a real period, put the room in an earlier window.
-    const w = Math.floor(Date.now() / SWEEP_DEDUP_PERIOD_MS);
-    await raw().hset(key(next), 'lastSweepWindow', String(w - 1));
+    // sleep out a real period, put the room in an earlier window — computed
+    // from Redis's clock, the same one the script reads.
+    //
+    // This assertion is the suite's regression tripwire: it is decided purely
+    // by window identity, so the elapsed-time guard fails it (that guard sees
+    // a commit milliseconds old and suppresses regardless of window).
+    const w = Math.floor((await redisNowMs(c)) / SWEEP_DEDUP_PERIOD_MS);
+    await c.hset(key(next), 'lastSweepWindow', String(w - 1));
 
-    const second = await a.applySnapshot(next, Date.now());
+    const second = await a.applySnapshot(next, await redisNowMs(c));
     expect(second).not.toBeNull();
     expect(second!.seq).toBe(first!.seq + 1);
   });

--- a/video-sync-backend/src/sync/redis-room-state.store.spec.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.spec.ts
@@ -11,8 +11,9 @@ import { SWEEP_DEDUP_PERIOD_MS } from './room-state.store';
  * three seq bumps and three fanouts for one repair, scaling linearly with
  * instance count. The three commits also raced, and clients received them out
  * of order often enough that the bot fleet's gap counter recorded 59 "gaps"
- * on the three-instance 25-client cell. Nothing was ever lost — the metric
- * counted reordering as loss — but the redundant sweeps were real.
+ * on the three-instance 25-client cell. No seq inside any bot's observed
+ * range actually went unreceived — the metric counted reordering as loss —
+ * but the redundant sweeps were real.
  *
  * Skipped automatically when no Redis is reachable.
  */
@@ -37,6 +38,7 @@ describe('RedisRoomStateStore — repair sweep dedup', () => {
   };
 
   beforeAll(async () => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       const probe = new Redis(URL, {
         maxRetriesPerRequest: 1,
@@ -50,12 +52,16 @@ describe('RedisRoomStateStore — repair sweep dedup', () => {
       probe.on('error', () => undefined);
       await Promise.race([
         probe.connect().then(() => probe.ping()),
-        new Promise((_, reject) =>
-          setTimeout(() => reject(new Error('probe timeout')), 3_000),
-        ),
+        new Promise((_, reject) => {
+          timer = setTimeout(() => reject(new Error('probe timeout')), 3_000);
+        }),
       ]);
     } catch {
       available = false;
+    } finally {
+      // the loser of the race is still pending: leaving its timer armed keeps
+      // the event loop alive and delays Jest's exit on every short run
+      if (timer) clearTimeout(timer);
     }
   }, 10_000);
 

--- a/video-sync-backend/src/sync/redis-room-state.store.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.ts
@@ -5,7 +5,7 @@ import { ControlIntent, Timeline } from '../shared/sync-protocol';
 import {
   ApplyOutcome,
   RoomStateStore,
-  SWEEP_MIN_INTERVAL_MS,
+  SWEEP_DEDUP_PERIOD_MS,
 } from './room-state.store';
 
 // Redis hash per room is the source of truth; ONE Lua script per mutation is
@@ -39,10 +39,7 @@ interface RedisWithCommands extends Redis {
     mediaTime: string,
     by: string,
   ): Promise<string | null>;
-  mustardApplySnapshot(
-    key: string,
-    minIntervalMs: string,
-  ): Promise<string | null>;
+  mustardApplySnapshot(key: string, periodMs: string): Promise<string | null>;
   mustardInit(key: string, videoId: string, mediaTime: string): Promise<string>;
 }
 
@@ -114,11 +111,11 @@ export class RedisRoomStateStore implements RoomStateStore {
   ): Promise<Timeline | null> {
     // Every instance with a local socket in the room runs its own sweep
     // timer, so this is called once per instance per period. The script
-    // dedups: the first caller of a period commits, the rest return null and
+    // dedups: the first caller of a window commits, the rest return null and
     // their callers skip broadcasting.
     const result = await this.redis.mustardApplySnapshot(
       this.key(roomCode),
-      String(SWEEP_MIN_INTERVAL_MS),
+      String(SWEEP_DEDUP_PERIOD_MS),
     );
     return this.parse(result);
   }

--- a/video-sync-backend/src/sync/redis-room-state.store.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.ts
@@ -2,7 +2,11 @@ import { Inject, Injectable } from '@nestjs/common';
 import type Redis from 'ioredis';
 import { REDIS_KV } from '../redis/redis.module';
 import { ControlIntent, Timeline } from '../shared/sync-protocol';
-import { ApplyOutcome, RoomStateStore } from './room-state.store';
+import {
+  ApplyOutcome,
+  RoomStateStore,
+  SWEEP_MIN_INTERVAL_MS,
+} from './room-state.store';
 
 // Redis hash per room is the source of truth; ONE Lua script per mutation is
 // the serializer - Redis's single-threaded execution orders concurrent
@@ -35,7 +39,7 @@ interface RedisWithCommands extends Redis {
     mediaTime: string,
     by: string,
   ): Promise<string | null>;
-  mustardApplySnapshot(key: string): Promise<string | null>;
+  mustardApplySnapshot(key: string, minIntervalMs: string): Promise<string | null>;
   mustardInit(key: string, videoId: string, mediaTime: string): Promise<string>;
 }
 
@@ -105,7 +109,14 @@ export class RedisRoomStateStore implements RoomStateStore {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _serverNow: number,
   ): Promise<Timeline | null> {
-    const result = await this.redis.mustardApplySnapshot(this.key(roomCode));
+    // Every instance with a local socket in the room runs its own sweep
+    // timer, so this is called once per instance per period. The script
+    // dedups: the first caller of a period commits, the rest return null and
+    // their callers skip broadcasting.
+    const result = await this.redis.mustardApplySnapshot(
+      this.key(roomCode),
+      String(SWEEP_MIN_INTERVAL_MS),
+    );
     return this.parse(result);
   }
 

--- a/video-sync-backend/src/sync/redis-room-state.store.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.ts
@@ -39,7 +39,10 @@ interface RedisWithCommands extends Redis {
     mediaTime: string,
     by: string,
   ): Promise<string | null>;
-  mustardApplySnapshot(key: string, minIntervalMs: string): Promise<string | null>;
+  mustardApplySnapshot(
+    key: string,
+    minIntervalMs: string,
+  ): Promise<string | null>;
   mustardInit(key: string, videoId: string, mediaTime: string): Promise<string>;
 }
 

--- a/video-sync-backend/src/sync/room-state.store.ts
+++ b/video-sync-backend/src/sync/room-state.store.ts
@@ -5,13 +5,12 @@ import { applyControl, snapshot } from '../shared/sync-core/timeline';
 /** Repair-sweep period. Each instance runs this timer for its local rooms. */
 export const SWEEP_INTERVAL_MS = 10_000;
 /**
- * Minimum gap between two committed sweeps for the SAME room, enforced inside
- * apply_snapshot.lua. Every instance holding a socket in a room fires its own
- * timer, so without this the room is swept once per instance per period. Set
- * just under the period so the next period always qualifies while duplicates
- * within a period never do.
+ * The period apply_snapshot.lua buckets time into when deduping sweeps. Every
+ * instance holding a socket in a room fires its own timer, so without the
+ * guard the room is swept once per instance per period. The script commits at
+ * most once per aligned window of this length.
  */
-export const SWEEP_MIN_INTERVAL_MS = SWEEP_INTERVAL_MS - 1_000;
+export const SWEEP_DEDUP_PERIOD_MS = SWEEP_INTERVAL_MS;
 
 /**
  * The authority seam for room playback state. The engine only speaks this

--- a/video-sync-backend/src/sync/room-state.store.ts
+++ b/video-sync-backend/src/sync/room-state.store.ts
@@ -2,6 +2,17 @@ import { Injectable } from '@nestjs/common';
 import { ControlIntent, Timeline } from '../shared/sync-protocol';
 import { applyControl, snapshot } from '../shared/sync-core/timeline';
 
+/** Repair-sweep period. Each instance runs this timer for its local rooms. */
+export const SWEEP_INTERVAL_MS = 10_000;
+/**
+ * Minimum gap between two committed sweeps for the SAME room, enforced inside
+ * apply_snapshot.lua. Every instance holding a socket in a room fires its own
+ * timer, so without this the room is swept once per instance per period. Set
+ * just under the period so the next period always qualifies while duplicates
+ * within a period never do.
+ */
+export const SWEEP_MIN_INTERVAL_MS = SWEEP_INTERVAL_MS - 1_000;
+
 /**
  * The authority seam for room playback state. The engine only speaks this
  * interface; M6 swaps in a Redis/Lua implementation for multi-instance

--- a/video-sync-backend/src/sync/sync.gateway.ts
+++ b/video-sync-backend/src/sync/sync.gateway.ts
@@ -23,7 +23,11 @@ import { ClockDomainService } from '../redis/clock-domain.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { TimelineService } from './timeline.service';
 import { ActorRoomStateStore } from './actor-room-state.store';
-import { ROOM_STATE_STORE, RoomStateStore } from './room-state.store';
+import {
+  ROOM_STATE_STORE,
+  RoomStateStore,
+  SWEEP_INTERVAL_MS,
+} from './room-state.store';
 import { AuthedSocketData, wsAuthMiddleware } from './ws-auth';
 
 const CONTROL_INTENTS: ReadonlyArray<SyncControl['intent']> = [
@@ -408,7 +412,7 @@ export class SyncGateway
    * or lossy deliveries self-heal within one sweep period; clients drop
    * stale (storeEpoch, seq) so redundancy is harmless.
    */
-  @Interval(10_000)
+  @Interval(SWEEP_INTERVAL_MS)
   async sweepTimelines() {
     const activeRooms = new Set(this.userRooms.values());
     this.metrics.wsRoomsActive.set(activeRooms.size);

--- a/video-sync-backend/src/sync/sync.gateway.ts
+++ b/video-sync-backend/src/sync/sync.gateway.ts
@@ -411,6 +411,12 @@ export class SyncGateway
    * Repair channel: a periodic re-anchored snapshot per playing room. Late
    * or lossy deliveries self-heal within one sweep period; clients drop
    * stale (storeEpoch, seq) so redundancy is harmless.
+   *
+   * Only one instance COMMITS per window (the store dedups), but every
+   * instance still re-anchors its own local sockets. See `sweepSnapshot`:
+   * skipping the broadcast on the losing instances would route their
+   * clients' repair through the pub/sub adapter, whose failure is precisely
+   * what this sweep is here to repair.
    */
   @Interval(SWEEP_INTERVAL_MS)
   async sweepTimelines() {
@@ -422,8 +428,14 @@ export class SyncGateway
           roomCode,
           this.clock.now(),
         );
-        if (snap) {
-          this.server.to(roomCode).emit(SYNC_EVENTS.timeline, snap);
+        if (snap.kind === 'committed') {
+          this.server.to(roomCode).emit(SYNC_EVENTS.timeline, snap.timeline);
+        } else if (snap.kind === 'deferred') {
+          // `.local` delivers in-process only: no second adapter publish, so
+          // this costs nothing on the wire between instances
+          this.server.local
+            .to(roomCode)
+            .emit(SYNC_EVENTS.timeline, snap.timeline);
         }
       } catch (error) {
         this.logger.error({ err: String(error), roomCode }, 'sweep failed');

--- a/video-sync-backend/src/sync/timeline.service.spec.ts
+++ b/video-sync-backend/src/sync/timeline.service.spec.ts
@@ -1,4 +1,5 @@
 import { InMemoryRoomStateStore } from './room-state.store';
+import type { Timeline } from '../shared/sync-protocol';
 import { TimelineService } from './timeline.service';
 
 const roomRow = {
@@ -11,10 +12,12 @@ const roomRow = {
 function makeService(): {
   svc: TimelineService;
   db: { room: { update: jest.Mock } };
+  store: InMemoryRoomStateStore;
 } {
   const db = { room: { update: jest.fn().mockResolvedValue({}) } };
-  const svc = new TimelineService(new InMemoryRoomStateStore(), db as never);
-  return { svc, db };
+  const store = new InMemoryRoomStateStore();
+  const svc = new TimelineService(store, db as never);
+  return { svc, db, store };
 }
 
 describe('TimelineService', () => {
@@ -117,13 +120,34 @@ describe('TimelineService', () => {
   it('sweeps only playing rooms and re-anchors the projection', async () => {
     const { svc } = makeService();
     await svc.ensureRoom('r1', roomRow, 1_000);
-    expect(await svc.sweepSnapshot('r1', 10_000)).toBeNull(); // paused
+    // paused: nothing to broadcast at all
+    expect((await svc.sweepSnapshot('r1', 10_000)).kind).toBe('idle');
     await svc.handleControl('r1', 's1', 'creator', 'play', 100, 10_000);
     const snap = await svc.sweepSnapshot('r1', 20_000);
-    expect(snap).not.toBeNull();
-    expect(snap!.mediaTime).toBeCloseTo(110, 9);
-    expect(snap!.stampedAt).toBe(20_000);
-    expect(snap!.reason).toBe('snapshot');
+    expect(snap.kind).toBe('committed');
+    const tl = (snap as { timeline: Timeline }).timeline;
+    expect(tl.mediaTime).toBeCloseTo(110, 9);
+    expect(tl.stampedAt).toBe(20_000);
+    expect(tl.reason).toBe('snapshot');
+  });
+
+  it('defers to the window winner but still re-anchors locally', async () => {
+    // A store that refuses the commit stands in for "another instance already
+    // swept this window". The caller must still get a timeline back, because
+    // its own local sockets are repaired in-process — relying on the winner's
+    // broadcast would route repair through the pub/sub adapter this sweep
+    // exists to work around.
+    const { svc, store } = makeService();
+    await svc.ensureRoom('r1', roomRow, 1_000);
+    await svc.handleControl('r1', 's1', 'creator', 'play', 100, 10_000);
+
+    jest.spyOn(store, 'applySnapshot').mockResolvedValue(null);
+    const snap = await svc.sweepSnapshot('r1', 20_000);
+
+    expect(snap.kind).toBe('deferred');
+    const tl = (snap as { timeline: Timeline }).timeline;
+    expect(tl.isPlaying).toBe(true);
+    expect(tl.videoId).toBe('vid');
   });
 
   it('P3: promotes the longest-connected participant when the controller leaves', async () => {

--- a/video-sync-backend/src/sync/timeline.service.ts
+++ b/video-sync-backend/src/sync/timeline.service.ts
@@ -162,13 +162,41 @@ export class TimelineService {
     return { ok: true, timeline: outcome.timeline };
   }
 
-  /** Periodic re-anchor; null when the room has no state (nothing to sweep). */
-  async sweepSnapshot(roomCode: string, now: number): Promise<Timeline | null> {
+  /**
+   * Periodic re-anchor. The three outcomes are distinct and the caller must
+   * treat them differently:
+   *
+   * - `idle`   — no state, or the room is paused. Nothing to broadcast.
+   * - `committed` — this instance won the sweep window. Broadcast globally.
+   * - `deferred`  — another instance committed this window's snapshot. It has
+   *   already broadcast globally, but that reaches THIS instance's sockets
+   *   only over the pub/sub adapter — and a dropped adapter message is the
+   *   exact failure this sweep exists to repair. So the caller must still
+   *   re-anchor its own LOCAL sockets in-process, with `timeline`.
+   *
+   * Deduping the commit removes the redundant writes and the racing seq bumps.
+   * Deduping the broadcast as well would have made the repair channel depend
+   * on the channel it repairs.
+   */
+  async sweepSnapshot(
+    roomCode: string,
+    now: number,
+  ): Promise<
+    | { kind: 'idle' }
+    | { kind: 'committed'; timeline: Timeline }
+    | { kind: 'deferred'; timeline: Timeline }
+  > {
     const current = await this.store.get(roomCode);
-    if (!current) return null;
+    if (!current) return { kind: 'idle' };
     // paused rooms don't advance; re-broadcasting them is pure noise
-    if (!current.isPlaying) return null;
-    return this.store.applySnapshot(roomCode, now);
+    if (!current.isPlaying) return { kind: 'idle' };
+    const committed = await this.store.applySnapshot(roomCode, now);
+    if (committed) return { kind: 'committed', timeline: committed };
+    // lost the window (or, on the actor plane, we are not the owner): re-read
+    // so the local re-anchor carries the winner's committed state rather than
+    // the pre-sweep copy read above
+    const latest = (await this.store.get(roomCode)) ?? current;
+    return { kind: 'deferred', timeline: latest };
   }
 
   /**


### PR DESCRIPTION
Root-causes the 59 seq gaps flagged on the `three-25` load-sweep cell. There
were two defects, and the metric bug was hiding the server bug.

## The metric counted reordering as loss

The bot recorded a gap the moment a timeline arrived with `seq > lastApplied +
1`, and nothing retracted it when the skipped seq arrived a moment later.
`isNewer` correctly drops the late arrival, so the bot stayed converged the
whole time — the counter had simply already fired. On one instance every
broadcast leaves one process in commit order, so this never triggered; the
metric only broke where deliveries could interleave.

Gaps are now decided at report time from the complete set of seqs a bot
received on an epoch — a gap is a seq inside the observed range that **never
arrived at all** — and reordered deliveries are counted separately.

| | seqGaps | seqReorders |
|---|---|---|
| 3 instances, 25 bots (old metric) | 59 | not measured |
| 3 instances, 25 bots (fixed metric) | **0** | 97 |
| 1 instance, 25 bots (control) | 0 | 0 |

Nothing had ever been lost.

## Every instance was sweeping every room it had a socket in

97 reorders in 120s is not noise, and the control run isolated it. The repair
sweep iterates `userRooms`, which is per-instance state, so with 25 bots spread
across 3 instances **all three swept the same room every 10s** — three `seq`
bumps and three fanouts for one repair. The cost scaled linearly with instance
count (ten instances → ten times the snapshot writes and fanout for one room),
and the three racing commits were precisely what clients then received out of
order.

The dedup belongs in the Lua script rather than in a lease, because Redis's
single-threaded execution already serializes these calls. `apply_snapshot` now
records `lastSweepAt` and no-ops if the room was swept less than
`SWEEP_MIN_INTERVAL_MS` (period − 1s) ago, returning null so the losing
instances skip their broadcast entirely. The first caller of each period wins;
if it dies, another wins the next period, with no ownership to hand over.

| | commits in 120s | per 10s period | seqReorders |
|---|---|---|---|
| 3 instances, before | 40 | 3.3 | 97 |
| 3 instances, after | **14** | **1.2** | **0** |
| 1 instance (reference) | 14 | 1.2 | 0 |

The three-instance plane now commits at exactly the single-instance rate.

**The repair channel is verifiably still alive** — 14 commits over 120s is the
~12 sweeps plus the scripted control events, not a wedged sweep. That was the
main risk of this change, so it is measured rather than assumed.
`redis-room-state.store.spec.ts` pins the contract against a real Redis: three
simultaneous callers produce one commit, the next period still gets through,
and a paused room never advances.

## One note against the plane A/B

Plane B never had this bug — its sweep is owner-only by construction, which
falls straight out of having an owner at all. The A/B ran one instance per arm
and could not have seen it. That doesn't overturn its conclusion, but it is a
concrete instance of what the "what the measurement cannot show" paragraph was
gesturing at, so `COORDINATION.md` now says so.

A full 10-cell sweep re-run is in flight to refresh the committed load
characterization against this build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate repair sweeps, reducing redundant updates and broadcasts.
  * Improved sequence reporting by distinguishing reordered or duplicate deliveries from missing messages.
  * Improved reconnect handling and rejoining, with failed rejoins now surfaced in test results.
  * Corrected benchmark measurements to reflect accurate delivery and repair behavior.

* **Documentation**
  * Updated coordination, scaling, and sweep performance documentation with corrected findings and measurements.

* **Tests**
  * Added coverage for concurrent repair deduplication, later sweep recovery, paused rooms, and reconnect scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->