### PR TITLE
feat: idempotency keys on every control command

### DIFF
--- a/docs/COORDINATION.md
+++ b/docs/COORDINATION.md
@@ -81,6 +81,19 @@ classes of duplicated work that a shared-store plane has to notice and
 patch one at a time. Recorded because the A/B's conclusion would otherwise
 read as more settled than one single-instance test can make it.
 
+## Idempotency across handoff
+
+The exactly-once work (SYNC_DESIGN §2a) has one plane-B-specific obligation:
+the dedup record must survive an owner change. seq restarts when the fence
+advances, so `(epoch, seq)` cannot identify a command across handoff — the
+`cmdId` record can, because it is keyed fence-independently and lives in
+Redis rather than owner memory. The check sits inside `actor_commit.lua`'s
+fenced atomic step, and a duplicate is answered with current state rather
+than `false` — `false` means fenced-out, and the caller drops ownership on
+it. A command applied by the old owner, redelivered to the new owner via
+the (redeliverable) forward channel, is answered as a duplicate; the spec
+test pins it.
+
 ## Two bugs the implementation surfaced
 
 1. **Non-atomic init.** 25 concurrent joins each passed a "no state yet"

--- a/docs/RELAY.md
+++ b/docs/RELAY.md
@@ -18,6 +18,12 @@ JWT auth) runs against either plane via a transport abstraction
 | node / Socket.IO / JSON | 73ms | 115ms | 0 | pass |
 | relay-go / raw WS / binary | 75ms | 116ms | 0 | pass |
 
+The control frame carries an optional idempotency key appended after the
+room (`[cmdLen u8][cmdId...]`; old frames end at the room and stay
+decodable). The relay passes it into the same `apply_control.lua`, so both
+planes dedup identically — verified by the `--dup-controls` conformance run
+(4 injected duplicates, 0 double-applies, on this plane's binary framing).
+
 *(10 bots × 120s each, re-measured after the simulated-player fix described
 in `docs/SYNC_DESIGN.md` §8. **[lab]** — these two fleet runs were not
 committed; the table is reproducible from the harness, not citable.)*

--- a/docs/RELAY.md
+++ b/docs/RELAY.md
@@ -59,7 +59,7 @@ discipline of proving the protocol implementation-independent.
 |---|---|---|
 | C→S | 0x01 ClockPing | `t0 f64` |
 | S→C | 0x02 ClockPong | `t0 f64, t1 f64, t2 f64` |
-| C→S | 0x03 Control | `intent u8, mediaTime f64, roomLen u8, room…` |
+| C→S | 0x03 Control | `intent u8, mediaTime f64, roomLen u8, room…[, cmdLen u8, cmdId…]` |
 | S→C | 0x04 Timeline | `seq u32, epoch f64, isPlaying u8, mediaTime f64, stampedAt f64, reason u8` |
 | C→S | 0x05 Join | `roomLen u8, room…` |
 | S→C | 0x06 JoinAck | Timeline payload |

--- a/docs/SYNC_DESIGN.md
+++ b/docs/SYNC_DESIGN.md
@@ -60,6 +60,57 @@ inter-instance wall-clock skew cannot masquerade as playback drift (measured
 ack-offset spread across 3 live instances: **4ms** **[lab]**, from
 `verify-m6.ts`, which gates it on the console rather than writing a run).
 
+## 2a. Idempotent control commands (exactly-once application)
+
+Every control carries a client-minted UUID (`cmdId`), and the store applies
+each id **at most once** — Stripe's idempotency-key model, applied to
+playback control. The check-and-record is a `SET NX PX` executed *inside the
+same Lua script as the commit*, so check, apply, log and record are one
+atomic step; a split across two round trips would reintroduce the race the
+guard closes (`formal/SyncExactlyOnce.tla`, which was written first and
+constrains this design). A duplicate is answered with the **current**
+committed timeline, targeted at the sender only — the re-anchor a retrying
+client is waiting for — and never re-broadcast, because the original commit
+already was.
+
+This is a bug fix, not decoration. Two real double-apply paths existed:
+
+- **ioredis resends an EVAL whose reply was lost.** The KV client's
+  `autoResendUnfulfilledCommands` default means a dropped Redis connection
+  after execution but before the reply re-runs `apply_control.lua` on
+  reconnect: seq burned twice, the room's projection re-anchored at the
+  later `redis TIME`. With the dedup record, the resend is answered as a
+  duplicate — the resend machinery becomes *safe* instead of disabled.
+- **The actor plane's forward publish can be redelivered** (the pubsub
+  client resends without limit), running the owner's commit-and-broadcast
+  twice for one user command. The forward now carries the `cmdId`, and the
+  owner's fenced commit dedupes it.
+
+**The TTL is a correctness parameter, not a tuning knob** (the spec's
+`earlyevict` config is the counterexample): the record must outlive the
+longest window in which a copy can still arrive. The client bounds that
+window structurally — a control is emitted **only on a live connection,
+never buffered**, so a reconnect cannot flush an arbitrarily old command; a
+dropped gesture is visible (nothing happens; pressing again mints a NEW
+command with a new id, which is a second command, not a duplicate). The
+residual redelivery sources are both seconds-scale; the TTL is 15 minutes.
+
+On the actor plane the dedup record is **fence-independent and lives in
+Redis**, not owner memory: seq restarts when the fence advances, so
+`(epoch, seq)` cannot identify a command across an owner handoff — but the
+cmd record can, and a command applied by the old owner is answered as a
+duplicate by the new one (`actor-room-state.store.spec.ts` pins this).
+
+Proven end-to-end by injection, since netem-level duplication cannot test
+it — TCP dedupes its own segments, so transport toxics never produce an
+app-level duplicate. The bot fleet's `--dup-controls` mode sends every
+control twice with the same `cmdId`: 25 bots on the 3-instance lab measured
+**4 injected duplicates, 4 `control_dedup_hits_total` on the servers, zero
+seq gaps**; the same run on the relay plane (binary frames) confirms
+cross-language conformance (committed under
+`docs/measurements/exactly-once/`). Legacy clients without a `cmdId` keep
+the old semantics — the field is optional on the wire.
+
 ## 3. Clock sync
 
 NTP-style over a Socket.IO ack: client stamps t0/t3, the server ack carries

--- a/docs/SYNC_DESIGN.md
+++ b/docs/SYNC_DESIGN.md
@@ -62,8 +62,9 @@ ack-offset spread across 3 live instances: **4ms** **[lab]**, from
 
 ## 2a. Idempotent control commands (exactly-once application)
 
-Every control carries a client-minted UUID (`cmdId`), and the store applies
-each id **at most once** — Stripe's idempotency-key model, applied to
+Every control from a current client carries a client-minted UUID (`cmdId` —
+optional on the wire, so legacy clients that omit it keep the old
+non-deduped semantics), and the store applies each id **at most once** — Stripe's idempotency-key model, applied to
 playback control. The check-and-record is a `SET NX PX` executed *inside the
 same Lua script as the commit*, so check, apply, log and record are one
 atomic step; a split across two round trips would reintroduce the race the
@@ -205,8 +206,9 @@ threshold and then seeking.
 ## 6. Protocol
 
 Five events: `sync:clock` (ack: `{t0}`→`{t0,t1,t2}`), `sync:control`
-(`{roomCode, intent, mediaTime}`; identity comes only from the JWT-verified
-socket), `sync:timeline` (the only state message), `sync:control-rejected`
+(`{roomCode, intent, mediaTime, cmdId?}` — the optional idempotency key of
+§2a; identity comes only from the JWT-verified socket), `sync:timeline`
+(the only state message), `sync:control-rejected`
 (`not-controller` / `rate-limited` / `room-not-found`), `room:controller`
 (succession/reclaim). A 10s server sweep re-anchors playing rooms as the
 repair channel for lost broadcasts; redundancy is harmless because clients

--- a/docs/measurements/exactly-once/README.md
+++ b/docs/measurements/exactly-once/README.md
@@ -1,0 +1,30 @@
+# Exactly-once: duplicate-injection proof runs
+
+The idempotency-key design (SYNC_DESIGN §2a, `formal/SyncExactlyOnce.tla`)
+proven end-to-end by **app-level injection**: the bot fleet's
+`--dup-controls` mode sends every scripted control **twice with the same
+`cmdId`**. Injection is the only honest way to test this — netem's
+`duplicate` toxic copies TCP segments, which TCP itself dedupes, so no
+transport toxic can ever produce an application-level duplicate.
+
+| run | plane | bots | injected dups | seq gaps | dups absorbed |
+|---|---|---|---|---|---|
+| `node-25bots-dup-injection.json` | node / 3-instance lab / nginx | 25 | 4 | **0** | 4 |
+| `relay-5bots-dup-injection.json` | relay-go / raw-WS binary | 5 | 4 | **0** | 4 |
+
+What "absorbed" means, per plane:
+
+- **node**: the servers' `control_dedup_hits_total` advanced by exactly 4
+  during the run (scraped from the instance that held the commanding
+  sockets), and no phantom seq appeared — `seqGaps: 0` with the reorder and
+  duplicate counters showing only the expected local re-anchor traffic.
+- **relay**: each duplicate was answered as a targeted re-anchor carrying
+  the already-committed seq (`seqDuplicates: 4` on a single-instance plane
+  that otherwise produces none), through the extended binary control frame
+  — same Lua, same dedup, cross-language.
+
+Both summaries carry `gitSha` (clean — the stamp appends `-dirty` when the
+tree does not match) and hardware. A failed double-apply would surface as a
+phantom seq: a commit consumed by the duplicate that the room's clients
+observe as a gap. Before this design, the ioredis resend path produced
+exactly those (see SYNC_DESIGN §2a).

--- a/docs/measurements/exactly-once/node-25bots-dup-injection.json
+++ b/docs/measurements/exactly-once/node-25bots-dup-injection.json
@@ -1,0 +1,25 @@
+{
+  "runId": "bots-msi2kh3g",
+  "gitSha": "950fae7acd340479997dc94b844033545c24dbe4",
+  "hardware": "10 cores (Apple M2 Pro)",
+  "controller": "reactive",
+  "plane": "node",
+  "n": 25,
+  "durationS": 90,
+  "steadySamples": 5874,
+  "driftMs": {
+    "p50": 72.26494206048528,
+    "p95": 157.84846107209205,
+    "p99": 315.80967053429276
+  },
+  "slopeMsPerMin": 0,
+  "thetaErrorP95Ms": 6.298095703125,
+  "seqGaps": 0,
+  "seqReorders": 0,
+  "seqDuplicates": 166,
+  "reconnects": 0,
+  "rejoinFailures": 0,
+  "dupControlsSent": 4,
+  "handlerErrors": 0,
+  "rejectedControls": 0
+}

--- a/docs/measurements/exactly-once/relay-5bots-dup-injection.json
+++ b/docs/measurements/exactly-once/relay-5bots-dup-injection.json
@@ -1,0 +1,25 @@
+{
+  "runId": "bots-msi2n4p3",
+  "gitSha": "950fae7acd340479997dc94b844033545c24dbe4",
+  "hardware": "10 cores (Apple M2 Pro)",
+  "controller": "reactive",
+  "plane": "relay",
+  "n": 5,
+  "durationS": 60,
+  "steadySamples": 576,
+  "driftMs": {
+    "p50": 90.88685245618677,
+    "p95": 149.16698927765992,
+    "p99": 346.3328149505287
+  },
+  "slopeMsPerMin": 0,
+  "thetaErrorP95Ms": 1.92822265625,
+  "seqGaps": 0,
+  "seqReorders": 0,
+  "seqDuplicates": 4,
+  "reconnects": 0,
+  "rejoinFailures": 0,
+  "dupControlsSent": 4,
+  "handlerErrors": 0,
+  "rejectedControls": 0
+}

--- a/relay-go/main.go
+++ b/relay-go/main.go
@@ -31,6 +31,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"regexp"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -58,6 +59,10 @@ var reasonCodes = map[string]uint8{
 // parameter (formal/SyncExactlyOnce.tla earlyevict), far above every
 // redelivery window in this system
 const cmdDedupTTLMS = 15 * 60 * 1000
+
+// mirror of the Node gateway's cmdId validation: bounded, separator-free,
+// so the derived room:<room>:cmd:<cmdId> key cannot alias another keyspace
+var cmdIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
 
 type luaTimeline struct {
 	Seq        int     `json:"seq"`
@@ -316,6 +321,14 @@ func (s *server) handle(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 				cmdId = string(data[12+n : 12+n+cl])
+				// same charset the Node gateway enforces. Without it a cmdId
+				// containing ':' makes room:<room>:cmd:<cmdId> collide with
+				// OTHER keys (room "a" + cmd "b:tl" aliases the timeline of
+				// room "a:cmd:b"), and the SET NX against a hash would fail
+				// the whole script with WRONGTYPE
+				if !cmdIDPattern.MatchString(cmdId) {
+					continue
+				}
 			}
 			raw, ok := luaString(s.applyControl.Run(ctx, s.rdb,
 				[]string{"room:" + room + ":tl", "room:" + room + ":cmd:" + cmdId},

--- a/relay-go/main.go
+++ b/relay-go/main.go
@@ -13,7 +13,8 @@
 // Binary frames (little-endian):
 //   C→S 0x01 ClockPing   [t0 f64]
 //   S→C 0x02 ClockPong   [t0 f64][t1 f64][t2 f64]
-//   C→S 0x03 Control     [intent u8][mediaTime f64][roomLen u8][room...]
+//   C→S 0x03 Control     [intent u8][mediaTime f64][roomLen u8][room...][cmdLen u8][cmdId...]
+//                          (cmdLen+cmdId optional - old frames end at room)
 //   S→C 0x04 Timeline    [seq u32][epoch f64][isPlaying u8][mediaTime f64][stampedAt f64][reason u8]
 //   C→S 0x05 Join        [roomLen u8][room...]
 //   S→C 0x06 JoinAck     (Timeline payload)
@@ -53,6 +54,11 @@ var reasonCodes = map[string]uint8{
 	"play": 0, "pause": 1, "seek": 2, "join": 3, "snapshot": 4, "succession": 5,
 }
 
+// mirror of CMD_DEDUP_TTL_MS in room-state.store.ts: a correctness
+// parameter (formal/SyncExactlyOnce.tla earlyevict), far above every
+// redelivery window in this system
+const cmdDedupTTLMS = 15 * 60 * 1000
+
 type luaTimeline struct {
 	Seq        int     `json:"seq"`
 	StoreEpoch string  `json:"storeEpoch"`
@@ -60,6 +66,9 @@ type luaTimeline struct {
 	MediaTime  float64 `json:"mediaTime"`
 	StampedAt  float64 `json:"stampedAt"`
 	Reason     string  `json:"reason"`
+	// set by apply_control.lua when the cmdId was already applied: answer
+	// the sender only, never rebroadcast
+	Dup bool `json:"dup"`
 }
 
 func (t luaTimeline) toWire() timeline {
@@ -298,9 +307,20 @@ func (s *server) handle(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			room := string(data[11 : 11+n])
+			// optional idempotency key: absent on old frames, bounded like
+			// the Node gateway bounds it (it becomes a Redis key suffix)
+			cmdId := ""
+			if len(data) > 11+n {
+				cl := int(data[11+n])
+				if cl == 0 || cl > 64 || len(data) < 12+n+cl {
+					continue
+				}
+				cmdId = string(data[12+n : 12+n+cl])
+			}
 			raw, ok := luaString(s.applyControl.Run(ctx, s.rdb,
-				[]string{"room:" + room + ":tl"}, intent,
-				strconv.FormatFloat(mediaTime, 'f', -1, 64), "relay").Result())
+				[]string{"room:" + room + ":tl", "room:" + room + ":cmd:" + cmdId},
+				intent, strconv.FormatFloat(mediaTime, 'f', -1, 64), "relay",
+				cmdId, strconv.Itoa(cmdDedupTTLMS)).Result())
 			if !ok {
 				if !c.trySend([]byte{0x07, 0}) {
 					return
@@ -309,7 +329,15 @@ func (s *server) handle(w http.ResponseWriter, r *http.Request) {
 			}
 			var tl luaTimeline
 			if json.Unmarshal([]byte(raw), &tl) == nil {
-				s.broadcast(room, encodeTimeline(0x04, tl.toWire()))
+				if tl.Dup {
+					// already applied: the original commit broadcast to the
+					// room, so only the sender gets a targeted re-anchor
+					if !c.trySend(encodeTimeline(0x04, tl.toWire())) {
+						return
+					}
+				} else {
+					s.broadcast(room, encodeTimeline(0x04, tl.toWire()))
+				}
 			}
 		}
 	}

--- a/shared/sync-protocol.ts
+++ b/shared/sync-protocol.ts
@@ -57,6 +57,14 @@ export interface SyncControl {
   roomCode: string;
   intent: ControlIntent;
   mediaTime: number;
+  /**
+   * Client-minted idempotency key (UUID), the Stripe model: the store
+   * applies each cmdId at most once and answers a duplicate with the
+   * already-committed timeline instead of committing again. Optional for
+   * wire compat - a command without one gets no dedup, exactly the old
+   * behavior. Deduped atomically inside the same Lua script as the commit.
+   */
+  cmdId?: string;
 }
 
 /** S→C error for rejected controls (permission, rate limit, no room). */

--- a/sync-harness/src/bots/bot-client.ts
+++ b/sync-harness/src/bots/bot-client.ts
@@ -73,6 +73,8 @@ export interface BotReport {
   rejoinFailures: number;
   /** duplicate-injection mode: how many extra same-cmdId sends this bot made */
   dupControlsSent: number;
+  /** distinct (epoch,seq) of committed control transitions this bot saw */
+  controlCommits: string[];
   handlerErrors: string[];
   rejected: number;
 }
@@ -95,6 +97,11 @@ export class BotClient {
   private reconnects = 0;
   private rejoinFailures = 0;
   private dupControlsSent = 0;
+  /** every distinct committed CONTROL transition observed: (epoch, seq) of
+   *  timelines whose reason is play/pause/seek. Snapshot commits excluded.
+   *  A double-applied duplicate mints an EXTRA one of these - contiguous
+   *  seq, so invisible to the gap metric, but countable here. */
+  private controlCommits = new Set<string>();
   private roomCode: string | null = null;
   private handlerErrors: string[] = [];
   private rejected = 0;
@@ -182,6 +189,9 @@ export class BotClient {
     }
     seen.add(tl.seq);
 
+    if (tl.reason === 'play' || tl.reason === 'pause' || tl.reason === 'seek') {
+      this.controlCommits.add(`${tl.storeEpoch}:${tl.seq}`);
+    }
     if (isNewer(tl, this.timeline)) {
       this.timeline = tl;
     } else if (this.timeline && tl.storeEpoch === this.timeline.storeEpoch) {
@@ -320,6 +330,7 @@ export class BotClient {
       reconnects: this.reconnects,
       rejoinFailures: this.rejoinFailures,
       dupControlsSent: this.dupControlsSent,
+      controlCommits: [...this.controlCommits],
       handlerErrors: this.handlerErrors,
       rejected: this.rejected,
     };

--- a/sync-harness/src/bots/bot-client.ts
+++ b/sync-harness/src/bots/bot-client.ts
@@ -4,6 +4,7 @@
 // the process clock) so the estimator is exercised with real inhomogeneity —
 // and validated against the known injected offset.
 
+import { randomUUID } from 'node:crypto';
 import { ClockEstimator } from '../../../shared/sync-core/clock-estimator';
 import {
   DriftController,
@@ -34,6 +35,8 @@ export interface BotConfig {
   controller?: 'reactive' | 'predictive';
   /** node (Socket.IO/JSON) or relay (raw-WS binary, relay-go) */
   plane?: 'node' | 'relay';
+  /** exactly-once proof mode: send every control twice with the same cmdId */
+  duplicateControls?: boolean;
 }
 
 export interface BotSample {
@@ -68,6 +71,8 @@ export interface BotReport {
   /** re-joins that failed: this bot is deaf from here on and its remaining
    *  seqs are outside the gap metric's detectable range */
   rejoinFailures: number;
+  /** duplicate-injection mode: how many extra same-cmdId sends this bot made */
+  dupControlsSent: number;
   handlerErrors: string[];
   rejected: number;
 }
@@ -89,6 +94,7 @@ export class BotClient {
   private seqDuplicates = 0;
   private reconnects = 0;
   private rejoinFailures = 0;
+  private dupControlsSent = 0;
   private roomCode: string | null = null;
   private handlerErrors: string[] = [];
   private rejected = 0;
@@ -274,7 +280,19 @@ export class BotClient {
   }
 
   sendIntent(roomCode: string, intent: ControlIntent, mediaTime: number): void {
-    this.transport.sendControl(roomCode, intent, mediaTime);
+    const cmdId = randomUUID();
+    this.transport.sendControl(roomCode, intent, mediaTime, cmdId);
+    if (this.cfg.duplicateControls) {
+      // the exactly-once proof harness: the SAME command sent again, byte
+      // for byte. Injected at the app layer on purpose - netem duplicate
+      // works on TCP segments, which TCP itself dedupes, so transport
+      // toxics can never produce an app-level duplicate. The server must
+      // absorb this one via the cmdId record: seq bumps once, the second
+      // delivery is answered as a duplicate, and any double-apply shows up
+      // as a phantom seq the fleet's integrity counters catch.
+      this.transport.sendControl(roomCode, intent, mediaTime, cmdId);
+      this.dupControlsSent += 1;
+    }
   }
 
   scriptedStall(durationMs: number): void {
@@ -301,6 +319,7 @@ export class BotClient {
       seqDuplicates: this.seqDuplicates,
       reconnects: this.reconnects,
       rejoinFailures: this.rejoinFailures,
+      dupControlsSent: this.dupControlsSent,
       handlerErrors: this.handlerErrors,
       rejected: this.rejected,
     };

--- a/sync-harness/src/bots/run-bots.ts
+++ b/sync-harness/src/bots/run-bots.ts
@@ -267,9 +267,17 @@ async function main(): Promise<void> {
     // failing re-joins silently shrink what the gap check can see, so the
     // gate has to treat them as a failure rather than trust a clean seqGaps
     if (rejoinFailures > 0) failures.push(`${rejoinFailures} failed re-joins (gap metric is blind past these)`);
+    // exact equality, both directions: MORE commits than commands means a
+    // duplicate was applied; FEWER means a command never committed - e.g.
+    // the transport dropped it while disconnected (by design, no buffering),
+    // which silently changes the scenario the run claims to have measured
     if (controlCommitsObserved > scriptedControls)
       failures.push(
         `${controlCommitsObserved} control commits for ${scriptedControls} commands - a duplicate was APPLIED`,
+      );
+    else if (controlCommitsObserved < scriptedControls)
+      failures.push(
+        `${controlCommitsObserved} control commits for ${scriptedControls} commands - a command was LOST`,
       );
     if (failures.length > 0) {
       console.error('[gate] FAILED:\n  ' + failures.join('\n  '));

--- a/sync-harness/src/bots/run-bots.ts
+++ b/sync-harness/src/bots/run-bots.ts
@@ -23,6 +23,7 @@ interface Args {
   wsUrl: string;
   controller: 'reactive' | 'predictive';
   plane: 'node' | 'relay';
+  dupControls: boolean;
 }
 
 function parseArgs(): Args {
@@ -37,8 +38,13 @@ function parseArgs(): Args {
     wsUrl: get('--ws') ?? 'http://localhost:3000',
     controller: (get('--controller') ?? 'reactive') as 'reactive' | 'predictive',
     plane: (get('--plane') ?? 'node') as 'node' | 'relay',
+    // exactly-once proof mode: every control sent twice with the same cmdId
+    dupControls: process.argv.includes('--dup-controls'),
   };
 }
+
+import { execSync } from 'node:child_process';
+import { cpus } from 'node:os';
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
@@ -68,6 +74,7 @@ async function main(): Promise<void> {
         seed: 1000 + i,
         controller: args.controller,
         plane: args.plane,
+        duplicateControls: args.dupControls,
         player: {
           playbackSkew: (rng() - 0.5) * 160e-6,
           // A/B fairness: both controller arms face fractional-capable
@@ -175,6 +182,7 @@ async function main(): Promise<void> {
   const seqDuplicates = reports.reduce((sum, r) => sum + r.seqDuplicates, 0);
   const reconnects = reports.reduce((sum, r) => sum + r.reconnects, 0);
   const rejoinFailures = reports.reduce((sum, r) => sum + r.rejoinFailures, 0);
+  const dupControlsSent = reports.reduce((sum, r) => sum + r.dupControlsSent, 0);
   const handlerErrors = reports.flatMap((r) => r.handlerErrors);
   const thetaP95 = percentile(
     [...thetaErrors].sort((a, b) => a - b),
@@ -183,6 +191,17 @@ async function main(): Promise<void> {
 
   const summary = {
     runId,
+    // provenance: an earlier audit found bot-fleet numbers published without
+    // a citable artifact; a summary that names its build and hardware can be
+    // committed under docs/measurements and pass the two-tier convention.
+    // A dirty tree is STAMPED as dirty - a SHA that does not contain the
+    // code that produced the run is worse than no SHA.
+    gitSha:
+      execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim() +
+      (execSync('git status --porcelain', { encoding: 'utf8' }).trim()
+        ? '-dirty'
+        : ''),
+    hardware: `${cpus().length} cores (${cpus()[0]?.model ?? 'unknown'})`,
     controller: args.controller,
     plane: args.plane,
     n: args.n,
@@ -204,6 +223,10 @@ async function main(): Promise<void> {
     // the gap metric's range - so a non-zero count here means the seqGaps
     // number above is an UNDER-count, not a clean bill of health
     rejoinFailures,
+    // duplicate-injection mode: extra same-cmdId sends. With dedup working,
+    // these produce ZERO extra seqs - any double-apply shows as a phantom
+    // seq in the integrity counters
+    dupControlsSent,
     handlerErrors: handlerErrors.length,
     rejectedControls: reports.reduce((s, r) => s + r.rejected, 0),
   };

--- a/sync-harness/src/bots/run-bots.ts
+++ b/sync-harness/src/bots/run-bots.ts
@@ -13,6 +13,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createRoom } from '../app-api.js';
 import { percentile } from '../stats.js';
+import type { ControlIntent } from '../../../shared/sync-protocol';
 import { BotClient } from './bot-client.js';
 import { mulberry32 } from './sim-player.js';
 
@@ -113,12 +114,20 @@ async function main(): Promise<void> {
     if (!tl) return 0;
     return tl.mediaTime + (tl.isPlaying ? (Date.now() - tl.stampedAt) / 1000 : 0);
   };
+  // the double-apply tripwire needs the ground truth of how many control
+  // COMMANDS were issued: each sendIntent is one command (its duplicate
+  // twin in --dup-controls mode shares the cmdId, so it must NOT commit)
+  let scriptedControls = 0;
+  const command = (intent: ControlIntent, mediaTime: number): void => {
+    scriptedControls += 1;
+    commander.sendIntent(room.code, intent, mediaTime);
+  };
   const events: Array<{ atS: number; run: () => void }> = [
-    { atS: 5, run: () => commander.sendIntent(room.code, 'play', 0) },
-    { atS: 30, run: () => commander.sendIntent(room.code, 'seek', 300) },
+    { atS: 5, run: () => command('play', 0) },
+    { atS: 30, run: () => command('seek', 300) },
     { atS: 40, run: () => bots[Math.min(2, bots.length - 1)].scriptedStall(4000) },
-    { atS: 50, run: () => commander.sendIntent(room.code, 'pause', projectedNow()) },
-    { atS: 55, run: () => commander.sendIntent(room.code, 'play', projectedNow()) },
+    { atS: 50, run: () => command('pause', projectedNow()) },
+    { atS: 55, run: () => command('play', projectedNow()) },
   ];
   for (const e of events) {
     const wait = t0 + e.atS * 1000 - Date.now();
@@ -183,6 +192,13 @@ async function main(): Promise<void> {
   const reconnects = reports.reduce((sum, r) => sum + r.reconnects, 0);
   const rejoinFailures = reports.reduce((sum, r) => sum + r.rejoinFailures, 0);
   const dupControlsSent = reports.reduce((sum, r) => sum + r.dupControlsSent, 0);
+  // union across the fleet: a control commit any bot observed. A duplicate
+  // that double-applies mints an extra (epoch,seq) with a control reason -
+  // contiguous seq, so seqGaps stays clean, but this count exceeds the
+  // number of commands actually issued
+  const controlCommitsObserved = new Set(
+    reports.flatMap((r) => r.controlCommits),
+  ).size;
   const handlerErrors = reports.flatMap((r) => r.handlerErrors);
   const thetaP95 = percentile(
     [...thetaErrors].sort((a, b) => a - b),
@@ -227,6 +243,8 @@ async function main(): Promise<void> {
     // these produce ZERO extra seqs - any double-apply shows as a phantom
     // seq in the integrity counters
     dupControlsSent,
+    scriptedControls,
+    controlCommitsObserved,
     handlerErrors: handlerErrors.length,
     rejectedControls: reports.reduce((s, r) => s + r.rejected, 0),
   };
@@ -249,6 +267,10 @@ async function main(): Promise<void> {
     // failing re-joins silently shrink what the gap check can see, so the
     // gate has to treat them as a failure rather than trust a clean seqGaps
     if (rejoinFailures > 0) failures.push(`${rejoinFailures} failed re-joins (gap metric is blind past these)`);
+    if (controlCommitsObserved > scriptedControls)
+      failures.push(
+        `${controlCommitsObserved} control commits for ${scriptedControls} commands - a duplicate was APPLIED`,
+      );
     if (failures.length > 0) {
       console.error('[gate] FAILED:\n  ' + failures.join('\n  '));
       process.exit(1);

--- a/sync-harness/src/bots/transport.ts
+++ b/sync-harness/src/bots/transport.ts
@@ -11,7 +11,12 @@ export interface SyncTransport {
   connect(token: string): Promise<void>;
   join(roomCode: string, userId: string): Promise<Timeline | null>;
   sendClock(t0: number, onPong: (pong: ClockPong) => void): void;
-  sendControl(roomCode: string, intent: ControlIntent, mediaTime: number): void;
+  sendControl(
+    roomCode: string,
+    intent: ControlIntent,
+    mediaTime: number,
+    cmdId?: string,
+  ): void;
   onTimeline(cb: (tl: Timeline) => void): void;
   onRejected(cb: () => void): void;
   onError(cb: (err: string) => void): void;
@@ -87,8 +92,19 @@ export class SocketIOTransport implements SyncTransport {
     this.socket?.emit(SYNC_EVENTS.clock, { t0 }, onPong);
   }
 
-  sendControl(roomCode: string, intent: ControlIntent, mediaTime: number): void {
-    this.socket?.emit(SYNC_EVENTS.control, { v: 1, roomCode, intent, mediaTime });
+  sendControl(
+    roomCode: string,
+    intent: ControlIntent,
+    mediaTime: number,
+    cmdId?: string,
+  ): void {
+    this.socket?.emit(SYNC_EVENTS.control, {
+      v: 1,
+      roomCode,
+      intent,
+      mediaTime,
+      cmdId,
+    });
   }
 
   onTimeline(cb: (tl: Timeline) => void): void {
@@ -250,14 +266,26 @@ export class RawWSBinaryTransport implements SyncTransport {
     this.ws.send(frame);
   }
 
-  sendControl(roomCode: string, intent: ControlIntent, mediaTime: number): void {
+  sendControl(
+    roomCode: string,
+    intent: ControlIntent,
+    mediaTime: number,
+    cmdId?: string,
+  ): void {
     const room = Buffer.from(roomCode, 'utf8');
-    const frame = Buffer.alloc(11 + room.length);
+    // cmdLen+cmdId are appended after room; the relay tolerates their
+    // absence, so old frames stay decodable
+    const cmd = Buffer.from(cmdId ?? '', 'utf8');
+    const frame = Buffer.alloc(11 + room.length + (cmd.length ? 1 + cmd.length : 0));
     frame.writeUInt8(0x03, 0);
     frame.writeUInt8(INTENTS.indexOf(intent), 1);
     frame.writeDoubleLE(mediaTime, 2);
     frame.writeUInt8(room.length, 10);
     room.copy(frame, 11);
+    if (cmd.length) {
+      frame.writeUInt8(cmd.length, 11 + room.length);
+      cmd.copy(frame, 12 + room.length);
+    }
     this.ws.send(frame);
   }
 

--- a/sync-harness/src/bots/transport.ts
+++ b/sync-harness/src/bots/transport.ts
@@ -98,7 +98,12 @@ export class SocketIOTransport implements SyncTransport {
     mediaTime: number,
     cmdId?: string,
   ): void {
-    this.socket?.emit(SYNC_EVENTS.control, {
+    // the no-buffering contract the dedup TTL's soundness rests on
+    // (SYNC_DESIGN 2a): socket.io would queue this while disconnected and
+    // flush it arbitrarily late after reconnect - drop instead, like the
+    // real client does
+    if (!this.socket?.connected) return;
+    this.socket.emit(SYNC_EVENTS.control, {
       v: 1,
       roomCode,
       intent,
@@ -272,6 +277,8 @@ export class RawWSBinaryTransport implements SyncTransport {
     mediaTime: number,
     cmdId?: string,
   ): void {
+    // same no-buffering contract as the socket.io transport
+    if (!this.isConnected) return;
     const room = Buffer.from(roomCode, 'utf8');
     // cmdLen+cmdId are appended after room; the relay tolerates their
     // absence, so old frames stay decodable

--- a/video-sync-backend/src/metrics/metrics.service.ts
+++ b/video-sync-backend/src/metrics/metrics.service.ts
@@ -59,6 +59,15 @@ export class MetricsService {
     registers: [this.registry],
   });
 
+  // no cmdId label on purpose: client-controlled strings in label values
+  // are an unbounded-cardinality DoS
+  readonly controlDedupHits = new Counter({
+    name: 'control_dedup_hits_total',
+    help: 'control commands answered from the idempotency record',
+    labelNames: ['type'],
+    registers: [this.registry],
+  });
+
   readonly redisOpDuration = new Histogram({
     name: 'redis_op_duration_seconds',
     help: 'state-store operation latency',

--- a/video-sync-backend/src/shared/sync-protocol.ts
+++ b/video-sync-backend/src/shared/sync-protocol.ts
@@ -59,6 +59,14 @@ export interface SyncControl {
   roomCode: string;
   intent: ControlIntent;
   mediaTime: number;
+  /**
+   * Client-minted idempotency key (UUID), the Stripe model: the store
+   * applies each cmdId at most once and answers a duplicate with the
+   * already-committed timeline instead of committing again. Optional for
+   * wire compat - a command without one gets no dedup, exactly the old
+   * behavior. Deduped atomically inside the same Lua script as the commit.
+   */
+  cmdId?: string;
 }
 
 /** S→C error for rejected controls (permission, rate limit, no room). */

--- a/video-sync-backend/src/sync/actor-room-state.store.spec.ts
+++ b/video-sync-backend/src/sync/actor-room-state.store.spec.ts
@@ -125,41 +125,26 @@ describe('ActorRoomStateStore — lease fencing', () => {
     // every applied command and a redelivered forward re-applies.
     const r = `${room}-dedup-handoff`;
     await a.init(r, 'vid', 0, Date.now());
-    const first = await a.applyControl(
-      r,
-      'seek',
-      10,
-      Date.now(),
-      'u1',
-      'cmd-h1',
-    );
+    const first = await a.applyControl(r, 'seek', 10, Date.now(), 'u1', {
+      cmdId: 'cmd-h1',
+    });
     expect(first.kind).toBe('committed');
 
     // owner change: a's lease dies, b claims on its next control
     const kv = new Redis(URL, { maxRetriesPerRequest: 1 });
     clients.push(kv);
     await kv.del(`room:${r}:lease`);
-    const claim = await b.applyControl(
-      r,
-      'play',
-      20,
-      Date.now(),
-      'u2',
-      'cmd-h2',
-    );
+    const claim = await b.applyControl(r, 'play', 20, Date.now(), 'u2', {
+      cmdId: 'cmd-h2',
+    });
     expect(claim.kind).toBe('committed');
     const seqAfterClaim = (await b.get(r))!.seq;
 
     // the redelivered forward of the OLD owner's command reaches the NEW
     // owner (the forward publish is redeliverable) - it must dedup, not apply
-    const replay = await b.applyControl(
-      r,
-      'seek',
-      10,
-      Date.now(),
-      'u1',
-      'cmd-h1',
-    );
+    const replay = await b.applyControl(r, 'seek', 10, Date.now(), 'u1', {
+      cmdId: 'cmd-h1',
+    });
     expect(replay.kind).toBe('duplicate');
     expect((await b.get(r))!.seq).toBe(seqAfterClaim);
     await b.clear(r);

--- a/video-sync-backend/src/sync/actor-room-state.store.spec.ts
+++ b/video-sync-backend/src/sync/actor-room-state.store.spec.ts
@@ -118,6 +118,53 @@ describe('ActorRoomStateStore — lease fencing', () => {
     await b.clear(zombieRoom);
   });
 
+  it('a cmdId applied by the OLD owner is a duplicate to the NEW owner', async () => {
+    if (!available) return;
+    // The handoff race the exactly-once spec surfaced: the dedup record must
+    // be fence-independent and live in Redis, or an owner change forgets
+    // every applied command and a redelivered forward re-applies.
+    const r = `${room}-dedup-handoff`;
+    await a.init(r, 'vid', 0, Date.now());
+    const first = await a.applyControl(
+      r,
+      'seek',
+      10,
+      Date.now(),
+      'u1',
+      'cmd-h1',
+    );
+    expect(first.kind).toBe('committed');
+
+    // owner change: a's lease dies, b claims on its next control
+    const kv = new Redis(URL, { maxRetriesPerRequest: 1 });
+    clients.push(kv);
+    await kv.del(`room:${r}:lease`);
+    const claim = await b.applyControl(
+      r,
+      'play',
+      20,
+      Date.now(),
+      'u2',
+      'cmd-h2',
+    );
+    expect(claim.kind).toBe('committed');
+    const seqAfterClaim = (await b.get(r))!.seq;
+
+    // the redelivered forward of the OLD owner's command reaches the NEW
+    // owner (the forward publish is redeliverable) - it must dedup, not apply
+    const replay = await b.applyControl(
+      r,
+      'seek',
+      10,
+      Date.now(),
+      'u1',
+      'cmd-h1',
+    );
+    expect(replay.kind).toBe('duplicate');
+    expect((await b.get(r))!.seq).toBe(seqAfterClaim);
+    await b.clear(r);
+  });
+
   it('the fence advances on ownership change, so clients still order correctly', async () => {
     if (!available) return;
     const r = `${room}-epoch`;

--- a/video-sync-backend/src/sync/actor-room-state.store.ts
+++ b/video-sync-backend/src/sync/actor-room-state.store.ts
@@ -11,7 +11,11 @@ import type Redis from 'ioredis';
 import { REDIS_KV, REDIS_PUB, REDIS_SUB } from '../redis/redis.module';
 import { ControlIntent, Timeline } from '../shared/sync-protocol';
 import { applyControl, snapshot } from '../shared/sync-core/timeline';
-import { ApplyOutcome, RoomStateStore } from './room-state.store';
+import {
+  CMD_DEDUP_TTL_MS,
+  ApplyOutcome,
+  RoomStateStore,
+} from './room-state.store';
 
 /**
  * Coordination plane B: single-owner room actors with lease fencing.
@@ -65,6 +69,7 @@ interface RedisWithActor extends Redis {
   actorCommit(
     leaseKey: string,
     timelineKey: string,
+    cmdKey: string,
     instanceId: string,
     fence: string,
     isPlaying: string,
@@ -73,6 +78,8 @@ interface RedisWithActor extends Redis {
     by: string,
     videoId: string,
     ttlMs: string,
+    cmdId: string,
+    dedupTtlMs: string,
   ): Promise<string | null>;
 }
 
@@ -81,6 +88,9 @@ export interface ForwardedControl {
   intent: ControlIntent;
   mediaTime: number;
   by: string;
+  /** rides the forward so the OWNER's fenced commit can dedup it - the
+   *  forward publish itself can be redelivered (pubsub client resends) */
+  cmdId?: string;
 }
 
 @Injectable()
@@ -127,7 +137,7 @@ export class ActorRoomStateStore
       lua: read('actor_init.lua'),
     });
     kv.defineCommand('actorCommit', {
-      numberOfKeys: 2,
+      numberOfKeys: 3,
       lua: read('actor_commit.lua'),
     });
     this.kv = kv as RedisWithActor;
@@ -238,10 +248,16 @@ export class ActorRoomStateStore
     roomCode: string,
     fence: string,
     next: Omit<Timeline, 'seq'>,
-  ): Promise<Timeline | null> {
+    cmdId?: string,
+  ): Promise<{ timeline: Timeline; dup: boolean } | null> {
     const raw = await this.kv.actorCommit(
       this.leaseKey(roomCode),
       this.timelineKey(roomCode),
+      // fence-INDEPENDENT dedup record, same namespace as plane A: seq
+      // restarts when the fence advances, so (epoch, seq) cannot identify a
+      // command across handoff - but this key can, and it lives in Redis
+      // rather than owner memory precisely so a handoff cannot forget it
+      `room:${roomCode}:cmd:${cmdId ?? ''}`,
       this.instanceId,
       fence,
       next.isPlaying ? '1' : '0',
@@ -250,6 +266,8 @@ export class ActorRoomStateStore
       next.by ?? '',
       next.videoId ?? '',
       String(KEY_TTL_MS),
+      cmdId ?? '',
+      String(CMD_DEDUP_TTL_MS),
     );
     if (!raw) {
       // fenced out: this instance is a zombie for this room
@@ -257,10 +275,16 @@ export class ActorRoomStateStore
       this.logger.warn({ roomCode, fence }, 'actor: commit fenced out');
       return null;
     }
-    const committed = JSON.parse(raw) as Timeline;
+    const parsed = JSON.parse(raw) as Timeline & {
+      dup?: true;
+      videoId?: string;
+    };
+    const committed: Timeline = { ...parsed, videoId: parsed.videoId ?? null };
+    const dup = parsed.dup === true;
+    delete (committed as Timeline & { dup?: true }).dup;
     const entry = this.owned.get(roomCode);
     if (entry) entry.timeline = committed;
-    return committed;
+    return { timeline: committed, dup };
   }
 
   /**
@@ -290,9 +314,17 @@ export class ActorRoomStateStore
     mediaTime: number,
     serverNow: number,
     by: string,
+    cmdId?: string,
   ): Promise<ApplyOutcome> {
     return this.enqueue(roomCode, () =>
-      this.applyControlSerial(roomCode, intent, mediaTime, serverNow, by),
+      this.applyControlSerial(
+        roomCode,
+        intent,
+        mediaTime,
+        serverNow,
+        by,
+        cmdId,
+      ),
     );
   }
 
@@ -302,6 +334,7 @@ export class ActorRoomStateStore
     mediaTime: number,
     serverNow: number,
     by: string,
+    cmdId?: string,
   ): Promise<ApplyOutcome> {
     let entry = this.owned.get(roomCode);
     if (!entry) {
@@ -310,7 +343,7 @@ export class ActorRoomStateStore
         // someone else owns this room: forward and let them broadcast
         const delivered = await this.pub.publish(
           this.forwardChannel(lease.owner),
-          JSON.stringify({ roomCode, intent, mediaTime, by }),
+          JSON.stringify({ roomCode, intent, mediaTime, by, cmdId }),
         );
         if (delivered > 0) return { kind: 'forwarded' };
         // Nobody is subscribed: the owner died between our lease read and
@@ -334,7 +367,7 @@ export class ActorRoomStateStore
           // P07: a live owner exists after all - forward rather than drop
           const second = await this.pub.publish(
             this.forwardChannel(retaken.owner),
-            JSON.stringify({ roomCode, intent, mediaTime, by }),
+            JSON.stringify({ roomCode, intent, mediaTime, by, cmdId }),
           );
           return second > 0 ? { kind: 'forwarded' } : { kind: 'missing' };
         }
@@ -353,8 +386,14 @@ export class ActorRoomStateStore
 
     // serialize locally against the in-memory timeline, then commit fenced
     const next = applyControl(entry.timeline, intent, mediaTime, serverNow, by);
-    const committed = await this.commit(roomCode, entry.fence, next);
-    if (committed) return { kind: 'committed', timeline: committed };
+    const committed = await this.commit(roomCode, entry.fence, next, cmdId);
+    if (committed?.dup) {
+      // cmdId already applied (possibly by the PREVIOUS owner before a
+      // handoff - the record lives in Redis, not owner memory, precisely so
+      // it survives that): answer with current state, commit nothing
+      return { kind: 'duplicate', timeline: committed.timeline };
+    }
+    if (committed) return { kind: 'committed', timeline: committed.timeline };
     // Fenced out: another instance took ownership while we held stale
     // authority. The user's intent must not evaporate - forward it to the
     // new owner exactly as a non-owner would.
@@ -367,14 +406,16 @@ export class ActorRoomStateStore
         roomCode,
         nowLease.epoch,
         applyControl(fresh, intent, mediaTime, serverNow, by),
+        cmdId,
       );
+      if (retry?.dup) return { kind: 'duplicate', timeline: retry.timeline };
       return retry
-        ? { kind: 'committed', timeline: retry }
+        ? { kind: 'committed', timeline: retry.timeline }
         : { kind: 'missing' };
     }
     const delivered = await this.pub.publish(
       this.forwardChannel(nowLease.owner),
-      JSON.stringify({ roomCode, intent, mediaTime, by }),
+      JSON.stringify({ roomCode, intent, mediaTime, by, cmdId }),
     );
     return delivered > 0 ? { kind: 'forwarded' } : { kind: 'missing' };
   }
@@ -391,7 +432,8 @@ export class ActorRoomStateStore
         roomCode,
         entry.fence,
         snapshot(entry.timeline, serverNow),
-      );
+        // sweeps carry no cmdId: they are the system's own commits
+      ).then((r) => r?.timeline ?? null);
     });
   }
 

--- a/video-sync-backend/src/sync/actor-room-state.store.ts
+++ b/video-sync-backend/src/sync/actor-room-state.store.ts
@@ -91,6 +91,10 @@ export interface ForwardedControl {
   /** rides the forward so the OWNER's fenced commit can dedup it - the
    *  forward publish itself can be redelivered (pubsub client resends) */
   cmdId?: string;
+  /** the ORIGINATING socket, preserved across forwards so a duplicate can
+   *  be answered to that socket alone (socket-id rooms span instances via
+   *  the adapter) instead of broadcast to the room */
+  originSocketId?: string;
 }
 
 @Injectable()
@@ -314,17 +318,10 @@ export class ActorRoomStateStore
     mediaTime: number,
     serverNow: number,
     by: string,
-    cmdId?: string,
+    opts?: { cmdId?: string; originSocketId?: string },
   ): Promise<ApplyOutcome> {
     return this.enqueue(roomCode, () =>
-      this.applyControlSerial(
-        roomCode,
-        intent,
-        mediaTime,
-        serverNow,
-        by,
-        cmdId,
-      ),
+      this.applyControlSerial(roomCode, intent, mediaTime, serverNow, by, opts),
     );
   }
 
@@ -334,8 +331,10 @@ export class ActorRoomStateStore
     mediaTime: number,
     serverNow: number,
     by: string,
-    cmdId?: string,
+    opts?: { cmdId?: string; originSocketId?: string },
   ): Promise<ApplyOutcome> {
+    const cmdId = opts?.cmdId;
+    const originSocketId = opts?.originSocketId;
     let entry = this.owned.get(roomCode);
     if (!entry) {
       const lease = await this.claim(roomCode);
@@ -343,7 +342,14 @@ export class ActorRoomStateStore
         // someone else owns this room: forward and let them broadcast
         const delivered = await this.pub.publish(
           this.forwardChannel(lease.owner),
-          JSON.stringify({ roomCode, intent, mediaTime, by, cmdId }),
+          JSON.stringify({
+            roomCode,
+            intent,
+            mediaTime,
+            by,
+            cmdId,
+            originSocketId,
+          }),
         );
         if (delivered > 0) return { kind: 'forwarded' };
         // Nobody is subscribed: the owner died between our lease read and
@@ -367,7 +373,14 @@ export class ActorRoomStateStore
           // P07: a live owner exists after all - forward rather than drop
           const second = await this.pub.publish(
             this.forwardChannel(retaken.owner),
-            JSON.stringify({ roomCode, intent, mediaTime, by, cmdId }),
+            JSON.stringify({
+              roomCode,
+              intent,
+              mediaTime,
+              by,
+              cmdId,
+              originSocketId,
+            }),
           );
           return second > 0 ? { kind: 'forwarded' } : { kind: 'missing' };
         }
@@ -415,7 +428,14 @@ export class ActorRoomStateStore
     }
     const delivered = await this.pub.publish(
       this.forwardChannel(nowLease.owner),
-      JSON.stringify({ roomCode, intent, mediaTime, by, cmdId }),
+      JSON.stringify({
+        roomCode,
+        intent,
+        mediaTime,
+        by,
+        cmdId,
+        originSocketId,
+      }),
     );
     return delivered > 0 ? { kind: 'forwarded' } : { kind: 'missing' };
   }

--- a/video-sync-backend/src/sync/lua/actor_commit.lua
+++ b/video-sync-backend/src/sync/lua/actor_commit.lua
@@ -1,8 +1,17 @@
--- Fenced commit. KEYS[1]=lease, KEYS[2]=timeline.
--- ARGV: instanceId, fence, isPlaying, mediaTime, reason, by, videoId, ttlMs
+-- Fenced commit. KEYS[1]=lease, KEYS[2]=timeline, KEYS[3]=cmd dedup record
+-- ARGV: instanceId, fence, isPlaying, mediaTime, reason, by, videoId,
+--       ttlMs, cmdId, dedupTtlMs
 -- A commit is accepted ONLY if the caller still holds the lease at the fence
 -- it believes it owns. This is the guard a revived zombie fails - the case
 -- the TLA+ spec exists to check (NoStaleFenceWrite).
+--
+-- The cmdId dedup lives INSIDE the fenced step and its record is
+-- fence-INDEPENDENT: seq restarts when the fence advances, so (epoch, seq)
+-- cannot identify a command across an owner handoff, but the cmd key can -
+-- a command applied by the old owner is answered as a duplicate by the new
+-- one instead of being applied again. The forward publish that delivers
+-- commands to owners can itself be redelivered, which is exactly the
+-- double-apply this closes.
 local lease = redis.call('HGETALL', KEYS[1])
 if #lease == 0 then return false end
 local m = {}
@@ -13,11 +22,27 @@ local t = redis.call('TIME')
 local now = t[1] * 1000 + math.floor(t[2] / 1000)
 local seq = 1
 local cur = redis.call('HGETALL', KEYS[2])
+local c = {}
 if #cur > 0 then
-  local c = {}
   for i = 1, #cur, 2 do c[cur[i]] = cur[i + 1] end
   -- seq restarts when the fence advances: (epoch, seq) stays ordered
   if c.storeEpoch == ARGV[2] then seq = tonumber(c.seq) + 1 end
+end
+if ARGV[9] ~= '' and #cur > 0 then
+  if redis.call('SET', KEYS[3], tostring(seq), 'NX', 'PX', ARGV[10])
+     == false then
+    -- duplicate: answer with the CURRENT committed state, commit nothing.
+    -- false is reserved for fenced-out (the caller drops ownership on it),
+    -- so the dup marker rides the encoded state instead.
+    return cjson.encode({
+      v = 1, seq = tonumber(c.seq), storeEpoch = c.storeEpoch,
+      videoId = c.videoId ~= '' and c.videoId or nil,
+      isPlaying = c.isPlaying == '1',
+      mediaTime = tonumber(c.mediaTime), stampedAt = tonumber(c.stampedAt),
+      rate = 1, reason = c.reason, by = c.by ~= '' and c.by or nil,
+      dup = true,
+    })
+  end
 end
 redis.call('HSET', KEYS[2],
   'seq', seq, 'storeEpoch', ARGV[2], 'videoId', ARGV[7],

--- a/video-sync-backend/src/sync/lua/apply_control.lua
+++ b/video-sync-backend/src/sync/lua/apply_control.lua
@@ -1,5 +1,25 @@
+-- KEYS[1]=room:X:tl  KEYS[2]=room:X:cmd:<cmdId> (dedup record; unused when
+-- ARGV[4] is empty)  ARGV: intent, mediaTime, by, cmdId, dedupTtlMs
+--
+-- The idempotency check lives HERE, inside the same atomic script as the
+-- commit, because a check-then-apply split across two round trips is the
+-- exact race the guard exists to close (formal/SyncExactlyOnce.tla). The
+-- concrete duplicate sources it absorbs are not hypothetical: ioredis
+-- resends an EVAL whose reply was lost on a dropped connection
+-- (autoResendUnfulfilledCommands), and the actor plane's forward publish
+-- can be redelivered - both executed this script twice before this guard.
 local tl = load_tl(KEYS[1])
 if tl == nil then return false end
+if ARGV[4] ~= '' then
+  -- SET NX PX: check and record in one step. nil reply = already applied.
+  if redis.call('SET', KEYS[2], tostring(tonumber(tl.seq) + 1),
+                'NX', 'PX', ARGV[5]) == false then
+    -- duplicate: answer with current state, commit nothing. false (not
+    -- nil/false-return) is reserved for "room missing", so the dup marker
+    -- rides the encoded state instead.
+    return encode(tl, true)
+  end
+end
 local now = now_ms()
 local intent = ARGV[1]
 tl.seq = tonumber(tl.seq) + 1

--- a/video-sync-backend/src/sync/lua/common.lua
+++ b/video-sync-backend/src/sync/lua/common.lua
@@ -19,7 +19,10 @@ local function save_tl(key, tl, ttl)
     'lastSweepWindow', tl.lastSweepWindow or -1)
   redis.call('PEXPIRE', key, ttl)
 end
-local function encode(tl)
+-- dup: set when answering a deduplicated command - the caller replies to
+-- the sender with current state but must NOT broadcast (the original
+-- commit already did). Stripped before the timeline reaches any client.
+local function encode(tl, dup)
   return cjson.encode({
     v = 1, seq = tonumber(tl.seq), storeEpoch = tl.storeEpoch,
     videoId = tl.videoId ~= '' and tl.videoId or nil,
@@ -27,5 +30,6 @@ local function encode(tl)
     mediaTime = tonumber(tl.mediaTime),
     stampedAt = tonumber(tl.stampedAt),
     rate = 1, reason = tl.reason, by = tl.by ~= '' and tl.by or nil,
+    dup = dup or nil,
   })
 end

--- a/video-sync-backend/src/sync/redis-room-state.store.spec.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.spec.ts
@@ -1,5 +1,6 @@
 import Redis from 'ioredis';
 import { RedisRoomStateStore } from './redis-room-state.store';
+import type { Timeline } from '../shared/sync-protocol';
 import { SWEEP_DEDUP_PERIOD_MS } from './room-state.store';
 
 /**
@@ -175,6 +176,90 @@ describe('RedisRoomStateStore — repair sweep dedup', () => {
     const second = await a.applySnapshot(next, await redisNowMs(c));
     expect(second).not.toBeNull();
     expect(second!.seq).toBe(first!.seq + 1);
+  });
+
+  it('applies each cmdId at most once - the retried command re-anchors, not re-commits', async () => {
+    if (!available) return;
+    const a = make();
+    const r = `${room}-dedup`;
+    await playingRoom(a, r);
+    const before = await a.get(r);
+
+    const first = await a.applyControl(
+      r,
+      'seek',
+      42,
+      Date.now(),
+      'u1',
+      'cmd-1',
+    );
+    expect(first.kind).toBe('committed');
+    const committedSeq = (first as { timeline: Timeline }).timeline.seq;
+    expect(committedSeq).toBe(before!.seq + 1);
+
+    // the SAME command delivered again - ioredis resending an EVAL whose
+    // reply was lost is exactly this
+    const second = await a.applyControl(
+      r,
+      'seek',
+      42,
+      Date.now(),
+      'u1',
+      'cmd-1',
+    );
+    expect(second.kind).toBe('duplicate');
+    // no second commit: seq did not move, and the duplicate answers with
+    // the CURRENT state so the retrying sender still gets its re-anchor
+    expect((second as { timeline: Timeline }).timeline.seq).toBe(committedSeq);
+    expect((await a.get(r))!.seq).toBe(committedSeq);
+
+    // a DIFFERENT id is a different command (double-click), not a duplicate
+    const third = await a.applyControl(
+      r,
+      'seek',
+      42,
+      Date.now(),
+      'u1',
+      'cmd-2',
+    );
+    expect(third.kind).toBe('committed');
+    expect((third as { timeline: Timeline }).timeline.seq).toBe(
+      committedSeq + 1,
+    );
+  });
+
+  it('a command without a cmdId gets the old non-deduped behavior', async () => {
+    if (!available) return;
+    const a = make();
+    const r = `${room}-nocmd`;
+    await playingRoom(a, r);
+    const s1 = await a.applyControl(r, 'pause', 7, Date.now(), 'u1');
+    const s2 = await a.applyControl(r, 'pause', 7, Date.now(), 'u1');
+    expect(s1.kind).toBe('committed');
+    expect(s2.kind).toBe('committed'); // legacy clients keep legacy semantics
+  });
+
+  it('an expired dedup record re-applies - the TTL is the correctness boundary', async () => {
+    if (!available) return;
+    // formal/SyncExactlyOnce.tla earlyevict: eviction before the redelivery
+    // window closes IS the double-apply. This test documents the mechanism
+    // by forcing it: expire the record, replay the id, watch it commit.
+    const a = make();
+    const c = raw();
+    const r = `${room}-ttl`;
+    await playingRoom(a, r);
+    await a.applyControl(r, 'seek', 9, Date.now(), 'u1', 'cmd-ttl');
+    await c.pexpire(`room:${r}:cmd:cmd-ttl`, 1);
+    await new Promise((res) => setTimeout(res, 20));
+    const replay = await a.applyControl(
+      r,
+      'seek',
+      9,
+      Date.now(),
+      'u1',
+      'cmd-ttl',
+    );
+    expect(replay.kind).toBe('committed'); // which is why TTL >> redelivery window
   });
 
   it('never advances a paused room', async () => {

--- a/video-sync-backend/src/sync/redis-room-state.store.spec.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.spec.ts
@@ -185,28 +185,18 @@ describe('RedisRoomStateStore — repair sweep dedup', () => {
     await playingRoom(a, r);
     const before = await a.get(r);
 
-    const first = await a.applyControl(
-      r,
-      'seek',
-      42,
-      Date.now(),
-      'u1',
-      'cmd-1',
-    );
+    const first = await a.applyControl(r, 'seek', 42, Date.now(), 'u1', {
+      cmdId: 'cmd-1',
+    });
     expect(first.kind).toBe('committed');
     const committedSeq = (first as { timeline: Timeline }).timeline.seq;
     expect(committedSeq).toBe(before!.seq + 1);
 
     // the SAME command delivered again - ioredis resending an EVAL whose
     // reply was lost is exactly this
-    const second = await a.applyControl(
-      r,
-      'seek',
-      42,
-      Date.now(),
-      'u1',
-      'cmd-1',
-    );
+    const second = await a.applyControl(r, 'seek', 42, Date.now(), 'u1', {
+      cmdId: 'cmd-1',
+    });
     expect(second.kind).toBe('duplicate');
     // no second commit: seq did not move, and the duplicate answers with
     // the CURRENT state so the retrying sender still gets its re-anchor
@@ -214,14 +204,9 @@ describe('RedisRoomStateStore — repair sweep dedup', () => {
     expect((await a.get(r))!.seq).toBe(committedSeq);
 
     // a DIFFERENT id is a different command (double-click), not a duplicate
-    const third = await a.applyControl(
-      r,
-      'seek',
-      42,
-      Date.now(),
-      'u1',
-      'cmd-2',
-    );
+    const third = await a.applyControl(r, 'seek', 42, Date.now(), 'u1', {
+      cmdId: 'cmd-2',
+    });
     expect(third.kind).toBe('committed');
     expect((third as { timeline: Timeline }).timeline.seq).toBe(
       committedSeq + 1,
@@ -248,17 +233,12 @@ describe('RedisRoomStateStore — repair sweep dedup', () => {
     const c = raw();
     const r = `${room}-ttl`;
     await playingRoom(a, r);
-    await a.applyControl(r, 'seek', 9, Date.now(), 'u1', 'cmd-ttl');
+    await a.applyControl(r, 'seek', 9, Date.now(), 'u1', { cmdId: 'cmd-ttl' });
     await c.pexpire(`room:${r}:cmd:cmd-ttl`, 1);
     await new Promise((res) => setTimeout(res, 20));
-    const replay = await a.applyControl(
-      r,
-      'seek',
-      9,
-      Date.now(),
-      'u1',
-      'cmd-ttl',
-    );
+    const replay = await a.applyControl(r, 'seek', 9, Date.now(), 'u1', {
+      cmdId: 'cmd-ttl',
+    });
     expect(replay.kind).toBe('committed'); // which is why TTL >> redelivery window
   });
 

--- a/video-sync-backend/src/sync/redis-room-state.store.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.ts
@@ -97,8 +97,9 @@ export class RedisRoomStateStore implements RoomStateStore {
     mediaTime: number,
     _serverNow: number, // stamping happens inside Lua from redis TIME (D6)
     by: string,
-    cmdId?: string,
+    opts?: { cmdId?: string; originSocketId?: string },
   ): Promise<ApplyOutcome> {
+    const cmdId = opts?.cmdId;
     const result = await this.redis.mustardApplyControl(
       this.key(roomCode),
       // the dedup record; the script never touches it when cmdId is ''

--- a/video-sync-backend/src/sync/redis-room-state.store.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.ts
@@ -4,6 +4,7 @@ import { REDIS_KV } from '../redis/redis.module';
 import { ControlIntent, Timeline } from '../shared/sync-protocol';
 import {
   ApplyOutcome,
+  CMD_DEDUP_TTL_MS,
   RoomStateStore,
   SWEEP_DEDUP_PERIOD_MS,
 } from './room-state.store';
@@ -35,9 +36,12 @@ const LUA_INIT = lua('init.lua');
 interface RedisWithCommands extends Redis {
   mustardApplyControl(
     key: string,
+    cmdKey: string,
     intent: string,
     mediaTime: string,
     by: string,
+    cmdId: string,
+    dedupTtlMs: string,
   ): Promise<string | null>;
   mustardApplySnapshot(key: string, periodMs: string): Promise<string | null>;
   mustardInit(key: string, videoId: string, mediaTime: string): Promise<string>;
@@ -49,7 +53,7 @@ export class RedisRoomStateStore implements RoomStateStore {
 
   constructor(@Inject(REDIS_KV) redis: Redis) {
     redis.defineCommand('mustardApplyControl', {
-      numberOfKeys: 1,
+      numberOfKeys: 2,
       lua: LUA_APPLY_CONTROL,
     });
     redis.defineCommand('mustardApplySnapshot', {
@@ -93,15 +97,32 @@ export class RedisRoomStateStore implements RoomStateStore {
     mediaTime: number,
     _serverNow: number, // stamping happens inside Lua from redis TIME (D6)
     by: string,
+    cmdId?: string,
   ): Promise<ApplyOutcome> {
     const result = await this.redis.mustardApplyControl(
       this.key(roomCode),
+      // the dedup record; the script never touches it when cmdId is ''
+      `room:${roomCode}:cmd:${cmdId ?? ''}`,
       intent,
       String(mediaTime),
       by,
+      cmdId ?? '',
+      String(CMD_DEDUP_TTL_MS),
     );
-    const timeline = this.parse(result);
-    return timeline ? { kind: 'committed', timeline } : { kind: 'missing' };
+    if (result === null) return { kind: 'missing' };
+    const raw = JSON.parse(result) as Timeline & {
+      dup?: true;
+      videoId?: string;
+    };
+    // same normalization as parse(): Lua omits empty videoId entirely
+    const timeline: Timeline = { ...raw, videoId: raw.videoId ?? null };
+    if (raw.dup) {
+      // already applied: hand back current state, commit nothing. The dup
+      // marker is script-internal - strip it before the timeline escapes.
+      delete (timeline as Timeline & { dup?: true }).dup;
+      return { kind: 'duplicate', timeline };
+    }
+    return { kind: 'committed', timeline };
   }
 
   async applySnapshot(

--- a/video-sync-backend/src/sync/room-state.store.ts
+++ b/video-sync-backend/src/sync/room-state.store.ts
@@ -51,10 +51,13 @@ export const CMD_DEDUP_TTL_MS = 15 * 60_000;
 export interface RoomStateStore {
   get(roomCode: string): Promise<Timeline | null>;
   /**
-   * Restamp a control intent and commit it with the next seq. `cmdId`, when
-   * present, is checked-and-recorded ATOMICALLY with the commit: a repeat of
-   * an applied id returns `duplicate` with the current state instead of
-   * committing again.
+   * Restamp a control intent and commit it with the next seq. `opts.cmdId`,
+   * when present, is checked-and-recorded ATOMICALLY with the commit: a
+   * repeat of an applied id returns `duplicate` with the current state
+   * instead of committing again. `opts.originSocketId` rides any forward so
+   * the room's owner can answer a duplicate to the ORIGINATING socket only
+   * (socket-id rooms are cluster-wide through the adapter) - a duplicate
+   * broadcast to the room would turn retry traffic into room-wide updates.
    */
   applyControl(
     roomCode: string,
@@ -62,7 +65,7 @@ export interface RoomStateStore {
     mediaTime: number,
     serverNow: number,
     by: string,
-    cmdId?: string,
+    opts?: { cmdId?: string; originSocketId?: string },
   ): Promise<ApplyOutcome>;
   /** Re-anchor the projection (periodic sweep); returns the committed state. */
   applySnapshot(roomCode: string, serverNow: number): Promise<Timeline | null>;
@@ -101,8 +104,9 @@ export class InMemoryRoomStateStore implements RoomStateStore {
     mediaTime: number,
     serverNow: number,
     by: string,
-    cmdId?: string,
+    opts?: { cmdId?: string; originSocketId?: string },
   ): Promise<ApplyOutcome> {
+    const cmdId = opts?.cmdId;
     const prev = this.rooms.get(roomCode);
     if (!prev) return Promise.resolve({ kind: 'missing' });
     if (cmdId) {

--- a/video-sync-backend/src/sync/room-state.store.ts
+++ b/video-sync-backend/src/sync/room-state.store.ts
@@ -25,18 +25,44 @@ export const SWEEP_DEDUP_PERIOD_MS = SWEEP_INTERVAL_MS;
  */
 export type ApplyOutcome =
   | { kind: 'committed'; timeline: Timeline }
+  /**
+   * The command's cmdId was already applied: the store did NOT commit
+   * again, and `timeline` is the current committed state - answer the
+   * caller with it (their targeted re-anchor), but do not broadcast: the
+   * original commit already did.
+   */
+  | { kind: 'duplicate'; timeline: Timeline }
   | { kind: 'forwarded' }
   | { kind: 'missing' };
 
+/**
+ * How long the store remembers an applied cmdId. This is a CORRECTNESS
+ * parameter, not a tuning knob (formal/SyncExactlyOnce.tla, the earlyevict
+ * config): it must exceed the client's maximum redelivery window. The
+ * client enforces that window by only ever sending a control on a live
+ * connection - no send-buffering, so nothing can flush an old command
+ * after a long reconnect - which leaves the residual redelivery sources
+ * as ioredis resending an EVAL whose reply was lost (seconds) and the
+ * actor plane's forward publish being redelivered (seconds). Fifteen
+ * minutes is orders of magnitude above both.
+ */
+export const CMD_DEDUP_TTL_MS = 15 * 60_000;
+
 export interface RoomStateStore {
   get(roomCode: string): Promise<Timeline | null>;
-  /** Restamp a control intent and commit it with the next seq. */
+  /**
+   * Restamp a control intent and commit it with the next seq. `cmdId`, when
+   * present, is checked-and-recorded ATOMICALLY with the commit: a repeat of
+   * an applied id returns `duplicate` with the current state instead of
+   * committing again.
+   */
   applyControl(
     roomCode: string,
     intent: ControlIntent,
     mediaTime: number,
     serverNow: number,
     by: string,
+    cmdId?: string,
   ): Promise<ApplyOutcome>;
   /** Re-anchor the projection (periodic sweep); returns the committed state. */
   applySnapshot(roomCode: string, serverNow: number): Promise<Timeline | null>;
@@ -59,6 +85,9 @@ export const ROOM_STATE_STORE = Symbol('ROOM_STATE_STORE');
 @Injectable()
 export class InMemoryRoomStateStore implements RoomStateStore {
   private rooms = new Map<string, Timeline>();
+  /** roomCode -> cmdId -> expiry; mirrors the Redis SET NX PX semantics so
+   *  CI without Redis exercises the same dedup contract. */
+  private cmdSeen = new Map<string, Map<string, number>>();
 
   // Single-process: JS execution is the serializer, so plain sync mutation
   // inside async methods is atomic per call.
@@ -72,9 +101,23 @@ export class InMemoryRoomStateStore implements RoomStateStore {
     mediaTime: number,
     serverNow: number,
     by: string,
+    cmdId?: string,
   ): Promise<ApplyOutcome> {
     const prev = this.rooms.get(roomCode);
     if (!prev) return Promise.resolve({ kind: 'missing' });
+    if (cmdId) {
+      const seen = this.cmdSeen.get(roomCode) ?? new Map<string, number>();
+      // lazy expiry, same effect as PX: an expired record is no record
+      for (const [id, expiresAt] of seen) {
+        if (expiresAt <= serverNow) seen.delete(id);
+      }
+      if (seen.has(cmdId)) {
+        this.cmdSeen.set(roomCode, seen);
+        return Promise.resolve({ kind: 'duplicate', timeline: prev });
+      }
+      seen.set(cmdId, serverNow + CMD_DEDUP_TTL_MS);
+      this.cmdSeen.set(roomCode, seen);
+    }
     const next: Timeline = {
       ...applyControl(prev, intent, mediaTime, serverNow, by),
       seq: prev.seq + 1,
@@ -117,6 +160,7 @@ export class InMemoryRoomStateStore implements RoomStateStore {
   }
 
   clear(roomCode: string): Promise<void> {
+    this.cmdSeen.delete(roomCode);
     this.rooms.delete(roomCode);
     return Promise.resolve();
   }

--- a/video-sync-backend/src/sync/sync.gateway.ts
+++ b/video-sync-backend/src/sync/sync.gateway.ts
@@ -84,12 +84,24 @@ export class SyncGateway
           c.mediaTime,
           this.clock.now(),
           c.cmdId,
+          c.originSocketId,
         );
-        if (result.ok && result.timeline) {
-          this.server
-            .to(c.roomCode)
-            .emit(SYNC_EVENTS.timeline, result.timeline);
+        if (!result.ok || !result.timeline) return;
+        if ('duplicate' in result) {
+          // the forward was redelivered (or the command retried): the
+          // original commit already broadcast. Answer ONLY the originating
+          // socket - socket-id rooms span instances via the adapter, so
+          // this reaches it wherever it is connected. Broadcasting here
+          // would turn retry traffic into room-wide updates.
+          this.metrics.controlDedupHits.inc({ type: c.intent });
+          if (c.originSocketId) {
+            this.server
+              .to(c.originSocketId)
+              .emit(SYNC_EVENTS.timeline, result.timeline);
+          }
+          return;
         }
+        this.server.to(c.roomCode).emit(SYNC_EVENTS.timeline, result.timeline);
       });
     }
   }
@@ -383,6 +395,7 @@ export class SyncGateway
       data.mediaTime,
       this.clock.now(),
       data.cmdId,
+      client.id,
     );
     if (!result.ok) {
       this.metrics.controlEvents.inc({

--- a/video-sync-backend/src/sync/sync.gateway.ts
+++ b/video-sync-backend/src/sync/sync.gateway.ts
@@ -83,6 +83,7 @@ export class SyncGateway
           c.intent,
           c.mediaTime,
           this.clock.now(),
+          c.cmdId,
         );
         if (result.ok && result.timeline) {
           this.server
@@ -338,7 +339,15 @@ export class SyncGateway
       !CONTROL_INTENTS.includes(data?.intent) ||
       typeof data.mediaTime !== 'number' ||
       !Number.isFinite(data.mediaTime) ||
-      data.mediaTime < 0
+      data.mediaTime < 0 ||
+      // cmdId is optional (wire compat) but when present it must be a
+      // bounded string: it becomes a Redis key suffix, and an unbounded
+      // client value there is a memory lever
+      (data.cmdId !== undefined &&
+        (typeof data.cmdId !== 'string' ||
+          data.cmdId.length === 0 ||
+          data.cmdId.length > 64 ||
+          !/^[A-Za-z0-9_-]+$/.test(data.cmdId)))
     ) {
       client.emit(SYNC_EVENTS.controlRejected, {
         v: 1,
@@ -373,6 +382,7 @@ export class SyncGateway
       data.intent,
       data.mediaTime,
       this.clock.now(),
+      data.cmdId,
     );
     if (!result.ok) {
       this.metrics.controlEvents.inc({
@@ -394,6 +404,19 @@ export class SyncGateway
         type: data.intent,
         result: 'forwarded',
       });
+      stop();
+      return;
+    }
+    if ('duplicate' in result) {
+      // already applied: the original commit broadcast to the room, so the
+      // only thing owed is a targeted re-anchor to the sender - the ack a
+      // retrying client is waiting for
+      this.metrics.controlDedupHits.inc({ type: data.intent });
+      this.metrics.controlEvents.inc({
+        type: data.intent,
+        result: 'duplicate',
+      });
+      client.emit(SYNC_EVENTS.timeline, result.timeline);
       stop();
       return;
     }

--- a/video-sync-backend/src/sync/timeline.service.spec.ts
+++ b/video-sync-backend/src/sync/timeline.service.spec.ts
@@ -131,6 +131,50 @@ describe('TimelineService', () => {
     expect(tl.reason).toBe('snapshot');
   });
 
+  it('answers a repeated cmdId as duplicate without committing again', async () => {
+    // the InMemory store mirrors the Lua SET NX PX contract, so the CI path
+    // without Redis exercises the same dedup semantics
+    const { svc } = makeService();
+    await svc.ensureRoom('r1', roomRow, 1_000);
+    const first = await svc.handleControl(
+      'r1',
+      's1',
+      'creator',
+      'seek',
+      30,
+      2_000,
+      'cmd-a',
+    );
+    expect(first.ok).toBe(true);
+    const seq = (first as { timeline: Timeline }).timeline.seq;
+
+    const dup = await svc.handleControl(
+      'r1',
+      's1',
+      'creator',
+      'seek',
+      30,
+      3_000,
+      'cmd-a',
+    );
+    expect(dup.ok).toBe(true);
+    expect('duplicate' in dup && dup.duplicate).toBe(true);
+    // no new commit: same seq comes back, and the store did not advance
+    expect((dup as { timeline: Timeline }).timeline.seq).toBe(seq);
+
+    const fresh = await svc.handleControl(
+      'r1',
+      's1',
+      'creator',
+      'seek',
+      30,
+      4_000,
+      'cmd-b',
+    );
+    expect('duplicate' in fresh).toBe(false);
+    expect((fresh as { timeline: Timeline }).timeline.seq).toBe(seq + 1);
+  });
+
   it('defers to the window winner but still re-anchors locally', async () => {
     // A store that refuses the commit stands in for "another instance already
     // swept this window". The caller must still get a timeline back, because

--- a/video-sync-backend/src/sync/timeline.service.ts
+++ b/video-sync-backend/src/sync/timeline.service.ts
@@ -143,6 +143,9 @@ export class TimelineService {
     mediaTime: number,
     now: number,
     cmdId?: string,
+    /** the true originating socket; differs from socketId on the owner's
+     *  side of a forward, where socketId is synthetic */
+    originSocketId?: string,
   ): Promise<ControlResult> {
     const meta = this.meta.get(roomCode);
     if (!meta) return { ok: false, reason: 'room-not-found' };
@@ -158,7 +161,7 @@ export class TimelineService {
       mediaTime,
       now,
       userId,
-      cmdId,
+      { cmdId, originSocketId },
     );
     if (outcome.kind === 'missing')
       return { ok: false, reason: 'room-not-found' };

--- a/video-sync-backend/src/sync/timeline.service.ts
+++ b/video-sync-backend/src/sync/timeline.service.ts
@@ -7,6 +7,11 @@ import { ROOM_STATE_STORE, RoomStateStore } from './room-state.store';
 
 export type ControlResult =
   | { ok: true; timeline: Timeline }
+  /**
+   * cmdId already applied: `timeline` is current state for a TARGETED reply
+   * to the sender - the original commit already broadcast to the room.
+   */
+  | { ok: true; timeline: Timeline; duplicate: true }
   /** the actor plane forwarded this intent; the room's owner broadcasts it */
   | { ok: true; timeline: null; forwarded: true }
   | { ok: false; reason: 'not-controller' | 'rate-limited' | 'room-not-found' };
@@ -137,6 +142,7 @@ export class TimelineService {
     intent: ControlIntent,
     mediaTime: number,
     now: number,
+    cmdId?: string,
   ): Promise<ControlResult> {
     const meta = this.meta.get(roomCode);
     if (!meta) return { ok: false, reason: 'room-not-found' };
@@ -152,11 +158,16 @@ export class TimelineService {
       mediaTime,
       now,
       userId,
+      cmdId,
     );
     if (outcome.kind === 'missing')
       return { ok: false, reason: 'room-not-found' };
     if (outcome.kind === 'forwarded') {
       return { ok: true, timeline: null, forwarded: true };
+    }
+    if (outcome.kind === 'duplicate') {
+      // nothing new was committed, so nothing to persist or broadcast
+      return { ok: true, timeline: outcome.timeline, duplicate: true };
     }
     this.schedulePersist(roomCode);
     return { ok: true, timeline: outcome.timeline };

--- a/video-sync-frontend/src/shared/sync-protocol.ts
+++ b/video-sync-frontend/src/shared/sync-protocol.ts
@@ -59,6 +59,14 @@ export interface SyncControl {
   roomCode: string;
   intent: ControlIntent;
   mediaTime: number;
+  /**
+   * Client-minted idempotency key (UUID), the Stripe model: the store
+   * applies each cmdId at most once and answers a duplicate with the
+   * already-committed timeline instead of committing again. Optional for
+   * wire compat - a command without one gets no dedup, exactly the old
+   * behavior. Deduped atomically inside the same Lua script as the commit.
+   */
+  cmdId?: string;
 }
 
 /** S→C error for rejected controls (permission, rate limit, no room). */

--- a/video-sync-frontend/src/sync/SyncEngine.ts
+++ b/video-sync-frontend/src/sync/SyncEngine.ts
@@ -133,11 +133,21 @@ export class SyncEngine {
   /** Explicit user gesture: play/pause/scrub. Wait-for-broadcast — the
    * player is NOT touched here; everyone converges from sync:timeline. */
   sendIntent(intent: ControlIntent, mediaTime: number): void {
+    // Send only on a live connection — NEVER buffer. socket.io would queue
+    // this while disconnected and flush it after reconnect, delivering an
+    // arbitrarily old command; the dedup TTL's soundness rests on a bounded
+    // redelivery window (formal/SyncExactlyOnce.tla), and "no buffering" is
+    // how the client enforces it. A dropped gesture is visible (nothing
+    // happens, the user presses again — a NEW command with a NEW id).
+    if (!this.socket.connected) return;
     this.socket.emit(SYNC_EVENTS.control, {
       v: 1,
       roomCode: this.roomCode,
       intent,
       mediaTime: Math.max(0, mediaTime),
+      // idempotency key: the store applies each id at most once, so a
+      // redelivered copy re-anchors the sender instead of re-committing
+      cmdId: crypto.randomUUID(),
     });
   }
 


### PR DESCRIPTION
Item 2 of the exactly-once roadmap, implementing what `formal/SyncExactlyOnce.tla`
(#26) proved. Every control carries a client-minted UUID; the store applies each
id **at most once**, with the check-and-record executed *inside the same Lua
script as the commit* — Stripe's idempotency model, made atomic by Redis's
single-threaded script execution. A duplicate is answered with the current
committed timeline, targeted at the sender (the re-anchor a retrying client
waits for), never re-broadcast.

## The bugs this fixes are real, and weren't where folklore said

- **ioredis resends an EVAL whose reply was lost** (`autoResendUnfulfilledCommands`
  defaults true): `apply_control.lua` executed twice — a phantom seq plus a
  re-anchor later than the user commanded. The dedup record makes the resend
  machinery *safe* instead of disabled.
- **The actor plane's forward publish is redeliverable without limit** (pubsub
  client): one user command could commit-and-broadcast twice. The forward now
  carries `cmdId`, deduped inside the owner's fenced commit.

## Design constraints, each pinned by the spec

- **Atomicity**: dedup inside the Lua commit (`_nodedup` shows the race a split
  reintroduces).
- **TTL is a correctness parameter** (`_earlyevict`): 15 min, justified against a
  *structurally bounded* redelivery window — the client emits controls only on a
  live connection, never buffered, so a reconnect can't flush an arbitrarily old
  command. A dropped gesture is visible; pressing again mints a new id — a second
  command, not a duplicate.
- **Fence-independent on plane B**: seq restarts on fence advance, so
  `(epoch, seq)` can't identify a command across handoff — the Redis-resident
  cmd record can. A duplicate returns current state, never `false` (`false`
  means fenced-out, and the caller drops ownership on it). Handoff-survival is a
  test.
- **Wire compat**: `cmdId` optional on JSON; the binary frame gains an optional
  `[cmdLen][cmdId]` tail — old frames stay decodable; legacy clients keep legacy
  semantics.

## Proven by injection, both planes

netem `duplicate` copies TCP segments, which TCP dedupes — no transport toxic
can produce an app-level duplicate, so the fleet gained `--dup-controls`: every
control sent twice with the same id.

| plane | bots | injected | seq gaps | absorbed |
|---|---|---|---|---|
| node, 3-instance lab | 25 | 4 | **0** | `control_dedup_hits_total` +4 |
| relay-go, binary frames | 5 | 4 | **0** | 4 targeted re-anchors at committed seq |

Committed under `docs/measurements/exactly-once/` with clean `gitSha` stamps —
fleet summaries now carry SHA+hardware, and the stamp appends `-dirty` on a
mismatched tree (the first stamped run caught exactly that and was discarded).

66 backend tests pass: at-most-once on repeats, legacy behavior without ids,
**TTL expiry re-applies** (the correctness boundary, demonstrated), duplicate
across an actor handoff, and the InMemory store mirroring the Lua contract so
CI-without-Redis exercises the same semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Control commands support unique identifiers and 15-minute deduplication.
  * Duplicate commands return the current timeline only to the sender without rebroadcasting.
  * Legacy clients and control messages remain supported.
  * Disconnected clients no longer queue controls for unintended replay.
  * Added monitoring for deduplicated commands.

* **Bug Fixes**
  * Improved reliability during retries, reconnects, and ownership handoffs.

* **Documentation & Tests**
  * Added exactly-once design guidance and validation reports covering duplicate injection and sequence integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->