### PR TITLE
feat: append-only command log with replay-based reconciliation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -131,6 +131,12 @@ jobs:
       - name: 50-bot fleet through nginx (gated)
         run: npx tsx src/bots/run-bots.ts --n 50 --duration 120 --ws http://localhost:3300 --gate
         working-directory: sync-harness
+      - name: replay reconciliation over the night's actual traffic
+        # TransitionContract + ReplayReconstructs (formal/SyncExactlyOnce.tla)
+        # against the append-only logs the fleet just produced: every retained
+        # transition legal, newest entry identical to live state, drift rate 0
+        run: npx tsx src/replay-check.ts --redis redis://localhost:6380 --gate
+        working-directory: sync-harness
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ flowchart LR
   control event with a monotone `seq`. Clients drop stale `(storeEpoch, seq)`.
 - **Wait-for-broadcast control**: the button-presser converges from the same
   broadcast as everyone else — echo storms are structurally impossible.
+- **Exactly-once control commands**: client-minted idempotency keys, deduped
+  atomically inside the same Lua script as the commit (Stripe's model), with
+  the design model-checked first — `formal/SyncExactlyOnce.tla` proves
+  at-most-once application under duplication and reordering, and three
+  committed must-fail configs pin why the dedup must be atomic, why the TTL
+  is a correctness parameter, and why sweep commits must be logged. Proven
+  live by injection: duplicates sent with the same key produce **zero extra
+  commits** on both the Socket.IO and binary-relay planes
+  ([artifacts](docs/measurements/exactly-once/)).
+- **Append-only command log + replay reconciliation**: every commit also
+  appends to a per-room stream in the same atomic step; a reconciler checks
+  every retained transition against an independently-written legal-transition
+  contract and compares the newest entry to live state — **measured drift
+  rate: 0**, gated nightly over real fleet traffic.
 - **Clock discipline**: NTP-style offset over a Socket.IO ack, median-of-
   best-RTT filtering, slew-not-step; validated by bot fleets with injected
   ±1s offsets and ±80ppm skews, recovered to a θ-error P95 of ~3ms

--- a/docs/COORDINATION.md
+++ b/docs/COORDINATION.md
@@ -90,9 +90,13 @@ advances, so `(epoch, seq)` cannot identify a command across handoff — the
 Redis rather than owner memory. The check sits inside `actor_commit.lua`'s
 fenced atomic step, and a duplicate is answered with current state rather
 than `false` — `false` means fenced-out, and the caller drops ownership on
-it. A command applied by the old owner, redelivered to the new owner via
-the (redeliverable) forward channel, is answered as a duplicate; the spec
-test pins it.
+it. A command **carrying a `cmdId`**, applied by the old owner and
+redelivered to the new owner via the (redeliverable) forward channel, is
+answered as a duplicate; the spec test pins it. Legacy commands without a
+`cmdId` keep the old non-deduped semantics — the guarantee is scoped to
+id-bearing commands, on this plane as everywhere else. Forward publishes
+ride the bounded KV client rather than the unbounded pubsub client, so a
+pending publish cannot outlive the dedup record's TTL.
 
 ## Two bugs the implementation surfaced
 

--- a/docs/RELAY.md
+++ b/docs/RELAY.md
@@ -19,10 +19,16 @@ JWT auth) runs against either plane via a transport abstraction
 | relay-go / raw WS / binary | 75ms | 116ms | 0 | pass |
 
 The control frame carries an optional idempotency key appended after the
-room (`[cmdLen u8][cmdId...]`; old frames end at the room and stay
-decodable). The relay passes it into the same `apply_control.lua`, so both
-planes dedup identically — verified by the `--dup-controls` conformance run
-(4 injected duplicates, 0 double-applies, on this plane's binary framing).
+room (`[cmdLen u8][cmdId...]`, ASCII `[A-Za-z0-9_-]{1,64}` — the same
+charset the Node gateway enforces, so the derived Redis key cannot alias
+another keyspace). Parsing is STRICT: a legacy frame must end exactly at
+the room and a suffixed frame exactly at the cmdId — trailing bytes are a
+malformed frame, rejected, because tolerating them lets two encoders
+disagree about where a field ends and still both "work"
+(`parseControl` in `main.go`, boundary cases in `main_test.go`). The relay
+passes the key into the same `apply_control.lua`, so both planes dedup
+identically — verified by the `--dup-controls` conformance run (4 injected
+duplicates, 0 double-applies, on this plane's binary framing).
 
 *(10 bots × 120s each, re-measured after the simulated-player fix described
 in `docs/SYNC_DESIGN.md` §8. **[lab]** — these two fleet runs were not

--- a/docs/SYNC_DESIGN.md
+++ b/docs/SYNC_DESIGN.md
@@ -112,6 +112,37 @@ cross-language conformance (committed under
 `docs/measurements/exactly-once/`). Legacy clients without a `cmdId` keep
 the old semantics — the field is optional on the wire.
 
+## 2b. The append-only command log, and replay as reconciliation
+
+Every commit — control, repair-sweep snapshot, and epoch birth — is appended
+to a per-room Redis stream (`room:X:log`, `MAXLEN ~1024`) **inside the same
+Lua script as the commit**, so the log cannot disagree with the store about
+what happened: they are written in one atomic step, on every plane (Node,
+relay, actor). Entries are full post-states, which makes the log a
+transition relation rather than a journal to re-execute: event sourcing
+where replay is a read, and the ledger discipline is in the checking.
+
+Reconciliation (`sync-harness/src/replay-check.ts`) is the live transfer of
+the spec's two log properties:
+
+- **TransitionContract**: every consecutive retained pair must satisfy its
+  reason's contract — a seek never flips play-state, a pause freezes at the
+  commanded frame, a snapshot moves the projection by *exactly nothing*,
+  `seq` is contiguous — checked by `shared/sync-core/replay.ts`, written
+  independently of the code that produces the transitions (double-entry).
+- **ReplayReconstructs**: the newest retained entry must *be* the live
+  state, field for field. Any disagreement is drift between what was
+  committed and what is served, reported per room as a **measured drift
+  rate** the way the harness reports percentiles.
+
+Sweep commits are logged because the spec's `nosnaplog` config proved the
+alternative: they bump `seq` and re-anchor the projection, so a log of user
+commands alone cannot rebuild live state and reconciliation would report
+phantom drift. Trimming anchors the check at the oldest retained entry —
+truncation is legal, holes are not. Deduplicated deliveries never append:
+the log records **commits, not deliveries**. The nightly runs the
+reconciler over the 50-bot fleet's actual traffic, gated.
+
 ## 3. Clock sync
 
 NTP-style over a Socket.IO ack: client stamps t0/t3, the server ack carries

--- a/docs/SYNC_DESIGN.md
+++ b/docs/SYNC_DESIGN.md
@@ -126,14 +126,23 @@ Reconciliation (`sync-harness/src/replay-check.ts`) is the live transfer of
 the spec's two log properties:
 
 - **TransitionContract**: every consecutive retained pair must satisfy its
-  reason's contract — a seek never flips play-state, a pause freezes at the
-  commanded frame, a snapshot moves the projection by *exactly nothing*,
-  `seq` is contiguous — checked by `shared/sync-core/replay.ts`, written
-  independently of the code that produces the transitions (double-entry).
+  reason's contract — a seek never flips play-state, play/pause set the
+  committed play-state, a snapshot moves the projection by *exactly
+  nothing*, `seq` is contiguous, `stampedAt` monotone — checked by
+  `shared/sync-core/replay.ts`, written independently of the code that
+  produces the transitions (double-entry). Stated precisely: for control
+  commits the *committed position is the command* (entries are post-states
+  and do not retain the request separately), so the checker verifies the
+  state-machine invariants, not commanded-vs-committed position — that
+  equality is what the TLA+ spec's `Contract` covers in the model, and the
+  per-command tests cover in code.
 - **ReplayReconstructs**: the newest retained entry must *be* the live
-  state, field for field. Any disagreement is drift between what was
-  committed and what is served, reported per room as a **measured drift
-  rate** the way the harness reports percentiles.
+  state, field for field (`reason` included). Any disagreement is drift
+  between what was committed and what is served, reported per room as a
+  **measured drift rate** the way the harness reports percentiles. The
+  reconciler reads log and live state as separate commands, so it re-reads
+  until the live version is stable across the pair — a commit racing the
+  reads must not masquerade as drift.
 
 Sweep commits are logged because the spec's `nosnaplog` config proved the
 alternative: they bump `seq` and re-anchor the projection, so a log of user

--- a/docs/measurements/exactly-once/README.md
+++ b/docs/measurements/exactly-once/README.md
@@ -28,3 +28,15 @@ tree does not match) and hardware. A failed double-apply would surface as a
 phantom seq: a commit consumed by the duplicate that the room's clients
 observe as a gap. Before this design, the ioredis resend path produced
 exactly those (see SYNC_DESIGN §2a).
+
+## Replay reconciliation (`replay-reconciliation.json`)
+
+The same injection scenario re-run against a fresh keyspace on the
+command-log build (`node-25bots-dup-injection-with-log.json`, clean SHA),
+then `replay-check.ts` over the append-only logs that traffic produced:
+**12 retained entries, 11 transitions checked, 0 contract violations, 0
+drift rooms — drift rate 0**. Every retained transition satisfies its
+intent's contract (a spec-derived double-entry check), the deduplicated
+deliveries appear nowhere in the log (commits, not deliveries), and the
+newest entry is field-for-field identical to the live state. The nightly
+runs this same reconciliation, gated, over the 50-bot fleet's traffic.

--- a/docs/measurements/exactly-once/README.md
+++ b/docs/measurements/exactly-once/README.md
@@ -15,9 +15,12 @@ transport toxic can ever produce an application-level duplicate.
 What "absorbed" means, per plane:
 
 - **node**: the servers' `control_dedup_hits_total` advanced by exactly 4
-  during the run (scraped from the instance that held the commanding
-  sockets), and no phantom seq appeared — `seqGaps: 0` with the reorder and
-  duplicate counters showing only the expected local re-anchor traffic.
+  during the run, and the **commit-count invariant** held:
+  `controlCommitsObserved == scriptedControls` (4 == 4). That equality is
+  the proof of deduplication — a duplicate that committed would mint the
+  *next contiguous* seq, so `seqGaps: 0` alone can never show it; the gap
+  counter is kept as a separate delivery-ordering check, not as dedup
+  evidence.
 - **relay**: each duplicate was answered as a targeted re-anchor carrying
   the already-committed seq (`seqDuplicates: 4` on a single-instance plane
   that otherwise produces none), through the extended binary control frame

--- a/docs/measurements/exactly-once/node-25bots-dup-injection-with-log.json
+++ b/docs/measurements/exactly-once/node-25bots-dup-injection-with-log.json
@@ -1,0 +1,27 @@
+{
+  "runId": "bots-msi4yfgc",
+  "gitSha": "e03d8de50b2b67d7e1461f5e8a8b91f064614298",
+  "hardware": "10 cores (Apple M2 Pro)",
+  "controller": "reactive",
+  "plane": "node",
+  "n": 25,
+  "durationS": 90,
+  "steadySamples": 5837,
+  "driftMs": {
+    "p50": 73.37686451330683,
+    "p95": 173.49908504030685,
+    "p99": 346.0004745402898
+  },
+  "slopeMsPerMin": 0,
+  "thetaErrorP95Ms": 3.0791015625,
+  "seqGaps": 0,
+  "seqReorders": 0,
+  "seqDuplicates": 118,
+  "reconnects": 0,
+  "rejoinFailures": 0,
+  "dupControlsSent": 4,
+  "scriptedControls": 4,
+  "controlCommitsObserved": 4,
+  "handlerErrors": 0,
+  "rejectedControls": 0
+}

--- a/docs/measurements/exactly-once/replay-reconciliation.json
+++ b/docs/measurements/exactly-once/replay-reconciliation.json
@@ -1,0 +1,12 @@
+{
+ "redis": "redis://localhost:6380",
+ "rooms": 1,
+ "entries": 12,
+ "transitionsChecked": 11,
+ "contractViolations": 0,
+ "driftRooms": 0,
+ "driftRate": 0,
+ "violations": [],
+ "gitSha": "e03d8de50b2b67d7e1461f5e8a8b91f064614298",
+ "sourceRun": "bots-msi4yfgc"
+}

--- a/relay-go/main.go
+++ b/relay-go/main.go
@@ -64,6 +64,48 @@ const cmdDedupTTLMS = 15 * 60 * 1000
 // so the derived room:<room>:cmd:<cmdId> key cannot alias another keyspace
 var cmdIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
 
+// parseControl decodes an 0x03 frame:
+//
+//	[0]=0x03 [1]=intent u8 [2..9]=mediaTime f64 [10]=roomLen [11..11+n)=room
+//	optionally followed by [cmdLen u8][cmdId ASCII [A-Za-z0-9_-]{1,64}]
+//
+// STRICT on length: a legacy frame must end exactly at room, a suffixed
+// frame exactly at cmdId. Trailing bytes are a malformed frame, not
+// padding - accepting them would let two encoders disagree about where a
+// field ends and still both "work".
+func parseControl(data []byte) (intent string, mediaTime float64, room, cmdID string, ok bool) {
+	if len(data) < 11 {
+		return "", 0, "", "", false
+	}
+	// validate rather than coerce: %3 turned any garbage byte into a
+	// valid intent, and a NaN/Inf mediaTime would poison the timeline
+	if data[1] > 2 {
+		return "", 0, "", "", false
+	}
+	intent = []string{"play", "pause", "seek"}[data[1]]
+	mediaTime = math.Float64frombits(binary.LittleEndian.Uint64(data[2:10]))
+	if math.IsNaN(mediaTime) || math.IsInf(mediaTime, 0) || mediaTime < 0 {
+		return "", 0, "", "", false
+	}
+	n := int(data[10])
+	if len(data) < 11+n {
+		return "", 0, "", "", false
+	}
+	room = string(data[11 : 11+n])
+	if len(data) == 11+n {
+		return intent, mediaTime, room, "", true // legacy: ends at room
+	}
+	cl := int(data[11+n])
+	if cl == 0 || cl > 64 || len(data) != 12+n+cl {
+		return "", 0, "", "", false
+	}
+	cmdID = string(data[12+n : 12+n+cl])
+	if !cmdIDPattern.MatchString(cmdID) {
+		return "", 0, "", "", false
+	}
+	return intent, mediaTime, room, cmdID, true
+}
+
 type luaTimeline struct {
 	Seq        int     `json:"seq"`
 	StoreEpoch string  `json:"storeEpoch"`
@@ -295,44 +337,13 @@ func (s *server) handle(w http.ResponseWriter, r *http.Request) {
 			}
 
 		case 0x03: // Control
-			if len(data) < 11 {
+			intent, mediaTime, room, cmdId, okc := parseControl(data)
+			if !okc {
 				continue
-			}
-			// validate rather than coerce: %3 turned any garbage byte into a
-			// valid intent, and a NaN/Inf mediaTime would poison the timeline
-			if data[1] > 2 {
-				continue
-			}
-			intent := []string{"play", "pause", "seek"}[data[1]]
-			mediaTime := math.Float64frombits(binary.LittleEndian.Uint64(data[2:10]))
-			if math.IsNaN(mediaTime) || math.IsInf(mediaTime, 0) || mediaTime < 0 {
-				continue
-			}
-			n := int(data[10])
-			if len(data) < 11+n {
-				continue
-			}
-			room := string(data[11 : 11+n])
-			// optional idempotency key: absent on old frames, bounded like
-			// the Node gateway bounds it (it becomes a Redis key suffix)
-			cmdId := ""
-			if len(data) > 11+n {
-				cl := int(data[11+n])
-				if cl == 0 || cl > 64 || len(data) < 12+n+cl {
-					continue
-				}
-				cmdId = string(data[12+n : 12+n+cl])
-				// same charset the Node gateway enforces. Without it a cmdId
-				// containing ':' makes room:<room>:cmd:<cmdId> collide with
-				// OTHER keys (room "a" + cmd "b:tl" aliases the timeline of
-				// room "a:cmd:b"), and the SET NX against a hash would fail
-				// the whole script with WRONGTYPE
-				if !cmdIDPattern.MatchString(cmdId) {
-					continue
-				}
 			}
 			raw, ok := luaString(s.applyControl.Run(ctx, s.rdb,
-				[]string{"room:" + room + ":tl", "room:" + room + ":cmd:" + cmdId},
+				[]string{"room:" + room + ":tl", "room:" + room + ":cmd:" + cmdId,
+					"room:" + room + ":log"},
 				intent, strconv.FormatFloat(mediaTime, 'f', -1, 64), "relay",
 				cmdId, strconv.Itoa(cmdDedupTTLMS)).Result())
 			if !ok {

--- a/relay-go/main.go
+++ b/relay-go/main.go
@@ -281,7 +281,8 @@ func (s *server) handle(w http.ResponseWriter, r *http.Request) {
 			room := string(data[2 : 2+n])
 			s.joinRoom(c, room)
 			raw, ok := luaString(s.initRoom.Run(ctx, s.rdb,
-				[]string{"room:" + room + ":tl"}, "", "0").Result())
+				[]string{"room:" + room + ":tl", "room:" + room + ":log"},
+				"", "0").Result())
 			if !ok {
 				log.Printf("init failed for room %s", room)
 				continue
@@ -406,7 +407,8 @@ func main() {
 				// most one sweep per room per aligned window no matter how
 				// many instances call it, and returns nil to the losers
 				raw, ok := luaString(snapshotScript.Run(context.Background(), s.rdb,
-					[]string{"room:" + room + ":tl"}, sweepDedupPeriodMS).Result())
+					[]string{"room:" + room + ":tl", "room:" + room + ":log"},
+					sweepDedupPeriodMS).Result())
 				if !ok {
 					continue
 				}

--- a/relay-go/main_test.go
+++ b/relay-go/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+func frame(intent byte, mediaTime float64, room string, tail []byte) []byte {
+	f := make([]byte, 0, 32)
+	f = append(f, 0x03, intent)
+	var mt [8]byte
+	binary.LittleEndian.PutUint64(mt[:], math.Float64bits(mediaTime))
+	f = append(f, mt[:]...)
+	f = append(f, byte(len(room)))
+	f = append(f, []byte(room)...)
+	return append(f, tail...)
+}
+
+func cmdTail(cmd string) []byte {
+	return append([]byte{byte(len(cmd))}, []byte(cmd)...)
+}
+
+func TestParseControlBoundaries(t *testing.T) {
+	cases := []struct {
+		name    string
+		data    []byte
+		ok      bool
+		wantCmd string
+	}{
+		{"legacy ends at room", frame(2, 42, "r1", nil), true, ""},
+		{"suffixed ends at cmdId", frame(2, 42, "r1", cmdTail("abc_DEF-123")), true, "abc_DEF-123"},
+		{"zero-length cmdId", frame(2, 42, "r1", []byte{0}), false, ""},
+		{"truncated cmdId", frame(2, 42, "r1", []byte{5, 'a', 'b'}), false, ""},
+		{"oversized cmdId", frame(2, 42, "r1", cmdTail(string(make([]byte, 65)))), false, ""},
+		{"separator in cmdId aliases keyspaces", frame(2, 42, "r1", cmdTail("b:tl")), false, ""},
+		{"trailing bytes after cmdId", frame(2, 42, "r1", append(cmdTail("abc"), 0xFF)), false, ""},
+		{"trailing byte after room is a cmdLen and must be complete", frame(2, 42, "r1", []byte{3, 'a'}), false, ""},
+		{"bad intent", frame(9, 42, "r1", nil), false, ""},
+		{"negative mediaTime", frame(0, -1, "r1", nil), false, ""},
+		{"NaN mediaTime", frame(0, math.NaN(), "r1", nil), false, ""},
+		{"short frame", []byte{0x03, 0}, false, ""},
+	}
+	for _, c := range cases {
+		_, _, _, cmd, ok := parseControl(c.data)
+		if ok != c.ok {
+			t.Errorf("%s: ok=%v want %v", c.name, ok, c.ok)
+		}
+		if ok && cmd != c.wantCmd {
+			t.Errorf("%s: cmd=%q want %q", c.name, cmd, c.wantCmd)
+		}
+	}
+}

--- a/relay-go/main_test.go
+++ b/relay-go/main_test.go
@@ -39,6 +39,7 @@ func TestParseControlBoundaries(t *testing.T) {
 		{"bad intent", frame(9, 42, "r1", nil), false, ""},
 		{"negative mediaTime", frame(0, -1, "r1", nil), false, ""},
 		{"NaN mediaTime", frame(0, math.NaN(), "r1", nil), false, ""},
+		{"+Inf mediaTime", frame(0, math.Inf(1), "r1", nil), false, ""},
 		{"short frame", []byte{0x03, 0}, false, ""},
 	}
 	for _, c := range cases {

--- a/shared/sync-core/replay.ts
+++ b/shared/sync-core/replay.ts
@@ -1,0 +1,155 @@
+import { ControlIntent, Timeline } from '../sync-protocol';
+import { projectMediaTime } from './timeline';
+
+/**
+ * One committed transition, as appended (atomically with the commit) to the
+ * per-room append-only log by every Lua commit script and the InMemory
+ * store. Entries are FULL post-states, so the log is a transition relation:
+ * replay does not need to re-execute anything, and every consecutive pair
+ * can be checked against the intent contract independently of the code that
+ * produced it.
+ *
+ * This is formal/SyncExactlyOnce.tla transferred to the implementation:
+ * `checkChain` is TransitionContract, `entryMatchesLive` is
+ * ReplayReconstructs - and the spec's nosnaplog config is why snapshot
+ * commits MUST be logged (they bump seq and re-anchor the projection; a log
+ * without them cannot rebuild live state and reconciliation would report
+ * phantom drift).
+ */
+export interface LogEntry {
+  seq: number;
+  storeEpoch: string;
+  videoId: string | null;
+  isPlaying: boolean;
+  mediaTime: number;
+  stampedAt: number;
+  reason: string;
+  by?: string;
+  cmdId?: string;
+}
+
+const CONTROL_REASONS: ReadonlySet<string> = new Set([
+  'play',
+  'pause',
+  'seek',
+]);
+
+/** float slack for the snapshot projection (Lua string arithmetic). */
+const EPS = 1e-6;
+
+/**
+ * The legal-transition contract between two consecutive same-epoch entries,
+ * written INDEPENDENTLY of applyControl/snapshot - double-entry bookkeeping,
+ * exactly like the spec's Contract vs Apply split. Returns a violation
+ * description, or null when legal.
+ */
+export function checkTransition(
+  prev: LogEntry,
+  next: LogEntry,
+): string | null {
+  if (next.storeEpoch !== prev.storeEpoch) {
+    return null; // epoch boundaries are anchored by init entries, not chained
+  }
+  if (next.seq !== prev.seq + 1) {
+    return `seq ${prev.seq} -> ${next.seq}: not contiguous`;
+  }
+  if (next.stampedAt < prev.stampedAt) {
+    return `stampedAt regressed ${prev.stampedAt} -> ${next.stampedAt}`;
+  }
+  if (next.videoId !== prev.videoId) {
+    return `videoId changed mid-epoch (${prev.videoId} -> ${next.videoId})`;
+  }
+  if (CONTROL_REASONS.has(next.reason)) {
+    const intent = next.reason as ControlIntent;
+    if (intent === 'play' && !next.isPlaying) {
+      return 'play committed a non-playing state';
+    }
+    if (intent === 'pause' && next.isPlaying) {
+      return 'pause committed a playing state';
+    }
+    if (intent === 'seek' && next.isPlaying !== prev.isPlaying) {
+      return 'seek flipped isPlaying';
+    }
+    return null; // mediaTime is the commanded position - any value is legal
+  }
+  if (next.reason === 'snapshot') {
+    if (next.isPlaying !== prev.isPlaying) {
+      return 'snapshot flipped isPlaying';
+    }
+    const projected = projectMediaTime(
+      {
+        ...toTimeline(prev),
+      },
+      next.stampedAt,
+    );
+    if (Math.abs(next.mediaTime - projected) > EPS) {
+      return `snapshot moved the projection: expected ${projected}, logged ${next.mediaTime}`;
+    }
+    return null;
+  }
+  return `unknown transition reason '${next.reason}'`;
+}
+
+export function toTimeline(e: LogEntry): Timeline {
+  return {
+    v: 1,
+    seq: e.seq,
+    storeEpoch: e.storeEpoch,
+    videoId: e.videoId,
+    isPlaying: e.isPlaying,
+    mediaTime: e.mediaTime,
+    stampedAt: e.stampedAt,
+    rate: 1,
+    reason: e.reason as Timeline['reason'],
+    by: e.by || undefined,
+  };
+}
+
+export interface ChainReport {
+  checked: number;
+  violations: string[];
+}
+
+/**
+ * Validate every consecutive pair in stream order. The log is trimmed
+ * (MAXLEN ~), so the chain is anchored at the OLDEST RETAINED entry - a
+ * truncated head is expected and legal; a hole or an illegal transition
+ * inside the retained window is not.
+ */
+export function checkChain(entries: LogEntry[]): ChainReport {
+  const violations: string[] = [];
+  for (let i = 1; i < entries.length; i++) {
+    const v = checkTransition(entries[i - 1], entries[i]);
+    if (v) violations.push(`entry ${i} (seq ${entries[i].seq}): ${v}`);
+  }
+  return { checked: Math.max(0, entries.length - 1), violations };
+}
+
+/**
+ * ReplayReconstructs: the newest retained log entry must BE the live state.
+ * Any disagreement is drift between what was committed and what is served.
+ */
+export function entryMatchesLive(
+  last: LogEntry,
+  live: Timeline,
+): string | null {
+  if (last.storeEpoch !== live.storeEpoch) {
+    return `epoch: log ${last.storeEpoch} vs live ${live.storeEpoch}`;
+  }
+  if (last.seq !== live.seq) {
+    return `seq: log ${last.seq} vs live ${live.seq}`;
+  }
+  if (last.isPlaying !== live.isPlaying) {
+    return `isPlaying: log ${last.isPlaying} vs live ${live.isPlaying}`;
+  }
+  if (Math.abs(last.mediaTime - live.mediaTime) > EPS) {
+    return `mediaTime: log ${last.mediaTime} vs live ${live.mediaTime}`;
+  }
+  if (last.stampedAt !== live.stampedAt) {
+    return `stampedAt: log ${last.stampedAt} vs live ${live.stampedAt}`;
+  }
+  if ((last.videoId ?? null) !== (live.videoId ?? null)) {
+    return `videoId: log ${last.videoId} vs live ${live.videoId}`;
+  }
+  return null;
+}

--- a/shared/sync-core/replay.ts
+++ b/shared/sync-core/replay.ts
@@ -28,11 +28,7 @@ export interface LogEntry {
   cmdId?: string;
 }
 
-const CONTROL_REASONS: ReadonlySet<string> = new Set([
-  'play',
-  'pause',
-  'seek',
-]);
+const CONTROL_REASONS: ReadonlySet<string> = new Set(['play', 'pause', 'seek']);
 
 /** float slack for the snapshot projection (Lua string arithmetic). */
 const EPS = 1e-6;
@@ -51,10 +47,7 @@ const differs = (a: number, b: number): boolean =>
  * exactly like the spec's Contract vs Apply split. Returns a violation
  * description, or null when legal.
  */
-export function checkTransition(
-  prev: LogEntry,
-  next: LogEntry,
-): string | null {
+export function checkTransition(prev: LogEntry, next: LogEntry): string | null {
   if (next.storeEpoch !== prev.storeEpoch) {
     return null; // epoch boundaries are anchored by init entries, not chained
   }

--- a/shared/sync-core/replay.ts
+++ b/shared/sync-core/replay.ts
@@ -38,6 +38,14 @@ const CONTROL_REASONS: ReadonlySet<string> = new Set([
 const EPS = 1e-6;
 
 /**
+ * NaN fails every > comparison, so `Math.abs(a-b) > EPS` reports a
+ * non-finite value as LEGAL - the one way a corrupt entry could pass this
+ * checker silently. Every float comparison goes through here instead.
+ */
+const differs = (a: number, b: number): boolean =>
+  !Number.isFinite(a) || !Number.isFinite(b) || Math.abs(a - b) > EPS;
+
+/**
  * The legal-transition contract between two consecutive same-epoch entries,
  * written INDEPENDENTLY of applyControl/snapshot - double-entry bookkeeping,
  * exactly like the spec's Contract vs Apply split. Returns a violation
@@ -76,13 +84,8 @@ export function checkTransition(
     if (next.isPlaying !== prev.isPlaying) {
       return 'snapshot flipped isPlaying';
     }
-    const projected = projectMediaTime(
-      {
-        ...toTimeline(prev),
-      },
-      next.stampedAt,
-    );
-    if (Math.abs(next.mediaTime - projected) > EPS) {
+    const projected = projectMediaTime({ ...toTimeline(prev) }, next.stampedAt);
+    if (differs(next.mediaTime, projected)) {
       return `snapshot moved the projection: expected ${projected}, logged ${next.mediaTime}`;
     }
     return null;
@@ -142,8 +145,11 @@ export function entryMatchesLive(
   if (last.isPlaying !== live.isPlaying) {
     return `isPlaying: log ${last.isPlaying} vs live ${live.isPlaying}`;
   }
-  if (Math.abs(last.mediaTime - live.mediaTime) > EPS) {
+  if (differs(last.mediaTime, live.mediaTime)) {
     return `mediaTime: log ${last.mediaTime} vs live ${live.mediaTime}`;
+  }
+  if (last.reason !== live.reason) {
+    return `reason: log ${last.reason} vs live ${live.reason}`;
   }
   if (last.stampedAt !== live.stampedAt) {
     return `stampedAt: log ${last.stampedAt} vs live ${live.stampedAt}`;

--- a/sync-harness/README.md
+++ b/sync-harness/README.md
@@ -102,6 +102,16 @@ platform-independent.
 | S5 | 25ms + 5% loss | netem | must |
 | S6 | asym 120ms up / 20ms down | Toxiproxy | must |
 | S7 | 60±40ms + 2% loss | netem | optional |
+| S8 | 25ms + 5% TCP-segment duplication | netem | optional† |
+| S9 | 40ms, 25% segments sent ahead (reorder) | netem | optional† |
+
+† S8/S9 are **TCP-pathology** scenarios, stated plainly: netem's duplicate
+and reorder act on TCP segments, and TCP dedupes and re-orders its own
+stream — the application never sees a duplicated or reordered message from
+them. They stress dup-ACK processing and head-of-line blocking (latency
+variance). The app-level duplicate proof is the bot fleet's
+`--dup-controls` injection, which bypasses what TCP hides
+(`docs/measurements/exactly-once/`).
 
 Test video: Big Buck Bunny (Blender Foundation official upload, CC-BY,
 embeddable, strong audio transients) — pinned in `src/scenarios.ts`.

--- a/sync-harness/package-lock.json
+++ b/sync-harness/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@types/ws": "^8.18.1",
+        "ioredis": "^6.0.0",
         "playwright": "^1.49.0",
         "serve": "^14.2.4",
         "socket.io-client": "^4.8.1",
@@ -441,6 +442,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-2.0.0.tgz",
+      "integrity": "sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==",
+      "license": "MIT"
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -832,6 +839,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1181,6 +1197,15 @@
         "robust-predicates": "^3.0.2"
       }
     },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1412,6 +1437,50 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ioredis": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-6.0.0.tgz",
+      "integrity": "sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "2.0.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
@@ -1703,6 +1772,15 @@
         "rc": "cli.js"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/registry-auth-token": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
@@ -1929,6 +2007,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
     "node_modules/string-width": {

--- a/sync-harness/package.json
+++ b/sync-harness/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@types/ws": "^8.18.1",
+    "ioredis": "^6.0.0",
     "playwright": "^1.49.0",
     "serve": "^14.2.4",
     "socket.io-client": "^4.8.1",

--- a/sync-harness/src/compare.ts
+++ b/sync-harness/src/compare.ts
@@ -45,7 +45,7 @@ const after = loadRuns(afterDir);
 const fmt = (s: number | undefined | null): string =>
   s === undefined || s === null || !Number.isFinite(s) ? '—' : s >= 10 ? `${s.toFixed(1)}s` : `${Math.round(s * 1000)}ms`;
 
-const scenarioOrder = ['S0', 'S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7'];
+const scenarioOrder = ['S0', 'S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7', 'S8', 'S9'];
 const rows: string[] = [
   '| scenario (one-way impairment) | baseline P50 / P95 | overhauled P50 / P95 / P99 | convergence after seek |',
   '|---|---|---|---|',

--- a/sync-harness/src/replay-check.ts
+++ b/sync-harness/src/replay-check.ts
@@ -26,6 +26,9 @@ const arg = (flag: string): string | undefined => {
 const URL = arg('--redis') ?? process.env.REDIS_URL ?? 'redis://localhost:6380';
 const GATE = process.argv.includes('--gate');
 
+/** the report is a committable artifact: never let URI userinfo reach it */
+const redacted = (u: string): string => u.replace(/\/\/[^@/]+@/, '//<redacted>@');
+
 function fieldsToEntry(fields: string[]): LogEntry {
   const m = new Map<string, string>();
   for (let i = 0; i < fields.length; i += 2) m.set(fields[i], fields[i + 1]);
@@ -90,16 +93,37 @@ async function main(): Promise<void> {
     const chain = checkChain(log);
     for (const v of chain.violations) violations.push(`${room}: ${v}`);
 
-    const live = await redis.hgetall(`room:${room}:tl`);
-    if (Object.keys(live).length === 0) {
-      // timeline expired but the log survived: nothing to reconcile against
-      continue;
+    // XRANGE and HGETALL are separate commands, so a commit landing between
+    // them yields a mixed-version pair and FALSE drift. Re-read the live
+    // hash and retry the pair until its version is stable across the log
+    // read - rooms commit a few times a minute, so one pass is the norm.
+    let mismatch: string | null = null;
+    let reconciled = false;
+    for (let attempt = 0; attempt < 3 && !reconciled; attempt++) {
+      const liveBefore = await redis.hgetall(`room:${room}:tl`);
+      if (Object.keys(liveBefore).length === 0) {
+        // timeline expired but the log survived: nothing to reconcile
+        reconciled = true;
+        mismatch = null;
+        break;
+      }
+      const tail = (await redis.xrevrange(logKey, '+', '-', 'COUNT', 1)) as Array<
+        [string, string[]]
+      >;
+      const liveAfter = await redis.hgetall(`room:${room}:tl`);
+      if (
+        liveBefore.storeEpoch !== liveAfter.storeEpoch ||
+        liveBefore.seq !== liveAfter.seq
+      ) {
+        continue; // a commit raced the reads; retry the pair
+      }
+      const newest = tail.length > 0 ? fieldsToEntry(tail[0][1]) : log[log.length - 1];
+      mismatch = entryMatchesLive(newest, hashToTimeline(liveAfter));
+      reconciled = true;
     }
-    const mismatch = entryMatchesLive(
-      log[log.length - 1],
-      hashToTimeline(live),
-    );
-    if (mismatch) {
+    if (!reconciled) {
+      violations.push(`${room}: UNSTABLE - versions kept moving across 3 read attempts`);
+    } else if (mismatch) {
       driftRooms += 1;
       violations.push(`${room}: LIVE DRIFT - ${mismatch}`);
     }
@@ -110,7 +134,7 @@ async function main(): Promise<void> {
   console.log(
     JSON.stringify(
       {
-        redis: URL,
+        redis: redacted(URL),
         rooms,
         entries,
         transitionsChecked: entries - rooms,

--- a/sync-harness/src/replay-check.ts
+++ b/sync-harness/src/replay-check.ts
@@ -1,0 +1,133 @@
+// Replay-based reconciliation over the append-only command log: the
+// event-sourcing half of the exactly-once work (SYNC_DESIGN 2b), and the
+// live transfer of formal/SyncExactlyOnce.tla's two log properties -
+// TransitionContract (every logged transition obeys its intent's contract)
+// and ReplayReconstructs (the newest retained entry IS the live state).
+//
+//   npx tsx src/replay-check.ts [--redis redis://localhost:6380] [--gate]
+//
+// Reads every room:*:log stream, validates the retained chain, and compares
+// the newest entry against the live room:*:tl hash. Reports a drift rate
+// the way the harness reports percentiles: measured, per room, committable.
+// The log is trimmed (MAXLEN ~1024), so chains anchor at the oldest
+// retained entry - truncation is legal, holes are not.
+import Redis from 'ioredis';
+import {
+  checkChain,
+  entryMatchesLive,
+  type LogEntry,
+} from '../../shared/sync-core/replay';
+import type { Timeline } from '../../shared/sync-protocol';
+
+const arg = (flag: string): string | undefined => {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+};
+const URL = arg('--redis') ?? process.env.REDIS_URL ?? 'redis://localhost:6380';
+const GATE = process.argv.includes('--gate');
+
+function fieldsToEntry(fields: string[]): LogEntry {
+  const m = new Map<string, string>();
+  for (let i = 0; i < fields.length; i += 2) m.set(fields[i], fields[i + 1]);
+  return {
+    seq: Number(m.get('seq')),
+    storeEpoch: m.get('storeEpoch') ?? '',
+    videoId: m.get('videoId') || null,
+    isPlaying: m.get('isPlaying') === '1',
+    mediaTime: Number(m.get('mediaTime')),
+    stampedAt: Number(m.get('stampedAt')),
+    reason: m.get('reason') ?? '',
+    by: m.get('by') || undefined,
+    cmdId: m.get('cmdId') || undefined,
+  };
+}
+
+function hashToTimeline(h: Record<string, string>): Timeline {
+  return {
+    v: 1,
+    seq: Number(h.seq),
+    storeEpoch: h.storeEpoch,
+    videoId: h.videoId || null,
+    isPlaying: h.isPlaying === '1',
+    mediaTime: Number(h.mediaTime),
+    stampedAt: Number(h.stampedAt),
+    rate: 1,
+    reason: h.reason as Timeline['reason'],
+    by: h.by || undefined,
+  };
+}
+
+async function main(): Promise<void> {
+  const redis = new Redis(URL, { maxRetriesPerRequest: 2 });
+  const logKeys: string[] = [];
+  let cursor = '0';
+  do {
+    const [next, keys] = await redis.scan(
+      cursor,
+      'MATCH',
+      'room:*:log',
+      'COUNT',
+      200,
+    );
+    cursor = next;
+    logKeys.push(...keys);
+  } while (cursor !== '0');
+
+  let rooms = 0;
+  let entries = 0;
+  let driftRooms = 0;
+  const violations: string[] = [];
+  for (const logKey of logKeys) {
+    const room = logKey.slice('room:'.length, -':log'.length);
+    const raw = (await redis.xrange(logKey, '-', '+')) as Array<
+      [string, string[]]
+    >;
+    if (raw.length === 0) continue;
+    rooms += 1;
+    const log = raw.map(([, fields]) => fieldsToEntry(fields));
+    entries += log.length;
+
+    const chain = checkChain(log);
+    for (const v of chain.violations) violations.push(`${room}: ${v}`);
+
+    const live = await redis.hgetall(`room:${room}:tl`);
+    if (Object.keys(live).length === 0) {
+      // timeline expired but the log survived: nothing to reconcile against
+      continue;
+    }
+    const mismatch = entryMatchesLive(
+      log[log.length - 1],
+      hashToTimeline(live),
+    );
+    if (mismatch) {
+      driftRooms += 1;
+      violations.push(`${room}: LIVE DRIFT - ${mismatch}`);
+    }
+  }
+  await redis.quit();
+
+  const driftRate = rooms > 0 ? driftRooms / rooms : 0;
+  console.log(
+    JSON.stringify(
+      {
+        redis: URL,
+        rooms,
+        entries,
+        transitionsChecked: entries - rooms,
+        contractViolations: violations.length - driftRooms,
+        driftRooms,
+        driftRate,
+        violations: violations.slice(0, 20),
+      },
+      null,
+      2,
+    ),
+  );
+  if (GATE && violations.length > 0) {
+    console.error(`[replay-check] FAILED: ${violations.length} violation(s)`);
+    process.exit(1);
+  }
+  console.log('[replay-check] PASSED');
+}
+
+void main();

--- a/sync-harness/src/scenarios.ts
+++ b/sync-harness/src/scenarios.ts
@@ -67,6 +67,27 @@ export const SCENARIOS: Record<string, ScenarioSpec> = {
     impairment: { tool: 'netem', netemSpec: 'delay 60ms 40ms 25% loss 2%' },
     durationS: 240,
   },
+  // HONESTY NOTE for S8/S9: netem duplicate/reorder operate on TCP
+  // SEGMENTS, and TCP dedupes and re-orders its own stream - the app never
+  // sees a duplicated or reordered message from these. What they actually
+  // stress is TCP-level pathology: duplicate-ACK processing and
+  // head-of-line blocking on reassembly, i.e. latency variance. The
+  // app-level duplicate/reorder proof is the bot fleet's --dup-controls
+  // injection (SYNC_DESIGN 2a), not a transport toxic.
+  S8: {
+    id: 'S8',
+    title: '25ms + 5% TCP-segment duplication (netem) — dup-ACK pathology',
+    must: false,
+    impairment: { tool: 'netem', netemSpec: 'delay 25ms duplicate 5%' },
+    durationS: 240,
+  },
+  S9: {
+    id: 'S9',
+    title: '40ms with 25% segments sent ahead (netem reorder) — HoL blocking',
+    must: false,
+    impairment: { tool: 'netem', netemSpec: 'delay 40ms reorder 25% 50%' },
+    durationS: 240,
+  },
 };
 
 // Deterministic scripted timeline (seconds from scenario start).

--- a/video-sync-backend/src/shared/sync-core/replay.ts
+++ b/video-sync-backend/src/shared/sync-core/replay.ts
@@ -30,14 +30,18 @@ export interface LogEntry {
   cmdId?: string;
 }
 
-const CONTROL_REASONS: ReadonlySet<string> = new Set([
-  'play',
-  'pause',
-  'seek',
-]);
+const CONTROL_REASONS: ReadonlySet<string> = new Set(['play', 'pause', 'seek']);
 
 /** float slack for the snapshot projection (Lua string arithmetic). */
 const EPS = 1e-6;
+
+/**
+ * NaN fails every > comparison, so `Math.abs(a-b) > EPS` reports a
+ * non-finite value as LEGAL - the one way a corrupt entry could pass this
+ * checker silently. Every float comparison goes through here instead.
+ */
+const differs = (a: number, b: number): boolean =>
+  !Number.isFinite(a) || !Number.isFinite(b) || Math.abs(a - b) > EPS;
 
 /**
  * The legal-transition contract between two consecutive same-epoch entries,
@@ -45,10 +49,7 @@ const EPS = 1e-6;
  * exactly like the spec's Contract vs Apply split. Returns a violation
  * description, or null when legal.
  */
-export function checkTransition(
-  prev: LogEntry,
-  next: LogEntry,
-): string | null {
+export function checkTransition(prev: LogEntry, next: LogEntry): string | null {
   if (next.storeEpoch !== prev.storeEpoch) {
     return null; // epoch boundaries are anchored by init entries, not chained
   }
@@ -78,13 +79,8 @@ export function checkTransition(
     if (next.isPlaying !== prev.isPlaying) {
       return 'snapshot flipped isPlaying';
     }
-    const projected = projectMediaTime(
-      {
-        ...toTimeline(prev),
-      },
-      next.stampedAt,
-    );
-    if (Math.abs(next.mediaTime - projected) > EPS) {
+    const projected = projectMediaTime({ ...toTimeline(prev) }, next.stampedAt);
+    if (differs(next.mediaTime, projected)) {
       return `snapshot moved the projection: expected ${projected}, logged ${next.mediaTime}`;
     }
     return null;
@@ -144,8 +140,11 @@ export function entryMatchesLive(
   if (last.isPlaying !== live.isPlaying) {
     return `isPlaying: log ${last.isPlaying} vs live ${live.isPlaying}`;
   }
-  if (Math.abs(last.mediaTime - live.mediaTime) > EPS) {
+  if (differs(last.mediaTime, live.mediaTime)) {
     return `mediaTime: log ${last.mediaTime} vs live ${live.mediaTime}`;
+  }
+  if (last.reason !== live.reason) {
+    return `reason: log ${last.reason} vs live ${live.reason}`;
   }
   if (last.stampedAt !== live.stampedAt) {
     return `stampedAt: log ${last.stampedAt} vs live ${live.stampedAt}`;

--- a/video-sync-backend/src/shared/sync-core/replay.ts
+++ b/video-sync-backend/src/shared/sync-core/replay.ts
@@ -1,0 +1,157 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+import { ControlIntent, Timeline } from '../sync-protocol';
+import { projectMediaTime } from './timeline';
+
+/**
+ * One committed transition, as appended (atomically with the commit) to the
+ * per-room append-only log by every Lua commit script and the InMemory
+ * store. Entries are FULL post-states, so the log is a transition relation:
+ * replay does not need to re-execute anything, and every consecutive pair
+ * can be checked against the intent contract independently of the code that
+ * produced it.
+ *
+ * This is formal/SyncExactlyOnce.tla transferred to the implementation:
+ * `checkChain` is TransitionContract, `entryMatchesLive` is
+ * ReplayReconstructs - and the spec's nosnaplog config is why snapshot
+ * commits MUST be logged (they bump seq and re-anchor the projection; a log
+ * without them cannot rebuild live state and reconciliation would report
+ * phantom drift).
+ */
+export interface LogEntry {
+  seq: number;
+  storeEpoch: string;
+  videoId: string | null;
+  isPlaying: boolean;
+  mediaTime: number;
+  stampedAt: number;
+  reason: string;
+  by?: string;
+  cmdId?: string;
+}
+
+const CONTROL_REASONS: ReadonlySet<string> = new Set([
+  'play',
+  'pause',
+  'seek',
+]);
+
+/** float slack for the snapshot projection (Lua string arithmetic). */
+const EPS = 1e-6;
+
+/**
+ * The legal-transition contract between two consecutive same-epoch entries,
+ * written INDEPENDENTLY of applyControl/snapshot - double-entry bookkeeping,
+ * exactly like the spec's Contract vs Apply split. Returns a violation
+ * description, or null when legal.
+ */
+export function checkTransition(
+  prev: LogEntry,
+  next: LogEntry,
+): string | null {
+  if (next.storeEpoch !== prev.storeEpoch) {
+    return null; // epoch boundaries are anchored by init entries, not chained
+  }
+  if (next.seq !== prev.seq + 1) {
+    return `seq ${prev.seq} -> ${next.seq}: not contiguous`;
+  }
+  if (next.stampedAt < prev.stampedAt) {
+    return `stampedAt regressed ${prev.stampedAt} -> ${next.stampedAt}`;
+  }
+  if (next.videoId !== prev.videoId) {
+    return `videoId changed mid-epoch (${prev.videoId} -> ${next.videoId})`;
+  }
+  if (CONTROL_REASONS.has(next.reason)) {
+    const intent = next.reason as ControlIntent;
+    if (intent === 'play' && !next.isPlaying) {
+      return 'play committed a non-playing state';
+    }
+    if (intent === 'pause' && next.isPlaying) {
+      return 'pause committed a playing state';
+    }
+    if (intent === 'seek' && next.isPlaying !== prev.isPlaying) {
+      return 'seek flipped isPlaying';
+    }
+    return null; // mediaTime is the commanded position - any value is legal
+  }
+  if (next.reason === 'snapshot') {
+    if (next.isPlaying !== prev.isPlaying) {
+      return 'snapshot flipped isPlaying';
+    }
+    const projected = projectMediaTime(
+      {
+        ...toTimeline(prev),
+      },
+      next.stampedAt,
+    );
+    if (Math.abs(next.mediaTime - projected) > EPS) {
+      return `snapshot moved the projection: expected ${projected}, logged ${next.mediaTime}`;
+    }
+    return null;
+  }
+  return `unknown transition reason '${next.reason}'`;
+}
+
+export function toTimeline(e: LogEntry): Timeline {
+  return {
+    v: 1,
+    seq: e.seq,
+    storeEpoch: e.storeEpoch,
+    videoId: e.videoId,
+    isPlaying: e.isPlaying,
+    mediaTime: e.mediaTime,
+    stampedAt: e.stampedAt,
+    rate: 1,
+    reason: e.reason as Timeline['reason'],
+    by: e.by || undefined,
+  };
+}
+
+export interface ChainReport {
+  checked: number;
+  violations: string[];
+}
+
+/**
+ * Validate every consecutive pair in stream order. The log is trimmed
+ * (MAXLEN ~), so the chain is anchored at the OLDEST RETAINED entry - a
+ * truncated head is expected and legal; a hole or an illegal transition
+ * inside the retained window is not.
+ */
+export function checkChain(entries: LogEntry[]): ChainReport {
+  const violations: string[] = [];
+  for (let i = 1; i < entries.length; i++) {
+    const v = checkTransition(entries[i - 1], entries[i]);
+    if (v) violations.push(`entry ${i} (seq ${entries[i].seq}): ${v}`);
+  }
+  return { checked: Math.max(0, entries.length - 1), violations };
+}
+
+/**
+ * ReplayReconstructs: the newest retained log entry must BE the live state.
+ * Any disagreement is drift between what was committed and what is served.
+ */
+export function entryMatchesLive(
+  last: LogEntry,
+  live: Timeline,
+): string | null {
+  if (last.storeEpoch !== live.storeEpoch) {
+    return `epoch: log ${last.storeEpoch} vs live ${live.storeEpoch}`;
+  }
+  if (last.seq !== live.seq) {
+    return `seq: log ${last.seq} vs live ${live.seq}`;
+  }
+  if (last.isPlaying !== live.isPlaying) {
+    return `isPlaying: log ${last.isPlaying} vs live ${live.isPlaying}`;
+  }
+  if (Math.abs(last.mediaTime - live.mediaTime) > EPS) {
+    return `mediaTime: log ${last.mediaTime} vs live ${live.mediaTime}`;
+  }
+  if (last.stampedAt !== live.stampedAt) {
+    return `stampedAt: log ${last.stampedAt} vs live ${live.stampedAt}`;
+  }
+  if ((last.videoId ?? null) !== (live.videoId ?? null)) {
+    return `videoId: log ${last.videoId} vs live ${live.videoId}`;
+  }
+  return null;
+}

--- a/video-sync-backend/src/sync/actor-room-state.store.spec.ts
+++ b/video-sync-backend/src/sync/actor-room-state.store.spec.ts
@@ -19,10 +19,9 @@ describe('ActorRoomStateStore — lease fencing', () => {
   const make = (id: string): ActorRoomStateStore => {
     process.env.INSTANCE_ID = id;
     const kv = new Redis(URL, { maxRetriesPerRequest: 1, lazyConnect: false });
-    const pub = new Redis(URL, { maxRetriesPerRequest: 1 });
     const sub = new Redis(URL, { maxRetriesPerRequest: 1 });
-    clients.push(kv, pub, sub);
-    return new ActorRoomStateStore(kv, pub, sub);
+    clients.push(kv, sub);
+    return new ActorRoomStateStore(kv, sub);
   };
 
   beforeAll(async () => {

--- a/video-sync-backend/src/sync/actor-room-state.store.ts
+++ b/video-sync-backend/src/sync/actor-room-state.store.ts
@@ -125,7 +125,6 @@ export class ActorRoomStateStore
 
   constructor(
     @Inject(REDIS_KV) kv: Redis,
-    @Inject(REDIS_PUB) private pub: Redis,
     @Inject(REDIS_SUB) private sub: Redis,
   ) {
     const dir = join(__dirname, 'lua');
@@ -199,6 +198,15 @@ export class ActorRoomStateStore
   private logKey(roomCode: string): string {
     return `room:${roomCode}:log`;
   }
+  /**
+   * Forward publishes ride the KV client, NOT the pubsub client, on
+   * purpose: REDIS_PUB retries without bound (offline queue), so a pending
+   * PUBLISH could be delivered after the cmdId dedup record's TTL expired -
+   * re-opening the double-apply the record exists to close. The KV client's
+   * bounded retries keep the redelivery window seconds-scale, far inside
+   * the 15-minute TTL, which is exactly the Ttl > RetryWindow relation the
+   * spec's earlyevict config makes a correctness requirement.
+   */
   private forwardChannel(instanceId: string): string {
     return `actor:fwd:${instanceId}`;
   }
@@ -347,7 +355,7 @@ export class ActorRoomStateStore
       const lease = await this.claim(roomCode);
       if (!lease.mine) {
         // someone else owns this room: forward and let them broadcast
-        const delivered = await this.pub.publish(
+        const delivered = await this.kv.publish(
           this.forwardChannel(lease.owner),
           JSON.stringify({
             roomCode,
@@ -378,7 +386,7 @@ export class ActorRoomStateStore
         const retaken = await this.claim(roomCode);
         if (!retaken.mine) {
           // P07: a live owner exists after all - forward rather than drop
-          const second = await this.pub.publish(
+          const second = await this.kv.publish(
             this.forwardChannel(retaken.owner),
             JSON.stringify({
               roomCode,
@@ -433,7 +441,7 @@ export class ActorRoomStateStore
         ? { kind: 'committed', timeline: retry.timeline }
         : { kind: 'missing' };
     }
-    const delivered = await this.pub.publish(
+    const delivered = await this.kv.publish(
       this.forwardChannel(nowLease.owner),
       JSON.stringify({
         roomCode,

--- a/video-sync-backend/src/sync/actor-room-state.store.ts
+++ b/video-sync-backend/src/sync/actor-room-state.store.ts
@@ -8,7 +8,7 @@ import { readFileSync } from 'node:fs';
 import { hostname } from 'node:os';
 import { join } from 'node:path';
 import type Redis from 'ioredis';
-import { REDIS_KV, REDIS_PUB, REDIS_SUB } from '../redis/redis.module';
+import { REDIS_KV, REDIS_SUB } from '../redis/redis.module';
 import { ControlIntent, Timeline } from '../shared/sync-protocol';
 import { applyControl, snapshot } from '../shared/sync-core/timeline';
 import {

--- a/video-sync-backend/src/sync/actor-room-state.store.ts
+++ b/video-sync-backend/src/sync/actor-room-state.store.ts
@@ -60,6 +60,7 @@ interface RedisWithActor extends Redis {
   actorInit(
     leaseKey: string,
     timelineKey: string,
+    logKey: string,
     instanceId: string,
     fence: string,
     mediaTime: string,
@@ -70,6 +71,7 @@ interface RedisWithActor extends Redis {
     leaseKey: string,
     timelineKey: string,
     cmdKey: string,
+    logKey: string,
     instanceId: string,
     fence: string,
     isPlaying: string,
@@ -137,11 +139,11 @@ export class ActorRoomStateStore
       lua: read('actor_reclaim.lua'),
     });
     kv.defineCommand('actorInit', {
-      numberOfKeys: 2,
+      numberOfKeys: 3,
       lua: read('actor_init.lua'),
     });
     kv.defineCommand('actorCommit', {
-      numberOfKeys: 3,
+      numberOfKeys: 4,
       lua: read('actor_commit.lua'),
     });
     this.kv = kv as RedisWithActor;
@@ -192,6 +194,10 @@ export class ActorRoomStateStore
   }
   private timelineKey(roomCode: string): string {
     return `room:${roomCode}:tl`;
+  }
+
+  private logKey(roomCode: string): string {
+    return `room:${roomCode}:log`;
   }
   private forwardChannel(instanceId: string): string {
     return `actor:fwd:${instanceId}`;
@@ -262,6 +268,7 @@ export class ActorRoomStateStore
       // command across handoff - but this key can, and it lives in Redis
       // rather than owner memory precisely so a handoff cannot forget it
       `room:${roomCode}:cmd:${cmdId ?? ''}`,
+      this.logKey(roomCode),
       this.instanceId,
       fence,
       next.isPlaying ? '1' : '0',
@@ -478,6 +485,7 @@ export class ActorRoomStateStore
       const raw = await this.kv.actorInit(
         this.leaseKey(roomCode),
         this.timelineKey(roomCode),
+        this.logKey(roomCode),
         this.instanceId,
         lease.epoch,
         String(mediaTime),

--- a/video-sync-backend/src/sync/lua/actor_commit.lua
+++ b/video-sync-backend/src/sync/lua/actor_commit.lua
@@ -1,4 +1,5 @@
--- Fenced commit. KEYS[1]=lease, KEYS[2]=timeline, KEYS[3]=cmd dedup record
+-- Fenced commit. KEYS[1]=lease, KEYS[2]=timeline, KEYS[3]=cmd dedup record,
+-- KEYS[4]=append-only command log
 -- ARGV: instanceId, fence, isPlaying, mediaTime, reason, by, videoId,
 --       ttlMs, cmdId, dedupTtlMs
 -- A commit is accepted ONLY if the caller still holds the lease at the fence
@@ -49,6 +50,13 @@ redis.call('HSET', KEYS[2],
   'isPlaying', ARGV[3], 'mediaTime', ARGV[4],
   'stampedAt', tostring(now), 'reason', ARGV[5], 'by', ARGV[6])
 redis.call('PEXPIRE', KEYS[2], ARGV[8])
+-- log atomically with the commit; duplicates return above and never land here
+redis.call('XADD', KEYS[4], 'MAXLEN', '~', 1024, '*',
+  'seq', seq, 'storeEpoch', ARGV[2], 'videoId', ARGV[7],
+  'isPlaying', ARGV[3], 'mediaTime', ARGV[4],
+  'stampedAt', tostring(now), 'reason', ARGV[5], 'by', ARGV[6],
+  'cmdId', ARGV[9])
+redis.call('PEXPIRE', KEYS[4], ARGV[8])
 return cjson.encode({
   v = 1, seq = seq, storeEpoch = ARGV[2],
   videoId = ARGV[7] ~= '' and ARGV[7] or nil,

--- a/video-sync-backend/src/sync/lua/actor_init.lua
+++ b/video-sync-backend/src/sync/lua/actor_init.lua
@@ -1,4 +1,5 @@
--- Fenced create-if-absent. KEYS[1]=lease, KEYS[2]=timeline.
+-- Fenced create-if-absent. KEYS[1]=lease, KEYS[2]=timeline,
+-- KEYS[3]=append-only command log.
 -- ARGV: instanceId, fence, mediaTime, videoId, ttlMs
 -- Atomicity matters as much as fencing: without the create-if-absent check
 -- INSIDE the script, N concurrent joins each saw "no state yet" and each
@@ -42,4 +43,10 @@ redis.call('HSET', KEYS[2],
   'isPlaying', '0', 'mediaTime', ARGV[3],
   'stampedAt', tostring(now), 'reason', 'join', 'by', '')
 redis.call('PEXPIRE', KEYS[2], ARGV[5])
+-- the fence-epoch's birth entry anchors the replay chain
+redis.call('XADD', KEYS[3], 'MAXLEN', '~', 1024, '*',
+  'seq', 0, 'storeEpoch', ARGV[2], 'videoId', ARGV[4],
+  'isPlaying', '0', 'mediaTime', ARGV[3],
+  'stampedAt', tostring(now), 'reason', 'join', 'by', '', 'cmdId', '')
+redis.call('PEXPIRE', KEYS[3], ARGV[5])
 return encode(0, ARGV[4], '0', ARGV[3], tostring(now), 'join')

--- a/video-sync-backend/src/sync/lua/apply_control.lua
+++ b/video-sync-backend/src/sync/lua/apply_control.lua
@@ -1,5 +1,6 @@
 -- KEYS[1]=room:X:tl  KEYS[2]=room:X:cmd:<cmdId> (dedup record; unused when
--- ARGV[4] is empty)  ARGV: intent, mediaTime, by, cmdId, dedupTtlMs
+-- ARGV[4] is empty)  KEYS[3]=room:X:log (append-only command log)
+-- ARGV: intent, mediaTime, by, cmdId, dedupTtlMs
 --
 -- The idempotency check lives HERE, inside the same atomic script as the
 -- commit, because a check-then-apply split across two round trips is the
@@ -34,4 +35,5 @@ elseif intent == 'pause' then
 end
 -- seek keeps isPlaying as-is
 save_tl(KEYS[1], tl, 86400000)
+log_tl(KEYS[3], tl, ARGV[4])
 return encode(tl)

--- a/video-sync-backend/src/sync/lua/apply_snapshot.lua
+++ b/video-sync-backend/src/sync/lua/apply_snapshot.lua
@@ -35,4 +35,5 @@ tl.lastSweepWindow = window
 tl.reason = 'snapshot'
 tl.by = ''
 save_tl(KEYS[1], tl, 86400000)
+log_tl(KEYS[2], tl, '')
 return encode(tl)

--- a/video-sync-backend/src/sync/lua/common.lua
+++ b/video-sync-backend/src/sync/lua/common.lua
@@ -19,6 +19,21 @@ local function save_tl(key, tl, ttl)
     'lastSweepWindow', tl.lastSweepWindow or -1)
   redis.call('PEXPIRE', key, ttl)
 end
+-- Append the committed post-state to the room's append-only log, atomic
+-- with the commit because it runs inside the same script. Auto-ID ('*') is
+-- legal in scripts on Redis >= 5 (effect-based replication; redis:7 here).
+-- MAXLEN ~ trims approximately; the replay checker anchors at the oldest
+-- retained entry, so trimming truncates history without corrupting it.
+-- Snapshot commits are logged too - formal/SyncExactlyOnce.tla's nosnaplog
+-- config is the counterexample for leaving them out.
+local function log_tl(logKey, tl, cmdId)
+  redis.call('XADD', logKey, 'MAXLEN', '~', 1024, '*',
+    'seq', tl.seq, 'storeEpoch', tl.storeEpoch, 'videoId', tl.videoId or '',
+    'isPlaying', tl.isPlaying, 'mediaTime', tl.mediaTime,
+    'stampedAt', tl.stampedAt, 'reason', tl.reason, 'by', tl.by or '',
+    'cmdId', cmdId or '')
+  redis.call('PEXPIRE', logKey, 86400000)
+end
 -- dup: set when answering a deduplicated command - the caller replies to
 -- the sender with current state but must NOT broadcast (the original
 -- commit already did). Stripped before the timeline reaches any client.

--- a/video-sync-backend/src/sync/lua/init.lua
+++ b/video-sync-backend/src/sync/lua/init.lua
@@ -7,4 +7,6 @@ local tl = {
   reason = 'join', by = '',
 }
 save_tl(KEYS[1], tl, 86400000)
+-- the epoch's birth entry anchors the replay chain for this epoch
+log_tl(KEYS[2], tl, '')
 return encode(tl)

--- a/video-sync-backend/src/sync/redis-room-state.store.spec.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.spec.ts
@@ -1,6 +1,7 @@
 import Redis from 'ioredis';
 import { RedisRoomStateStore } from './redis-room-state.store';
 import type { Timeline } from '../shared/sync-protocol';
+import { checkChain, type LogEntry } from '../shared/sync-core/replay';
 import { SWEEP_DEDUP_PERIOD_MS } from './room-state.store';
 
 /**
@@ -240,6 +241,46 @@ describe('RedisRoomStateStore — repair sweep dedup', () => {
       cmdId: 'cmd-ttl',
     });
     expect(replay.kind).toBe('committed'); // which is why TTL >> redelivery window
+  });
+
+  it('every commit lands in the append-only log; duplicates never do', async () => {
+    if (!available) return;
+    const a = make();
+    const c = raw();
+    const r = `${room}-log`;
+    await playingRoom(a, r);
+    await a.applyControl(r, 'seek', 300, Date.now(), 'u1', { cmdId: 'log-1' });
+    await a.applyControl(r, 'seek', 300, Date.now(), 'u1', { cmdId: 'log-1' });
+    await a.applySnapshot(r, Date.now());
+
+    const rawLog = (await c.xrange(`room:${r}:log`, '-', '+')) as Array<
+      [string, string[]]
+    >;
+    // init + play (from playingRoom) + ONE seek (dup absorbed) + sweep
+    expect(rawLog).toHaveLength(4);
+    const log: LogEntry[] = rawLog.map(([, f]) => {
+      const m = new Map<string, string>();
+      for (let i = 0; i < f.length; i += 2) m.set(f[i], f[i + 1]);
+      return {
+        seq: Number(m.get('seq')),
+        storeEpoch: m.get('storeEpoch') ?? '',
+        videoId: m.get('videoId') || null,
+        isPlaying: m.get('isPlaying') === '1',
+        mediaTime: Number(m.get('mediaTime')),
+        stampedAt: Number(m.get('stampedAt')),
+        reason: m.get('reason') ?? '',
+        by: m.get('by') || undefined,
+        cmdId: m.get('cmdId') || undefined,
+      };
+    });
+    // the retained chain is contract-legal end to end (TransitionContract),
+    // and the deduped delivery is nowhere in it
+    expect(checkChain(log).violations).toEqual([]);
+    expect(log.filter((e) => e.cmdId === 'log-1')).toHaveLength(1);
+    // and the newest entry IS the live state (ReplayReconstructs)
+    const live = await a.get(r);
+    expect(log[log.length - 1].seq).toBe(live!.seq);
+    expect(log[log.length - 1].mediaTime).toBeCloseTo(live!.mediaTime, 6);
   });
 
   it('never advances a paused room', async () => {

--- a/video-sync-backend/src/sync/redis-room-state.store.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.ts
@@ -37,14 +37,24 @@ interface RedisWithCommands extends Redis {
   mustardApplyControl(
     key: string,
     cmdKey: string,
+    logKey: string,
     intent: string,
     mediaTime: string,
     by: string,
     cmdId: string,
     dedupTtlMs: string,
   ): Promise<string | null>;
-  mustardApplySnapshot(key: string, periodMs: string): Promise<string | null>;
-  mustardInit(key: string, videoId: string, mediaTime: string): Promise<string>;
+  mustardApplySnapshot(
+    key: string,
+    logKey: string,
+    periodMs: string,
+  ): Promise<string | null>;
+  mustardInit(
+    key: string,
+    logKey: string,
+    videoId: string,
+    mediaTime: string,
+  ): Promise<string>;
 }
 
 @Injectable()
@@ -53,19 +63,23 @@ export class RedisRoomStateStore implements RoomStateStore {
 
   constructor(@Inject(REDIS_KV) redis: Redis) {
     redis.defineCommand('mustardApplyControl', {
-      numberOfKeys: 2,
+      numberOfKeys: 3,
       lua: LUA_APPLY_CONTROL,
     });
     redis.defineCommand('mustardApplySnapshot', {
-      numberOfKeys: 1,
+      numberOfKeys: 2,
       lua: LUA_APPLY_SNAPSHOT,
     });
-    redis.defineCommand('mustardInit', { numberOfKeys: 1, lua: LUA_INIT });
+    redis.defineCommand('mustardInit', { numberOfKeys: 2, lua: LUA_INIT });
     this.redis = redis as RedisWithCommands;
   }
 
   private key(roomCode: string): string {
     return `room:${roomCode}:tl`;
+  }
+
+  private logKey(roomCode: string): string {
+    return `room:${roomCode}:log`;
   }
 
   private parse(json: string | null): Timeline | null {
@@ -104,6 +118,7 @@ export class RedisRoomStateStore implements RoomStateStore {
       this.key(roomCode),
       // the dedup record; the script never touches it when cmdId is ''
       `room:${roomCode}:cmd:${cmdId ?? ''}`,
+      this.logKey(roomCode),
       intent,
       String(mediaTime),
       by,
@@ -137,6 +152,7 @@ export class RedisRoomStateStore implements RoomStateStore {
     // their callers skip broadcasting.
     const result = await this.redis.mustardApplySnapshot(
       this.key(roomCode),
+      this.logKey(roomCode),
       String(SWEEP_DEDUP_PERIOD_MS),
     );
     return this.parse(result);
@@ -151,6 +167,7 @@ export class RedisRoomStateStore implements RoomStateStore {
   ): Promise<Timeline> {
     const result = await this.redis.mustardInit(
       this.key(roomCode),
+      this.logKey(roomCode),
       videoId ?? '',
       String(mediaTime),
     );

--- a/video-sync-backend/src/sync/replay.spec.ts
+++ b/video-sync-backend/src/sync/replay.spec.ts
@@ -1,0 +1,96 @@
+import { InMemoryRoomStateStore } from './room-state.store';
+import {
+  checkChain,
+  checkTransition,
+  entryMatchesLive,
+} from '../shared/sync-core/replay';
+
+/**
+ * The replay contract (formal/SyncExactlyOnce.tla: TransitionContract +
+ * ReplayReconstructs) against the InMemory store's mirrored log - the same
+ * checker the harness reconciler runs against the Redis streams, so the
+ * CI-without-Redis path proves the identical semantics.
+ */
+describe('append-only log replay contract', () => {
+  it('a real command sequence produces a legal chain that matches live', async () => {
+    const store = new InMemoryRoomStateStore();
+    const r = 'replay-room';
+    await store.init(r, 'vid', 0, 1_000);
+    await store.applyControl(r, 'play', 0, 2_000, 'u1', { cmdId: 'c1' });
+    await store.applyControl(r, 'seek', 300, 3_000, 'u1', { cmdId: 'c2' });
+    await store.applySnapshot(r, 5_000);
+    await store.applyControl(r, 'pause', 305, 6_000, 'u1', { cmdId: 'c3' });
+
+    const log = store.getLog(r);
+    expect(log).toHaveLength(5); // init + 3 controls + 1 sweep - ALL logged
+
+    const chain = checkChain(log);
+    expect(chain.violations).toEqual([]);
+    expect(chain.checked).toBe(4);
+
+    const live = await store.get(r);
+    expect(entryMatchesLive(log[log.length - 1], live!)).toBeNull();
+  });
+
+  it('a duplicate does not append - the log records commits, not deliveries', async () => {
+    const store = new InMemoryRoomStateStore();
+    const r = 'replay-dup';
+    await store.init(r, 'vid', 0, 1_000);
+    await store.applyControl(r, 'seek', 42, 2_000, 'u1', { cmdId: 'dup' });
+    await store.applyControl(r, 'seek', 42, 3_000, 'u1', { cmdId: 'dup' });
+    expect(store.getLog(r)).toHaveLength(2); // init + ONE commit
+  });
+
+  it('the contract catches what it exists to catch', () => {
+    const base = {
+      storeEpoch: '1000',
+      videoId: 'vid',
+      isPlaying: true,
+      mediaTime: 100,
+      stampedAt: 5_000,
+      by: 'u1',
+    };
+    const prev = { ...base, seq: 3, reason: 'play' };
+    // a seek that flips isPlaying - the double-entry check the spec transfers
+    expect(
+      checkTransition(prev, {
+        ...base,
+        seq: 4,
+        reason: 'seek',
+        isPlaying: false,
+        mediaTime: 200,
+        stampedAt: 6_000,
+      }),
+    ).toMatch(/flipped isPlaying/);
+    // a snapshot that moves the projection: playing at 100 anchored at 5s,
+    // snapshotted at 7s must land at exactly 102
+    expect(
+      checkTransition(prev, {
+        ...base,
+        seq: 4,
+        reason: 'snapshot',
+        mediaTime: 150,
+        stampedAt: 7_000,
+      }),
+    ).toMatch(/moved the projection/);
+    expect(
+      checkTransition(prev, {
+        ...base,
+        seq: 4,
+        reason: 'snapshot',
+        mediaTime: 102,
+        stampedAt: 7_000,
+      }),
+    ).toBeNull();
+    // a hole in the chain
+    expect(
+      checkTransition(prev, {
+        ...base,
+        seq: 6,
+        reason: 'pause',
+        isPlaying: false,
+        stampedAt: 6_000,
+      }),
+    ).toMatch(/not contiguous/);
+  });
+});

--- a/video-sync-backend/src/sync/room-state.store.ts
+++ b/video-sync-backend/src/sync/room-state.store.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ControlIntent, Timeline } from '../shared/sync-protocol';
 import { applyControl, snapshot } from '../shared/sync-core/timeline';
+import type { LogEntry } from '../shared/sync-core/replay';
 
 /** Repair-sweep period. Each instance runs this timer for its local rooms. */
 export const SWEEP_INTERVAL_MS = 10_000;
@@ -91,6 +92,31 @@ export class InMemoryRoomStateStore implements RoomStateStore {
   /** roomCode -> cmdId -> expiry; mirrors the Redis SET NX PX semantics so
    *  CI without Redis exercises the same dedup contract. */
   private cmdSeen = new Map<string, Map<string, number>>();
+  /** append-only per-room log of committed transitions, mirroring the Lua
+   *  XADD (bounded like MAXLEN ~): the replay checker's CI-without-Redis
+   *  substrate */
+  private logs = new Map<string, LogEntry[]>();
+
+  private appendLog(roomCode: string, tl: Timeline, cmdId?: string): void {
+    const log = this.logs.get(roomCode) ?? [];
+    log.push({
+      seq: tl.seq,
+      storeEpoch: tl.storeEpoch,
+      videoId: tl.videoId,
+      isPlaying: tl.isPlaying,
+      mediaTime: tl.mediaTime,
+      stampedAt: tl.stampedAt,
+      reason: tl.reason,
+      by: tl.by,
+      cmdId,
+    });
+    if (log.length > 1024) log.shift();
+    this.logs.set(roomCode, log);
+  }
+
+  getLog(roomCode: string): LogEntry[] {
+    return this.logs.get(roomCode) ?? [];
+  }
 
   // Single-process: JS execution is the serializer, so plain sync mutation
   // inside async methods is atomic per call.
@@ -127,6 +153,7 @@ export class InMemoryRoomStateStore implements RoomStateStore {
       seq: prev.seq + 1,
     };
     this.rooms.set(roomCode, next);
+    this.appendLog(roomCode, next, cmdId);
     return Promise.resolve({ kind: 'committed', timeline: next });
   }
 
@@ -135,6 +162,7 @@ export class InMemoryRoomStateStore implements RoomStateStore {
     if (!prev) return Promise.resolve(null);
     const next: Timeline = { ...snapshot(prev, serverNow), seq: prev.seq + 1 };
     this.rooms.set(roomCode, next);
+    this.appendLog(roomCode, next);
     return Promise.resolve(next);
   }
 
@@ -160,10 +188,12 @@ export class InMemoryRoomStateStore implements RoomStateStore {
       reason: 'join',
     };
     this.rooms.set(roomCode, created);
+    this.appendLog(roomCode, created);
     return Promise.resolve(created);
   }
 
   clear(roomCode: string): Promise<void> {
+    this.logs.delete(roomCode);
     this.cmdSeen.delete(roomCode);
     this.rooms.delete(roomCode);
     return Promise.resolve();

--- a/video-sync-frontend/src/shared/sync-core/replay.ts
+++ b/video-sync-frontend/src/shared/sync-core/replay.ts
@@ -30,11 +30,7 @@ export interface LogEntry {
   cmdId?: string;
 }
 
-const CONTROL_REASONS: ReadonlySet<string> = new Set([
-  'play',
-  'pause',
-  'seek',
-]);
+const CONTROL_REASONS: ReadonlySet<string> = new Set(['play', 'pause', 'seek']);
 
 /** float slack for the snapshot projection (Lua string arithmetic). */
 const EPS = 1e-6;
@@ -53,10 +49,7 @@ const differs = (a: number, b: number): boolean =>
  * exactly like the spec's Contract vs Apply split. Returns a violation
  * description, or null when legal.
  */
-export function checkTransition(
-  prev: LogEntry,
-  next: LogEntry,
-): string | null {
+export function checkTransition(prev: LogEntry, next: LogEntry): string | null {
   if (next.storeEpoch !== prev.storeEpoch) {
     return null; // epoch boundaries are anchored by init entries, not chained
   }

--- a/video-sync-frontend/src/shared/sync-core/replay.ts
+++ b/video-sync-frontend/src/shared/sync-core/replay.ts
@@ -1,0 +1,157 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+import { ControlIntent, Timeline } from '../sync-protocol';
+import { projectMediaTime } from './timeline';
+
+/**
+ * One committed transition, as appended (atomically with the commit) to the
+ * per-room append-only log by every Lua commit script and the InMemory
+ * store. Entries are FULL post-states, so the log is a transition relation:
+ * replay does not need to re-execute anything, and every consecutive pair
+ * can be checked against the intent contract independently of the code that
+ * produced it.
+ *
+ * This is formal/SyncExactlyOnce.tla transferred to the implementation:
+ * `checkChain` is TransitionContract, `entryMatchesLive` is
+ * ReplayReconstructs - and the spec's nosnaplog config is why snapshot
+ * commits MUST be logged (they bump seq and re-anchor the projection; a log
+ * without them cannot rebuild live state and reconciliation would report
+ * phantom drift).
+ */
+export interface LogEntry {
+  seq: number;
+  storeEpoch: string;
+  videoId: string | null;
+  isPlaying: boolean;
+  mediaTime: number;
+  stampedAt: number;
+  reason: string;
+  by?: string;
+  cmdId?: string;
+}
+
+const CONTROL_REASONS: ReadonlySet<string> = new Set([
+  'play',
+  'pause',
+  'seek',
+]);
+
+/** float slack for the snapshot projection (Lua string arithmetic). */
+const EPS = 1e-6;
+
+/**
+ * The legal-transition contract between two consecutive same-epoch entries,
+ * written INDEPENDENTLY of applyControl/snapshot - double-entry bookkeeping,
+ * exactly like the spec's Contract vs Apply split. Returns a violation
+ * description, or null when legal.
+ */
+export function checkTransition(
+  prev: LogEntry,
+  next: LogEntry,
+): string | null {
+  if (next.storeEpoch !== prev.storeEpoch) {
+    return null; // epoch boundaries are anchored by init entries, not chained
+  }
+  if (next.seq !== prev.seq + 1) {
+    return `seq ${prev.seq} -> ${next.seq}: not contiguous`;
+  }
+  if (next.stampedAt < prev.stampedAt) {
+    return `stampedAt regressed ${prev.stampedAt} -> ${next.stampedAt}`;
+  }
+  if (next.videoId !== prev.videoId) {
+    return `videoId changed mid-epoch (${prev.videoId} -> ${next.videoId})`;
+  }
+  if (CONTROL_REASONS.has(next.reason)) {
+    const intent = next.reason as ControlIntent;
+    if (intent === 'play' && !next.isPlaying) {
+      return 'play committed a non-playing state';
+    }
+    if (intent === 'pause' && next.isPlaying) {
+      return 'pause committed a playing state';
+    }
+    if (intent === 'seek' && next.isPlaying !== prev.isPlaying) {
+      return 'seek flipped isPlaying';
+    }
+    return null; // mediaTime is the commanded position - any value is legal
+  }
+  if (next.reason === 'snapshot') {
+    if (next.isPlaying !== prev.isPlaying) {
+      return 'snapshot flipped isPlaying';
+    }
+    const projected = projectMediaTime(
+      {
+        ...toTimeline(prev),
+      },
+      next.stampedAt,
+    );
+    if (Math.abs(next.mediaTime - projected) > EPS) {
+      return `snapshot moved the projection: expected ${projected}, logged ${next.mediaTime}`;
+    }
+    return null;
+  }
+  return `unknown transition reason '${next.reason}'`;
+}
+
+export function toTimeline(e: LogEntry): Timeline {
+  return {
+    v: 1,
+    seq: e.seq,
+    storeEpoch: e.storeEpoch,
+    videoId: e.videoId,
+    isPlaying: e.isPlaying,
+    mediaTime: e.mediaTime,
+    stampedAt: e.stampedAt,
+    rate: 1,
+    reason: e.reason as Timeline['reason'],
+    by: e.by || undefined,
+  };
+}
+
+export interface ChainReport {
+  checked: number;
+  violations: string[];
+}
+
+/**
+ * Validate every consecutive pair in stream order. The log is trimmed
+ * (MAXLEN ~), so the chain is anchored at the OLDEST RETAINED entry - a
+ * truncated head is expected and legal; a hole or an illegal transition
+ * inside the retained window is not.
+ */
+export function checkChain(entries: LogEntry[]): ChainReport {
+  const violations: string[] = [];
+  for (let i = 1; i < entries.length; i++) {
+    const v = checkTransition(entries[i - 1], entries[i]);
+    if (v) violations.push(`entry ${i} (seq ${entries[i].seq}): ${v}`);
+  }
+  return { checked: Math.max(0, entries.length - 1), violations };
+}
+
+/**
+ * ReplayReconstructs: the newest retained log entry must BE the live state.
+ * Any disagreement is drift between what was committed and what is served.
+ */
+export function entryMatchesLive(
+  last: LogEntry,
+  live: Timeline,
+): string | null {
+  if (last.storeEpoch !== live.storeEpoch) {
+    return `epoch: log ${last.storeEpoch} vs live ${live.storeEpoch}`;
+  }
+  if (last.seq !== live.seq) {
+    return `seq: log ${last.seq} vs live ${live.seq}`;
+  }
+  if (last.isPlaying !== live.isPlaying) {
+    return `isPlaying: log ${last.isPlaying} vs live ${live.isPlaying}`;
+  }
+  if (Math.abs(last.mediaTime - live.mediaTime) > EPS) {
+    return `mediaTime: log ${last.mediaTime} vs live ${live.mediaTime}`;
+  }
+  if (last.stampedAt !== live.stampedAt) {
+    return `stampedAt: log ${last.stampedAt} vs live ${live.stampedAt}`;
+  }
+  if ((last.videoId ?? null) !== (live.videoId ?? null)) {
+    return `videoId: log ${last.videoId} vs live ${live.videoId}`;
+  }
+  return null;
+}

--- a/video-sync-frontend/src/shared/sync-core/replay.ts
+++ b/video-sync-frontend/src/shared/sync-core/replay.ts
@@ -40,6 +40,14 @@ const CONTROL_REASONS: ReadonlySet<string> = new Set([
 const EPS = 1e-6;
 
 /**
+ * NaN fails every > comparison, so `Math.abs(a-b) > EPS` reports a
+ * non-finite value as LEGAL - the one way a corrupt entry could pass this
+ * checker silently. Every float comparison goes through here instead.
+ */
+const differs = (a: number, b: number): boolean =>
+  !Number.isFinite(a) || !Number.isFinite(b) || Math.abs(a - b) > EPS;
+
+/**
  * The legal-transition contract between two consecutive same-epoch entries,
  * written INDEPENDENTLY of applyControl/snapshot - double-entry bookkeeping,
  * exactly like the spec's Contract vs Apply split. Returns a violation
@@ -78,13 +86,8 @@ export function checkTransition(
     if (next.isPlaying !== prev.isPlaying) {
       return 'snapshot flipped isPlaying';
     }
-    const projected = projectMediaTime(
-      {
-        ...toTimeline(prev),
-      },
-      next.stampedAt,
-    );
-    if (Math.abs(next.mediaTime - projected) > EPS) {
+    const projected = projectMediaTime({ ...toTimeline(prev) }, next.stampedAt);
+    if (differs(next.mediaTime, projected)) {
       return `snapshot moved the projection: expected ${projected}, logged ${next.mediaTime}`;
     }
     return null;
@@ -144,8 +147,11 @@ export function entryMatchesLive(
   if (last.isPlaying !== live.isPlaying) {
     return `isPlaying: log ${last.isPlaying} vs live ${live.isPlaying}`;
   }
-  if (Math.abs(last.mediaTime - live.mediaTime) > EPS) {
+  if (differs(last.mediaTime, live.mediaTime)) {
     return `mediaTime: log ${last.mediaTime} vs live ${live.mediaTime}`;
+  }
+  if (last.reason !== live.reason) {
+    return `reason: log ${last.reason} vs live ${live.reason}`;
   }
   if (last.stampedAt !== live.stampedAt) {
     return `stampedAt: log ${last.stampedAt} vs live ${live.stampedAt}`;


### PR DESCRIPTION
Item 3 of the exactly-once roadmap, stacked on #27. Event sourcing plus
reconciliation, with the ledger discipline in the *checking*.

## The log

Every commit — control, repair-sweep snapshot, epoch birth — appends to a
per-room Redis stream (`room:X:log`, `MAXLEN ~1024`) **inside the same Lua
script as the commit**, on every plane (Node, relay-go, actor — same files,
shared verbatim). Written in one atomic step with the state change, the log
cannot disagree with the store about what happened. Entries are full
post-states: the log is a transition relation, and replay is a read.

Sweep commits are logged because the spec's `nosnaplog` config proved the
alternative — they bump `seq` and re-anchor the projection, so a log of user
commands alone reports phantom drift. Deduplicated deliveries never append
(**commits, not deliveries** — pinned by a test).

## The reconciliation

`replay-check.ts` is the live transfer of `formal/SyncExactlyOnce.tla`'s two
log properties:

- **TransitionContract** — `shared/sync-core/replay.ts` checks every retained
  consecutive pair against its reason's contract (seek never flips play
  state; pause freezes at the commanded frame; a snapshot moves the
  projection by exactly nothing; `seq` contiguous), written independently of
  the code that produces transitions — the same double-entry split as the
  spec's `Contract` vs `Apply`.
- **ReplayReconstructs** — the newest retained entry must *be* the live
  state, field for field. Disagreement = drift, reported per room as a
  **measured drift rate**.

Trimming anchors the check at the oldest retained entry — truncation legal,
holes not. The InMemory store mirrors the log through the same shared
checker, so CI-without-Redis proves identical semantics. The nightly now
runs the reconciler, gated, over the 50-bot fleet's actual traffic.

## Measured (committed, clean SHA)

Duplicate-injection fleet on the 3-instance lab, fresh keyspace: 4 commands +
4 duplicates → **exactly 4 commits** (the equality gate from #27), then
reconciliation over that traffic: **12 retained entries, 11 transitions
checked, 0 contract violations, 0 drift rooms — drift rate 0**
(`docs/measurements/exactly-once/replay-reconciliation.json`).

70 backend tests pass, including the chain contract on both substrates and
"the contract catches what it exists to catch" (flipped play-state, moved
projection, seq holes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added exactly-once handling for control commands, preventing duplicate deliveries from reapplying changes.
  - Added append-only room history to support state replay and recovery.
  - Added replay reconciliation that verifies room history matches live state and detects gaps or drift.
  - Added support for optional validated command IDs in control messages.

- **Bug Fixes**
  - Improved handling of malformed control frames, invalid values, and trailing data.

- **Documentation**
  - Expanded guidance and measurements for command deduplication, replay validation, and network impairment testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->