### PR TITLE
formal: exactly-once command application, spec-first

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,6 +37,15 @@ jobs:
           fi
           java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config SyncActor.cfg SyncActor.tla
           java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config SyncActor_live.cfg SyncActor.tla
+          # exactly-once: the guarded design must pass; each of the three
+          # degraded designs must still FAIL on its named property, or the
+          # spec has lost its teeth
+          java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config SyncExactlyOnce.cfg SyncExactlyOnce.tla
+          for bad in nodedup earlyevict nosnaplog; do
+            if java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config "SyncExactlyOnce_${bad}.cfg" SyncExactlyOnce.tla; then
+              echo "SyncExactlyOnce_${bad} unexpectedly passed - the spec lost its teeth"; exit 1
+            fi
+          done
 
   lab-50:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,15 +37,25 @@ jobs:
           fi
           java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config SyncActor.cfg SyncActor.tla
           java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config SyncActor_live.cfg SyncActor.tla
-          # exactly-once: the guarded design must pass; each of the three
-          # degraded designs must still FAIL on its named property, or the
-          # spec has lost its teeth
+          # exactly-once: both green configs must pass; each degraded design
+          # must fail on its NAMED property. Accepting any nonzero TLC exit
+          # would let a malformed config or a TLC crash impersonate the
+          # intended violation, so the exact message is asserted.
           java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config SyncExactlyOnce.cfg SyncExactlyOnce.tla
-          for bad in nodedup earlyevict nosnaplog; do
-            if java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config "SyncExactlyOnce_${bad}.cfg" SyncExactlyOnce.tla; then
-              echo "SyncExactlyOnce_${bad} unexpectedly passed - the spec lost its teeth"; exit 1
+          java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config SyncExactlyOnce_live.cfg SyncExactlyOnce.tla
+          expect_violation() {
+            local cfg="$1" prop="$2" out
+            if out=$(java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config "$cfg" SyncExactlyOnce.tla 2>&1); then
+              echo "$cfg unexpectedly passed - the spec lost its teeth"; return 1
             fi
-          done
+            if ! grep -q "Invariant $prop is violated" <<<"$out"; then
+              echo "$cfg failed, but NOT on $prop - TLC output:"; tail -30 <<<"$out"; return 1
+            fi
+            echo "$cfg: $prop violated as designed"
+          }
+          expect_violation SyncExactlyOnce_nodedup.cfg AtMostOnce
+          expect_violation SyncExactlyOnce_earlyevict.cfg AtMostOnce
+          expect_violation SyncExactlyOnce_nosnaplog.cfg ReplayReconstructs
 
   lab-50:
     runs-on: ubuntu-latest

--- a/docs/FORMAL.md
+++ b/docs/FORMAL.md
@@ -220,30 +220,48 @@ delivery picks any pending command, so reordering needs no extra machinery.
 The store's apply is **one atomic step** containing the dedup check, the
 commit, the log append, and the dedup record — because in the implementation
 all four live inside the same Lua script, and Redis's single-threaded
-execution is what makes the composition atomic. Dedup entries can be
-**evicted** (a TTL), and the repair sweep commits re-anchored snapshots that
-may or may not be logged. Exactly-once is therefore proven as a composition:
-at-least-once delivery (retry) with at-most-once application (atomic dedup)
-— never as a property of the network.
+execution is what makes the composition atomic. Exactly-once is therefore
+proven as a composition: at-least-once delivery (retry) with at-most-once
+application (atomic dedup) — never as a property of the network.
+
+**Time is concrete where it matters.** Dedup records expire a fixed `Ttl`
+after the apply — a plain clock, exactly what `SET .. PX` gives the
+implementation, with no oracle about in-flight copies. Sending, resending,
+network duplication, and *delivery* are all bounded by `RetryWindow` after
+first issue: past the client's retry deadline nothing carries the command
+any more. That bound is an **assumption the implementation must enforce** —
+the client abandons unacked commands older than the window instead of
+letting an arbitrarily old send-buffer flush — and it is what makes any
+finite TTL sound: with an unbounded retry window, no TTL is safe, and the
+spec would say so.
 
 ## Properties and teeth
 
-| config | switches | result |
+| config | constants | result |
 |---|---|---|
-| `SyncExactlyOnce.cfg` | all guards on | **green**: `TypeOK`, `AtMostOnce`, `TransitionContract`, `ReplayReconstructs`, `AckedWasApplied`, and liveness `EventuallyExactlyOnce` — 281,111 states, 98,103 distinct, depth 17 |
+| `SyncExactlyOnce.cfg` (safety) | `Ttl=2 > RetryWindow=1`, eviction reachable | **green**: `TypeOK`, `AtMostOnce`, `TransitionContract`, `ReplayReconstructs`, `AckedWasApplied` — 1,559,644 states, 628,684 distinct |
+| `SyncExactlyOnce_live.cfg` (liveness) | window spans the model clock | **green**: `EventuallyExactlyOnce` — 371,055 states, 144,147 distinct |
 | `SyncExactlyOnce_nodedup.cfg` | `DedupOn = FALSE` | **must fail** `AtMostOnce`: a retried command applies twice |
-| `SyncExactlyOnce_earlyevict.cfg` | `SafeEviction = FALSE` | **must fail** `AtMostOnce`: an entry evicted while a duplicate is still in flight re-applies |
+| `SyncExactlyOnce_earlyevict.cfg` | `Ttl=1 <= RetryWindow=2` | **must fail** `AtMostOnce`: the record expires while a copy can still arrive and the late duplicate re-applies |
 | `SyncExactlyOnce_nosnaplog.cfg` | `LogSnapshots = FALSE` | **must fail** `ReplayReconstructs`: unlogged sweep commits leave the log unable to rebuild live state |
+
+Liveness lives in its own config because a retry window that closes
+mid-model legitimately *abandons* an unacked command — at-most-once by
+design, not a stuck system — so "eventually applied exactly once" is only a
+theorem while the client is still trying.
 
 The three failure configs are the spec keeping its teeth, and each pins a
 real implementation constraint:
 
 1. **The dedup must be atomic with the commit** — a check outside the Lua
    script reintroduces the race the guard exists to close.
-2. **The dedup TTL is a correctness parameter, not a tuning knob.** It must
-   exceed the client's maximum redelivery window; shorter, and the spec
-   shows the exact double-apply. "SET NX with some TTL" is not a design
-   until the TTL is justified against the retry policy.
+2. **The dedup TTL is a correctness parameter, not a tuning knob.** The
+   relation is modeled with concrete clocks: `Ttl > RetryWindow` is checked
+   green, and `Ttl <= RetryWindow` is a committed counterexample (apply at
+   t, record expires at t+`Ttl`, duplicate arrives inside the still-open
+   window). "SET NX with some TTL" is not a design until the TTL is
+   justified against the enforced retry deadline — and the deadline must be
+   enforced: the client abandons unacked commands older than the window.
 3. **The command log must include the repair sweep's snapshot commits.**
    Sweeps bump `seq` and re-anchor the projection; a log of user commands
    alone cannot replay to live state, so reconciliation built on it would

--- a/docs/FORMAL.md
+++ b/docs/FORMAL.md
@@ -201,3 +201,68 @@ Stated here rather than left for a reader to infer from the constants.
 neutralizes zombies *and* the client ordering rule proven above. One
 mechanism, two guarantees, which is why plane B needs no new client-side
 concept.
+
+# Exactly-once command application
+
+`formal/SyncExactlyOnce.tla` — the third spec, written **before** the
+idempotency-key implementation it constrains, the same spec-first order as
+plane B.
+
+## What is modeled
+
+Every control command carries a client-minted id. The client **retries** a
+command until it observes the commit — which is at-least-once delivery, and
+is deliberately how the model gets its duplicates: a socket.io send-buffer
+flushing after a reconnect *is* a retry, whether or not anyone calls it that.
+On top of that the channel can duplicate in-flight copies outright, and
+delivery picks any pending command, so reordering needs no extra machinery.
+
+The store's apply is **one atomic step** containing the dedup check, the
+commit, the log append, and the dedup record — because in the implementation
+all four live inside the same Lua script, and Redis's single-threaded
+execution is what makes the composition atomic. Dedup entries can be
+**evicted** (a TTL), and the repair sweep commits re-anchored snapshots that
+may or may not be logged. Exactly-once is therefore proven as a composition:
+at-least-once delivery (retry) with at-most-once application (atomic dedup)
+— never as a property of the network.
+
+## Properties and teeth
+
+| config | switches | result |
+|---|---|---|
+| `SyncExactlyOnce.cfg` | all guards on | **green**: `TypeOK`, `AtMostOnce`, `TransitionContract`, `ReplayReconstructs`, `AckedWasApplied`, and liveness `EventuallyExactlyOnce` — 281,111 states, 98,103 distinct, depth 17 |
+| `SyncExactlyOnce_nodedup.cfg` | `DedupOn = FALSE` | **must fail** `AtMostOnce`: a retried command applies twice |
+| `SyncExactlyOnce_earlyevict.cfg` | `SafeEviction = FALSE` | **must fail** `AtMostOnce`: an entry evicted while a duplicate is still in flight re-applies |
+| `SyncExactlyOnce_nosnaplog.cfg` | `LogSnapshots = FALSE` | **must fail** `ReplayReconstructs`: unlogged sweep commits leave the log unable to rebuild live state |
+
+The three failure configs are the spec keeping its teeth, and each pins a
+real implementation constraint:
+
+1. **The dedup must be atomic with the commit** — a check outside the Lua
+   script reintroduces the race the guard exists to close.
+2. **The dedup TTL is a correctness parameter, not a tuning knob.** It must
+   exceed the client's maximum redelivery window; shorter, and the spec
+   shows the exact double-apply. "SET NX with some TTL" is not a design
+   until the TTL is justified against the retry policy.
+3. **The command log must include the repair sweep's snapshot commits.**
+   Sweeps bump `seq` and re-anchor the projection; a log of user commands
+   alone cannot replay to live state, so reconciliation built on it would
+   report phantom drift.
+
+`TransitionContract` is double-entry bookkeeping: the legal-transition
+contract (a seek never flips play state; a pause freezes at the commanded
+frame, not the projection; a snapshot moves the projection by exactly
+nothing; `seq` increments by exactly one) is written independently of the
+`Apply`/`Snap` definitions, so if either side drifts, TLC reports the
+disagreement rather than trusting the model's own construction.
+
+## Composition with the other specs
+
+This spec is single-epoch and single-store on purpose: `SyncActor.tla` owns
+instance fencing and lease handoff, `SyncTimeline.tla` owns client-side
+`(storeEpoch, seq)` ordering under lossy fanout. The seam between them is a
+real implementation obligation this spec makes visible rather than proves:
+**the dedup record must survive owner handoff** on the actor plane, or a
+command applied by the old owner can be re-applied by the new one. That
+lives with the fencing machinery, and is called out in COORDINATION.md
+rather than silently assumed here.

--- a/formal/SyncExactlyOnce.cfg
+++ b/formal/SyncExactlyOnce.cfg
@@ -1,0 +1,22 @@
+\* The guarded design: atomic dedup, eviction only after quiescence,
+\* sweep commits logged. Everything must hold.
+SPECIFICATION Spec
+CONSTANTS
+  Cmds = {c1, c2}
+  Positions = {0, 1}
+  MaxTime = 2
+  MaxSends = 2
+  DedupOn = TRUE
+  SafeEviction = TRUE
+  LogSnapshots = TRUE
+INVARIANTS
+  TypeOK
+  AtMostOnce
+  TransitionContract
+  ReplayReconstructs
+  AckedWasApplied
+PROPERTIES
+  EventuallyExactlyOnce
+
+\* bounded model: exhausted counters produce terminal states by design
+CHECK_DEADLOCK FALSE

--- a/formal/SyncExactlyOnce.cfg
+++ b/formal/SyncExactlyOnce.cfg
@@ -1,13 +1,16 @@
-\* The guarded design: atomic dedup, eviction only after quiescence,
-\* sweep commits logged. Everything must hold.
+\* Safety at the guarded design point: Ttl STRICTLY exceeds the client's
+\* retry window, so a dedup record outlives every copy that could arrive.
+\* MaxTime is large enough that eviction is reachable - the evict path is
+\* exercised, not vacuously absent.
 SPECIFICATION Spec
 CONSTANTS
   Cmds = {c1, c2}
   Positions = {0, 1}
-  MaxTime = 2
+  MaxTime = 3
   MaxSends = 2
   DedupOn = TRUE
-  SafeEviction = TRUE
+  Ttl = 2
+  RetryWindow = 1
   LogSnapshots = TRUE
 INVARIANTS
   TypeOK
@@ -15,8 +18,6 @@ INVARIANTS
   TransitionContract
   ReplayReconstructs
   AckedWasApplied
-PROPERTIES
-  EventuallyExactlyOnce
 
 \* bounded model: exhausted counters produce terminal states by design
 CHECK_DEADLOCK FALSE

--- a/formal/SyncExactlyOnce.tla
+++ b/formal/SyncExactlyOnce.tla
@@ -1,0 +1,270 @@
+--------------------------- MODULE SyncExactlyOnce ---------------------------
+(***************************************************************************)
+(* Exactly-once application of control commands under duplication and      *)
+(* reordering, plus log-replay reconstruction.                             *)
+(*                                                                         *)
+(* The mechanism this models: every control command carries a client-      *)
+(* minted id; the store's apply script atomically checks-and-records the   *)
+(* id (Redis SET NX semantics, executed inside the same Lua script as the  *)
+(* commit, so check+apply+record is one atomic step); commands are         *)
+(* RETRIED by the client until it observes the commit - which is exactly   *)
+(* how socket.io's send-buffer behaves across a reconnect, and is where    *)
+(* duplicates come from in the real system. Exactly-once is therefore     *)
+(* at-least-once delivery (retry) composed with at-most-once application   *)
+(* (atomic dedup), never a property of the network.                        *)
+(*                                                                         *)
+(* Three switches make the spec keep its teeth - each OFF position is a    *)
+(* committed config whose named failure pins a real design constraint:     *)
+(*                                                                         *)
+(*   DedupOn      = FALSE  ->  AtMostOnce fails: a retried command applies *)
+(*                             twice. (SyncExactlyOnce_nodedup.cfg)        *)
+(*   SafeEviction = FALSE  ->  AtMostOnce fails: a dedup entry evicted     *)
+(*                             (TTL) while a duplicate is still in flight  *)
+(*                             re-applies. The implementation's TTL must   *)
+(*                             exceed the client's maximum redelivery      *)
+(*                             window. (SyncExactlyOnce_earlyevict.cfg)    *)
+(*   LogSnapshots = FALSE  ->  ReplayReconstructs fails: the repair        *)
+(*                             sweep's snapshot commits bump seq and       *)
+(*                             re-anchor the projection, so a log that     *)
+(*                             only records control commands cannot        *)
+(*                             rebuild live state.                         *)
+(*                             (SyncExactlyOnce_nosnaplog.cfg)             *)
+(*                                                                         *)
+(* Abstractions: real time is a bounded counter in the store's clock       *)
+(* domain (redis TIME); media position is a small integer; the projection  *)
+(* pos + (now - anchor) mirrors projectMediaTime. Store epochs and         *)
+(* instance fencing are NOT modeled here - SyncActor.tla owns those; this  *)
+(* spec is single-epoch, and the composition note lives in FORMAL.md.      *)
+(***************************************************************************)
+EXTENDS Naturals, Sequences, FiniteSets
+
+CONSTANTS
+  Cmds,          \* command identities (client-minted UUIDs), e.g. {c1, c2}
+  Positions,     \* abstract commanded media positions, e.g. 0..1
+  MaxTime,       \* bound on the abstract clock
+  MaxSends,      \* per-command bound on channel insertions (issue+retry+dup)
+  DedupOn,       \* the store atomically checks-and-records command ids
+  SafeEviction,  \* dedup entries evicted only when no copy can still arrive
+  LogSnapshots   \* sweep commits are appended to the log
+
+Intents == {"play", "pause", "seek"}
+
+VARIABLES
+  now,        \* abstract store-domain clock
+  intentOf,   \* [Cmds -> Intents \cup {"unissued"}]: payload, fixed at issue
+  posOf,      \* [Cmds -> Positions \cup {0}]: commanded position
+  sends,      \* [Cmds -> Nat]: channel insertions so far (bounds the space)
+  chan,       \* [Cmds -> Nat]: copies in flight. A bag: delivery picks ANY
+              \* command with a copy pending, so reordering is inherent.
+  acked,      \* commands whose commit the client has observed (stops retry)
+  dedup,      \* ids the store remembers (the SET NX record)
+  applyCount, \* [Cmds -> Nat]: ground truth - how often each cmd applied
+  store,      \* [seq, playing, pos, anchor]
+  log         \* append-only sequence of committed transitions
+
+vars == <<now, intentOf, posOf, sends, chan, acked, dedup, applyCount,
+          store, log>>
+
+InitStore == [seq |-> 0, playing |-> FALSE, pos |-> 0, anchor |-> 0]
+
+(* projectMediaTime: where playback has advanced to at instant t. *)
+Projection(s, t) == IF s.playing THEN s.pos + (t - s.anchor) ELSE s.pos
+
+(* shared/sync-core/timeline.ts applyControl, abstracted. *)
+Apply(s, i, p, t) ==
+  IF i = "play"       THEN [seq |-> s.seq + 1, playing |-> TRUE,
+                            pos |-> p, anchor |-> t]
+  ELSE IF i = "pause" THEN [seq |-> s.seq + 1, playing |-> FALSE,
+                            pos |-> p, anchor |-> t]
+  ELSE                     [seq |-> s.seq + 1, playing |-> s.playing,
+                            pos |-> p, anchor |-> t]   \* seek
+
+(* shared/sync-core/timeline.ts snapshot: re-anchor without changing state. *)
+Snap(s, t) == [seq |-> s.seq + 1, playing |-> s.playing,
+               pos |-> Projection(s, t), anchor |-> t]
+
+CmdEntry(c, t) == [kind |-> "cmd", id |-> c, intent |-> intentOf[c],
+                   pos |-> posOf[c], t |-> t]
+SnapEntry(t) == [kind |-> "snap", t |-> t]
+
+ApplyEntry(s, e) ==
+  IF e.kind = "cmd" THEN Apply(s, e.intent, e.pos, e.t) ELSE Snap(s, e.t)
+
+RECURSIVE ReplayFrom(_, _)
+ReplayFrom(s, entries) ==
+  IF entries = << >> THEN s
+  ELSE ReplayFrom(ApplyEntry(s, Head(entries)), Tail(entries))
+
+(***************************************************************************)
+(* Actions                                                                 *)
+(***************************************************************************)
+
+Init ==
+  /\ now = 0
+  /\ intentOf = [c \in Cmds |-> "unissued"]
+  /\ posOf = [c \in Cmds |-> 0]
+  /\ sends = [c \in Cmds |-> 0]
+  /\ chan = [c \in Cmds |-> 0]
+  /\ acked = {}
+  /\ dedup = {}
+  /\ applyCount = [c \in Cmds |-> 0]
+  /\ store = InitStore
+  /\ log = << >>
+
+Tick ==
+  /\ now < MaxTime
+  /\ now' = now + 1
+  /\ UNCHANGED <<intentOf, posOf, sends, chan, acked, dedup, applyCount,
+                 store, log>>
+
+(* The client mints an id and sends: payload chosen once, fixed forever. *)
+Issue(c) ==
+  /\ intentOf[c] = "unissued"
+  /\ sends[c] < MaxSends
+  /\ \E i \in Intents, p \in Positions :
+       /\ intentOf' = [intentOf EXCEPT ![c] = i]
+       /\ posOf' = [posOf EXCEPT ![c] = p]
+  /\ sends' = [sends EXCEPT ![c] = @ + 1]
+  /\ chan' = [chan EXCEPT ![c] = @ + 1]
+  /\ UNCHANGED <<now, acked, dedup, applyCount, store, log>>
+
+(* The client has not observed the commit, so it sends the SAME command
+   again. This is the socket.io send-buffer flushing after a reconnect as
+   much as it is a deliberate retry - either way, at-least-once delivery,
+   and the origin of duplicates. *)
+Retry(c) ==
+  /\ intentOf[c] # "unissued"
+  /\ c \notin acked
+  /\ sends[c] < MaxSends
+  /\ sends' = [sends EXCEPT ![c] = @ + 1]
+  /\ chan' = [chan EXCEPT ![c] = @ + 1]
+  /\ UNCHANGED <<now, intentOf, posOf, acked, dedup, applyCount, store, log>>
+
+(* Infrastructure-level duplication of an in-flight copy. *)
+NetworkDup(c) ==
+  /\ chan[c] >= 1
+  /\ sends[c] < MaxSends
+  /\ sends' = [sends EXCEPT ![c] = @ + 1]
+  /\ chan' = [chan EXCEPT ![c] = @ + 1]
+  /\ UNCHANGED <<now, intentOf, posOf, acked, dedup, applyCount, store, log>>
+
+(* The store's apply script: ONE atomic step containing the dedup check,
+   the commit, the log append, and the dedup record - because in the
+   implementation all four live inside the same Lua script.  Delivery picks
+   any pending command, so reordering needs no extra machinery. *)
+Deliver(c) ==
+  /\ chan[c] >= 1
+  /\ chan' = [chan EXCEPT ![c] = @ - 1]
+  /\ IF DedupOn /\ c \in dedup
+     THEN \* duplicate: dropped by the guard, nothing else moves
+          UNCHANGED <<store, log, applyCount, dedup>>
+     ELSE /\ store' = Apply(store, intentOf[c], posOf[c], now)
+          /\ log' = Append(log, CmdEntry(c, now))
+          /\ applyCount' = [applyCount EXCEPT ![c] = @ + 1]
+          /\ dedup' = dedup \cup {c}
+  /\ UNCHANGED <<now, intentOf, posOf, sends, acked>>
+
+(* The client observes the committed broadcast (or the ack) and stops
+   retrying. Broadcast loss only delays this - Retry covers the gap. *)
+Ack(c) ==
+  /\ applyCount[c] >= 1
+  /\ c \notin acked
+  /\ acked' = acked \cup {c}
+  /\ UNCHANGED <<now, intentOf, posOf, sends, chan, dedup, applyCount,
+                 store, log>>
+
+(* A copy of c can still reach the store if one is in flight, or if the
+   client may still resend it. Eviction while that holds re-opens the
+   double-apply window - which is exactly what a TTL shorter than the
+   client's maximum redelivery window does in production. *)
+CanStillArrive(c) ==
+  \/ chan[c] >= 1
+  \/ (c \notin acked /\ sends[c] < MaxSends)
+
+Evict(c) ==
+  /\ c \in dedup
+  /\ SafeEviction => ~CanStillArrive(c)
+  /\ dedup' = dedup \ {c}
+  /\ UNCHANGED <<now, intentOf, posOf, sends, chan, acked, applyCount,
+                 store, log>>
+
+(* The repair sweep commits a re-anchored snapshot (seq+1). Whether it is
+   LOGGED is the design decision the nosnaplog config exists to test.
+   Guarded to at most one sweep per clock unit: the real sweep is periodic,
+   and an unguarded action would sweep unboundedly at a fixed instant,
+   making the state space infinite without adding any behavior - a
+   re-anchor at an unchanged clock is the identity on the projection. *)
+Sweep ==
+  /\ store.playing = TRUE
+  /\ store.anchor # now
+  /\ store' = Snap(store, now)
+  /\ log' = IF LogSnapshots THEN Append(log, SnapEntry(now)) ELSE log
+  /\ UNCHANGED <<now, intentOf, posOf, sends, chan, acked, dedup,
+                 applyCount>>
+
+Next ==
+  \/ Tick
+  \/ Sweep
+  \/ \E c \in Cmds : Issue(c) \/ Retry(c) \/ NetworkDup(c) \/ Deliver(c)
+                     \/ Ack(c) \/ Evict(c)
+
+Spec == Init /\ [][Next]_vars
+             /\ \A c \in Cmds : WF_vars(Deliver(c)) /\ WF_vars(Ack(c))
+
+(***************************************************************************)
+(* Invariants                                                              *)
+(***************************************************************************)
+
+TypeOK ==
+  /\ now \in 0..MaxTime
+  /\ intentOf \in [Cmds -> Intents \cup {"unissued"}]
+  /\ posOf \in [Cmds -> Positions \cup {0}]
+  /\ sends \in [Cmds -> 0..MaxSends]
+  /\ chan \in [Cmds -> 0..MaxSends]
+  /\ acked \subseteq Cmds
+  /\ dedup \subseteq Cmds
+  /\ applyCount \in [Cmds -> 0..MaxSends]
+  /\ store \in [seq : Nat, playing : BOOLEAN, pos : Nat, anchor : 0..MaxTime]
+  /\ Len(log) <= store.seq
+
+(* THE exactly-once safety property: no command applies twice. *)
+AtMostOnce == \A c \in Cmds : applyCount[c] <= 1
+
+(* Every logged transition obeys its intent's contract. Contract is written
+   INDEPENDENTLY of Apply/Snap - double-entry bookkeeping: if either side
+   drifts (a seek that flips playing, a snapshot that moves the projection),
+   TLC reports the disagreement. *)
+Contract(pre, e, post) ==
+  /\ post.seq = pre.seq + 1
+  /\ post.anchor = e.t
+  /\ IF e.kind = "snap"
+     THEN /\ post.playing = pre.playing
+          /\ post.pos = Projection(pre, e.t)   \* re-anchor moves nothing
+     ELSE IF e.intent = "play"  THEN post.playing /\ post.pos = e.pos
+     ELSE IF e.intent = "pause" THEN ~post.playing /\ post.pos = e.pos
+     ELSE (* seek *) post.playing = pre.playing /\ post.pos = e.pos
+
+RECURSIVE ContractHoldsFrom(_, _)
+ContractHoldsFrom(s, entries) ==
+  IF entries = << >> THEN TRUE
+  ELSE /\ Contract(s, Head(entries), ApplyEntry(s, Head(entries)))
+       /\ ContractHoldsFrom(ApplyEntry(s, Head(entries)), Tail(entries))
+
+TransitionContract == ContractHoldsFrom(InitStore, log)
+
+(* Folding the log from the initial state reproduces live state exactly. *)
+ReplayReconstructs == ReplayFrom(InitStore, log) = store
+
+(* Bookkeeping consistency: an acked command was applied; with the guard on
+   and no eviction possible yet, applied commands are remembered. *)
+AckedWasApplied == \A c \in acked : applyCount[c] >= 1
+
+(***************************************************************************)
+(* Liveness: every issued command is eventually applied exactly once and   *)
+(* the client learns it. Holds only with the guard on and safe eviction.   *)
+(***************************************************************************)
+EventuallyExactlyOnce ==
+  \A c \in Cmds :
+    (intentOf[c] # "unissued") ~> (applyCount[c] = 1 /\ c \in acked)
+
+===============================================================================

--- a/formal/SyncExactlyOnce.tla
+++ b/formal/SyncExactlyOnce.tla
@@ -16,13 +16,17 @@
 (* Three switches make the spec keep its teeth - each OFF position is a    *)
 (* committed config whose named failure pins a real design constraint:     *)
 (*                                                                         *)
-(*   DedupOn      = FALSE  ->  AtMostOnce fails: a retried command applies *)
+(*   DedupOn = FALSE       ->  AtMostOnce fails: a retried command applies *)
 (*                             twice. (SyncExactlyOnce_nodedup.cfg)        *)
-(*   SafeEviction = FALSE  ->  AtMostOnce fails: a dedup entry evicted     *)
-(*                             (TTL) while a duplicate is still in flight  *)
-(*                             re-applies. The implementation's TTL must   *)
-(*                             exceed the client's maximum redelivery      *)
-(*                             window. (SyncExactlyOnce_earlyevict.cfg)    *)
+(*   Ttl <= RetryWindow    ->  AtMostOnce fails: a dedup entry expires     *)
+(*                             while a copy can still arrive, and the      *)
+(*                             late duplicate re-applies. The TTL and the  *)
+(*                             client's retry deadline are modeled as      *)
+(*                             CONCRETE clock bounds, so the proof is the  *)
+(*                             time relation itself: Ttl > RetryWindow is  *)
+(*                             checked green, Ttl <= RetryWindow is a      *)
+(*                             committed counterexample.                   *)
+(*                             (SyncExactlyOnce_earlyevict.cfg)            *)
 (*   LogSnapshots = FALSE  ->  ReplayReconstructs fails: the repair        *)
 (*                             sweep's snapshot commits bump seq and       *)
 (*                             re-anchor the projection, so a log that     *)
@@ -44,7 +48,11 @@ CONSTANTS
   MaxTime,       \* bound on the abstract clock
   MaxSends,      \* per-command bound on channel insertions (issue+retry+dup)
   DedupOn,       \* the store atomically checks-and-records command ids
-  SafeEviction,  \* dedup entries evicted only when no copy can still arrive
+  Ttl,           \* clock units a dedup record lives after the apply
+  RetryWindow,   \* clock units after ISSUE during which a copy can still
+                 \* be (re)sent or delivered - the client abandons unacked
+                 \* commands past this deadline, which is what makes any
+                 \* finite TTL sound at all
   LogSnapshots   \* sweep commits are appended to the log
 
 Intents == {"play", "pause", "seek"}
@@ -57,13 +65,15 @@ VARIABLES
   chan,       \* [Cmds -> Nat]: copies in flight. A bag: delivery picks ANY
               \* command with a copy pending, so reordering is inherent.
   acked,      \* commands whose commit the client has observed (stops retry)
+  issuedAt,   \* [Cmds -> 0..MaxTime]: when the command was first sent
   dedup,      \* ids the store remembers (the SET NX record)
+  evictAt,    \* [Cmds -> Nat]: when c's dedup record expires (apply + Ttl)
   applyCount, \* [Cmds -> Nat]: ground truth - how often each cmd applied
   store,      \* [seq, playing, pos, anchor]
   log         \* append-only sequence of committed transitions
 
-vars == <<now, intentOf, posOf, sends, chan, acked, dedup, applyCount,
-          store, log>>
+vars == <<now, intentOf, posOf, sends, chan, acked, issuedAt, dedup, evictAt,
+          applyCount, store, log>>
 
 InitStore == [seq |-> 0, playing |-> FALSE, pos |-> 0, anchor |-> 0]
 
@@ -106,7 +116,9 @@ Init ==
   /\ sends = [c \in Cmds |-> 0]
   /\ chan = [c \in Cmds |-> 0]
   /\ acked = {}
+  /\ issuedAt = [c \in Cmds |-> 0]
   /\ dedup = {}
+  /\ evictAt = [c \in Cmds |-> 0]
   /\ applyCount = [c \in Cmds |-> 0]
   /\ store = InitStore
   /\ log = << >>
@@ -114,8 +126,8 @@ Init ==
 Tick ==
   /\ now < MaxTime
   /\ now' = now + 1
-  /\ UNCHANGED <<intentOf, posOf, sends, chan, acked, dedup, applyCount,
-                 store, log>>
+  /\ UNCHANGED <<intentOf, posOf, sends, chan, acked, issuedAt, dedup,
+                 evictAt, applyCount, store, log>>
 
 (* The client mints an id and sends: payload chosen once, fixed forever. *)
 Issue(c) ==
@@ -124,9 +136,10 @@ Issue(c) ==
   /\ \E i \in Intents, p \in Positions :
        /\ intentOf' = [intentOf EXCEPT ![c] = i]
        /\ posOf' = [posOf EXCEPT ![c] = p]
+  /\ issuedAt' = [issuedAt EXCEPT ![c] = now]
   /\ sends' = [sends EXCEPT ![c] = @ + 1]
   /\ chan' = [chan EXCEPT ![c] = @ + 1]
-  /\ UNCHANGED <<now, acked, dedup, applyCount, store, log>>
+  /\ UNCHANGED <<now, acked, dedup, evictAt, applyCount, store, log>>
 
 (* The client has not observed the commit, so it sends the SAME command
    again. This is the socket.io send-buffer flushing after a reconnect as
@@ -135,34 +148,46 @@ Issue(c) ==
 Retry(c) ==
   /\ intentOf[c] # "unissued"
   /\ c \notin acked
+  /\ now <= issuedAt[c] + RetryWindow
   /\ sends[c] < MaxSends
   /\ sends' = [sends EXCEPT ![c] = @ + 1]
   /\ chan' = [chan EXCEPT ![c] = @ + 1]
-  /\ UNCHANGED <<now, intentOf, posOf, acked, dedup, applyCount, store, log>>
+  /\ UNCHANGED <<now, intentOf, posOf, acked, issuedAt, dedup, evictAt,
+                 applyCount, store, log>>
 
 (* Infrastructure-level duplication of an in-flight copy. *)
 NetworkDup(c) ==
   /\ chan[c] >= 1
+  /\ now <= issuedAt[c] + RetryWindow
   /\ sends[c] < MaxSends
   /\ sends' = [sends EXCEPT ![c] = @ + 1]
   /\ chan' = [chan EXCEPT ![c] = @ + 1]
-  /\ UNCHANGED <<now, intentOf, posOf, acked, dedup, applyCount, store, log>>
+  /\ UNCHANGED <<now, intentOf, posOf, acked, issuedAt, dedup, evictAt,
+                 applyCount, store, log>>
 
 (* The store's apply script: ONE atomic step containing the dedup check,
    the commit, the log append, and the dedup record - because in the
    implementation all four live inside the same Lua script.  Delivery picks
    any pending command, so reordering needs no extra machinery. *)
+(* Delivery is bounded by the same window: past the client's retry
+   deadline nothing carries the command any more - the send buffer died
+   with the page, the connection is gone. This is the assumption that
+   makes any finite TTL sound; the implementation must ENFORCE it by
+   abandoning unacked commands older than the window rather than letting
+   an arbitrarily old buffer flush. *)
 Deliver(c) ==
   /\ chan[c] >= 1
+  /\ now <= issuedAt[c] + RetryWindow
   /\ chan' = [chan EXCEPT ![c] = @ - 1]
   /\ IF DedupOn /\ c \in dedup
      THEN \* duplicate: dropped by the guard, nothing else moves
-          UNCHANGED <<store, log, applyCount, dedup>>
+          UNCHANGED <<store, log, applyCount, dedup, evictAt>>
      ELSE /\ store' = Apply(store, intentOf[c], posOf[c], now)
           /\ log' = Append(log, CmdEntry(c, now))
           /\ applyCount' = [applyCount EXCEPT ![c] = @ + 1]
           /\ dedup' = dedup \cup {c}
-  /\ UNCHANGED <<now, intentOf, posOf, sends, acked>>
+          /\ evictAt' = [evictAt EXCEPT ![c] = now + Ttl]
+  /\ UNCHANGED <<now, intentOf, posOf, sends, acked, issuedAt>>
 
 (* The client observes the committed broadcast (or the ack) and stops
    retrying. Broadcast loss only delays this - Retry covers the gap. *)
@@ -170,23 +195,19 @@ Ack(c) ==
   /\ applyCount[c] >= 1
   /\ c \notin acked
   /\ acked' = acked \cup {c}
-  /\ UNCHANGED <<now, intentOf, posOf, sends, chan, dedup, applyCount,
-                 store, log>>
+  /\ UNCHANGED <<now, intentOf, posOf, sends, chan, issuedAt, dedup,
+                 evictAt, applyCount, store, log>>
 
-(* A copy of c can still reach the store if one is in flight, or if the
-   client may still resend it. Eviction while that holds re-opens the
-   double-apply window - which is exactly what a TTL shorter than the
-   client's maximum redelivery window does in production. *)
-CanStillArrive(c) ==
-  \/ chan[c] >= 1
-  \/ (c \notin acked /\ sends[c] < MaxSends)
-
+(* The dedup record expires Ttl units after the apply - a plain clock,
+   exactly what SET .. PX gives the implementation, with no oracle about
+   in-flight copies. Whether this is safe is precisely the Ttl-vs-
+   RetryWindow relation the configs check. *)
 Evict(c) ==
   /\ c \in dedup
-  /\ SafeEviction => ~CanStillArrive(c)
+  /\ now >= evictAt[c]
   /\ dedup' = dedup \ {c}
-  /\ UNCHANGED <<now, intentOf, posOf, sends, chan, acked, applyCount,
-                 store, log>>
+  /\ UNCHANGED <<now, intentOf, posOf, sends, chan, acked, issuedAt,
+                 evictAt, applyCount, store, log>>
 
 (* The repair sweep commits a re-anchored snapshot (seq+1). Whether it is
    LOGGED is the design decision the nosnaplog config exists to test.
@@ -199,8 +220,8 @@ Sweep ==
   /\ store.anchor # now
   /\ store' = Snap(store, now)
   /\ log' = IF LogSnapshots THEN Append(log, SnapEntry(now)) ELSE log
-  /\ UNCHANGED <<now, intentOf, posOf, sends, chan, acked, dedup,
-                 applyCount>>
+  /\ UNCHANGED <<now, intentOf, posOf, sends, chan, acked, issuedAt,
+                 dedup, evictAt, applyCount>>
 
 Next ==
   \/ Tick
@@ -222,7 +243,9 @@ TypeOK ==
   /\ sends \in [Cmds -> 0..MaxSends]
   /\ chan \in [Cmds -> 0..MaxSends]
   /\ acked \subseteq Cmds
+  /\ issuedAt \in [Cmds -> 0..MaxTime]
   /\ dedup \subseteq Cmds
+  /\ evictAt \in [Cmds -> 0..(MaxTime + Ttl)]
   /\ applyCount \in [Cmds -> 0..MaxSends]
   /\ store \in [seq : Nat, playing : BOOLEAN, pos : Nat, anchor : 0..MaxTime]
   /\ Len(log) <= store.seq

--- a/formal/SyncExactlyOnce_earlyevict.cfg
+++ b/formal/SyncExactlyOnce_earlyevict.cfg
@@ -1,18 +1,19 @@
-\* Dedup ON but entries may be evicted while a duplicate is still in
-\* flight - a TTL shorter than the client's redelivery window. MUST fail:
-\* this config is the proof that the TTL is a correctness parameter.
+\* Dedup ON but Ttl <= RetryWindow: the record expires while a copy can
+\* still arrive, and the late duplicate re-applies. MUST fail - this
+\* config is the proof that the TTL is a correctness parameter whose
+\* value is constrained by the client's retry deadline.
 SPECIFICATION Spec
 CONSTANTS
   Cmds = {c1, c2}
   Positions = {0, 1}
-  MaxTime = 2
+  MaxTime = 3
   MaxSends = 2
   DedupOn = TRUE
-  SafeEviction = FALSE
+  Ttl = 1
+  RetryWindow = 2
   LogSnapshots = TRUE
 INVARIANTS
   TypeOK
   AtMostOnce
 
-\* bounded model: exhausted counters produce terminal states by design
 CHECK_DEADLOCK FALSE

--- a/formal/SyncExactlyOnce_earlyevict.cfg
+++ b/formal/SyncExactlyOnce_earlyevict.cfg
@@ -1,0 +1,18 @@
+\* Dedup ON but entries may be evicted while a duplicate is still in
+\* flight - a TTL shorter than the client's redelivery window. MUST fail:
+\* this config is the proof that the TTL is a correctness parameter.
+SPECIFICATION Spec
+CONSTANTS
+  Cmds = {c1, c2}
+  Positions = {0, 1}
+  MaxTime = 2
+  MaxSends = 2
+  DedupOn = TRUE
+  SafeEviction = FALSE
+  LogSnapshots = TRUE
+INVARIANTS
+  TypeOK
+  AtMostOnce
+
+\* bounded model: exhausted counters produce terminal states by design
+CHECK_DEADLOCK FALSE

--- a/formal/SyncExactlyOnce_live.cfg
+++ b/formal/SyncExactlyOnce_live.cfg
@@ -1,0 +1,22 @@
+\* Liveness: every issued command is eventually applied exactly once and
+\* acked. The retry window spans the whole model clock here because a
+\* window that closes mid-model legitimately abandons an unacked command -
+\* that is at-most-once by design, not a liveness bug - so liveness is
+\* meaningful only while the client is still trying.
+SPECIFICATION Spec
+CONSTANTS
+  Cmds = {c1, c2}
+  Positions = {0, 1}
+  MaxTime = 2
+  MaxSends = 2
+  DedupOn = TRUE
+  Ttl = 3
+  RetryWindow = 2
+  LogSnapshots = TRUE
+INVARIANTS
+  TypeOK
+  AtMostOnce
+PROPERTIES
+  EventuallyExactlyOnce
+
+CHECK_DEADLOCK FALSE

--- a/formal/SyncExactlyOnce_nodedup.cfg
+++ b/formal/SyncExactlyOnce_nodedup.cfg
@@ -1,0 +1,17 @@
+\* No dedup guard: a retried command MUST be shown to double-apply.
+\* The nightly asserts this config FAILS - the spec keeping its teeth.
+SPECIFICATION Spec
+CONSTANTS
+  Cmds = {c1, c2}
+  Positions = {0, 1}
+  MaxTime = 2
+  MaxSends = 2
+  DedupOn = FALSE
+  SafeEviction = TRUE
+  LogSnapshots = TRUE
+INVARIANTS
+  TypeOK
+  AtMostOnce
+
+\* bounded model: exhausted counters produce terminal states by design
+CHECK_DEADLOCK FALSE

--- a/formal/SyncExactlyOnce_nodedup.cfg
+++ b/formal/SyncExactlyOnce_nodedup.cfg
@@ -7,11 +7,11 @@ CONSTANTS
   MaxTime = 2
   MaxSends = 2
   DedupOn = FALSE
-  SafeEviction = TRUE
+  Ttl = 3
+  RetryWindow = 2
   LogSnapshots = TRUE
 INVARIANTS
   TypeOK
   AtMostOnce
 
-\* bounded model: exhausted counters produce terminal states by design
 CHECK_DEADLOCK FALSE

--- a/formal/SyncExactlyOnce_nosnaplog.cfg
+++ b/formal/SyncExactlyOnce_nosnaplog.cfg
@@ -1,0 +1,18 @@
+\* Log records control commands but not the repair sweep's snapshot
+\* commits. MUST fail ReplayReconstructs: sweeps bump seq and re-anchor
+\* the projection, so an incomplete log cannot rebuild live state.
+SPECIFICATION Spec
+CONSTANTS
+  Cmds = {c1, c2}
+  Positions = {0, 1}
+  MaxTime = 2
+  MaxSends = 2
+  DedupOn = TRUE
+  SafeEviction = TRUE
+  LogSnapshots = FALSE
+INVARIANTS
+  TypeOK
+  ReplayReconstructs
+
+\* bounded model: exhausted counters produce terminal states by design
+CHECK_DEADLOCK FALSE

--- a/formal/SyncExactlyOnce_nosnaplog.cfg
+++ b/formal/SyncExactlyOnce_nosnaplog.cfg
@@ -8,11 +8,11 @@ CONSTANTS
   MaxTime = 2
   MaxSends = 2
   DedupOn = TRUE
-  SafeEviction = TRUE
+  Ttl = 3
+  RetryWindow = 2
   LogSnapshots = FALSE
 INVARIANTS
   TypeOK
   ReplayReconstructs
 
-\* bounded model: exhausted counters produce terminal states by design
 CHECK_DEADLOCK FALSE


### PR DESCRIPTION
Item 1 of the exactly-once roadmap, in the established order: the spec
constrains the implementation before the implementation exists.

`formal/SyncExactlyOnce.tla` models client-minted command ids, retry-until-
acked delivery (at-least-once — a socket.io send-buffer flush after reconnect
*is* a retry), outright channel duplication, arbitrary reordering, an
atomically-composed apply step (dedup check + commit + log append + dedup
record, one Lua script), dedup eviction (TTL), and the repair sweep's
snapshot commits.

**Green** (`SyncExactlyOnce.cfg`, 281,111 states / 98,103 distinct / depth 17):
`AtMostOnce`, `TransitionContract`, `ReplayReconstructs`, `AckedWasApplied`,
`TypeOK`, and liveness `EventuallyExactlyOnce`.

**Three must-fail configs** keep the teeth, each pinning an implementation
constraint:

| config | fails | constraint it pins |
|---|---|---|
| `_nodedup` | `AtMostOnce` | dedup must be atomic with the commit, inside the Lua script |
| `_earlyevict` | `AtMostOnce` | the dedup TTL must exceed the client's max redelivery window — a correctness parameter, not a tuning knob |
| `_nosnaplog` | `ReplayReconstructs` | the command log must include sweep commits, or replay reports phantom drift |

`TransitionContract` is double-entry bookkeeping — the legal-transition
contract is written independently of `Apply`/`Snap`, so either side drifting
makes TLC report the disagreement rather than trusting the model's own
construction.

The nightly TLC job now asserts the green config passes **and** all three
degraded configs still fail on their named properties, same pattern as
`SyncTimeline_naive`.

Scouting for the implementation (next PR) found the duplication paths are
real today, not hypothetical: ioredis resends an EVAL whose reply was lost
(`autoResendUnfulfilledCommands` defaults true), running `apply_control.lua`
twice; and the actor plane's forward PUBLISH rides the pubsub client with
unlimited resends — a full double-apply with double broadcast. Those fixes
land with the idempotency keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a formal model for exactly-once command application, covering retries, duplicate delivery, reordering, deduplication, eviction, and replay.
  * Added verification configurations for standard and intentionally degraded scenarios.

* **Documentation**
  * Documented exactly-once guarantees, safety and liveness properties, implementation constraints, and composition boundaries.

* **Tests**
  * Nightly validation now confirms the standard configuration succeeds while configurations without deduplication, with unsafe eviction, or without snapshot logging fail as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->