### PR TITLE
feat: shared media-source classifier — one place decides what a videoUrl means

### DIFF
--- a/shared/media-source.spec.ts
+++ b/shared/media-source.spec.ts
@@ -1,0 +1,146 @@
+import {
+  MediaSource,
+  VIDEO_URL_MAX_LEN,
+  classifyMediaSource,
+  isAcceptableVideoUrl,
+} from './media-source';
+
+describe('classifyMediaSource', () => {
+  const cases: Array<[string, string | null | undefined, MediaSource]> = [
+    // -- null sentinel --------------------------------------------------
+    ['empty string', '', { kind: 'none', reason: 'empty' }],
+    ['whitespace only', '   ', { kind: 'none', reason: 'empty' }],
+    ['null', null, { kind: 'none', reason: 'empty' }],
+    ['undefined', undefined, { kind: 'none', reason: 'empty' }],
+
+    // -- YouTube --------------------------------------------------------
+    ['bare 11-char id (legacy rooms)', 'aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    [
+      'watch URL',
+      'https://www.youtube.com/watch?v=aqz-KE-bpKQ',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
+    [
+      'watch URL with playlist params',
+      'https://www.youtube.com/watch?v=aqz-KE-bpKQ&list=PLxyz&index=2',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
+    ['youtu.be with timestamp', 'https://youtu.be/aqz-KE-bpKQ?t=30', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    ['embed URL', 'https://www.youtube.com/embed/aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    ['shorts URL', 'https://www.youtube.com/shorts/aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    ['live URL', 'https://www.youtube.com/live/aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    ['mobile host', 'https://m.youtube.com/watch?v=aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    [
+      'nocookie host',
+      'https://www.youtube-nocookie.com/embed/aqz-KE-bpKQ',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
+    // a YouTube host without a valid id is a doomed fetch, not a file URL
+    [
+      'watch URL with malformed id',
+      'https://www.youtube.com/watch?v=tooshort',
+      { kind: 'none', reason: 'unsupported' },
+    ],
+    ['YouTube homepage', 'https://www.youtube.com/', { kind: 'none', reason: 'unsupported' }],
+    [
+      'playlist pseudo-id videoseries',
+      'https://www.youtube.com/embed/videoseries?list=PLxyz',
+      { kind: 'none', reason: 'unsupported' },
+    ],
+
+    // -- Vimeo ----------------------------------------------------------
+    ['vimeo canonical', 'https://vimeo.com/76979871', { kind: 'vimeo', videoId: '76979871' }],
+    [
+      'vimeo unlisted hash',
+      'https://vimeo.com/76979871/9b1d4c2f8a',
+      { kind: 'vimeo', videoId: '76979871', hash: '9b1d4c2f8a' },
+    ],
+    [
+      'player.vimeo.com with h param',
+      'https://player.vimeo.com/video/76979871?h=9b1d4c2f8a',
+      { kind: 'vimeo', videoId: '76979871', hash: '9b1d4c2f8a' },
+    ],
+    ['vimeo non-video page', 'https://vimeo.com/about', { kind: 'none', reason: 'unsupported' }],
+
+    // -- HLS ------------------------------------------------------------
+    ['m3u8', 'https://cdn.example.com/vod/master.m3u8', { kind: 'hls', url: 'https://cdn.example.com/vod/master.m3u8' }],
+    [
+      'uppercase .M3U8 with query',
+      'https://cdn.example.com/vod/master.M3U8?sig=abc',
+      { kind: 'hls', url: 'https://cdn.example.com/vod/master.M3U8?sig=abc' },
+    ],
+    [
+      'movie.mp4.m3u8 is hls (last extension wins)',
+      'https://cdn.example.com/movie.mp4.m3u8',
+      { kind: 'hls', url: 'https://cdn.example.com/movie.mp4.m3u8' },
+    ],
+
+    // -- direct files ---------------------------------------------------
+    [
+      'signed mp4 (query never interferes with extension)',
+      'https://cdn.example.com/movie.mp4?X-Amz-Signature=abc123',
+      { kind: 'file', url: 'https://cdn.example.com/movie.mp4?X-Amz-Signature=abc123', container: 'mp4' },
+    ],
+    ['same-origin /media webm', '/media/clip.webm', { kind: 'file', url: '/media/clip.webm', container: 'webm' }],
+    ['relative media ogg', 'media/clip.ogg', { kind: 'file', url: 'media/clip.ogg', container: 'ogg' }],
+
+    // -- attempt-and-fail-visibly fallback ------------------------------
+    [
+      'extensionless signed CDN URL',
+      'https://cdn.example.com/stream/8f3ab21?token=eyJhbGciOiJI',
+      { kind: 'file', url: 'https://cdn.example.com/stream/8f3ab21?token=eyJhbGciOiJI', container: 'unknown' },
+    ],
+    ['garbage text', 'watch this movie', { kind: 'file', url: 'watch this movie', container: 'unknown' }],
+  ];
+
+  it.each(cases)('%s', (_name, input, want) => {
+    expect(classifyMediaSource(input)).toEqual(want);
+  });
+
+  it('11 chars of the id charset classify as youtube even when unintended', () => {
+    // "not-a-video" is exactly 11 chars of [A-Za-z0-9_-]: the legacy-room
+    // rule admits it by design; the YT player's onError owns the failure
+    expect(classifyMediaSource('not-a-video')).toEqual({ kind: 'youtube', videoId: 'not-a-video' });
+  });
+});
+
+describe('isAcceptableVideoUrl', () => {
+  it('admits absolute http(s) URLs, /media/ paths, and bare YouTube ids', () => {
+    expect(isAcceptableVideoUrl('https://www.youtube.com/watch?v=aqz-KE-bpKQ')).toBe(true);
+    expect(isAcceptableVideoUrl('http://cdn.example.com/movie.mp4')).toBe(true);
+    expect(isAcceptableVideoUrl('/media/clip.webm')).toBe(true);
+    expect(isAcceptableVideoUrl('media/clip.webm')).toBe(true);
+    expect(isAcceptableVideoUrl('aqz-KE-bpKQ')).toBe(true);
+  });
+
+  it('admits extensionless signed links (playability is the player card, not validation)', () => {
+    expect(isAcceptableVideoUrl('https://cdn.example.com/stream/8f3ab21?token=abc')).toBe(true);
+    expect(isAcceptableVideoUrl('https://example.com/not-a-video-page')).toBe(true);
+  });
+
+  it('refuses single-token garbage at the shape floor', () => {
+    expect(isAcceptableVideoUrl('hello')).toBe(false);
+    expect(isAcceptableVideoUrl('watch this movie')).toBe(false);
+    expect(isAcceptableVideoUrl('javascript:alert(1)')).toBe(false);
+    expect(isAcceptableVideoUrl('ftp://example.com/movie.mp4')).toBe(false);
+  });
+
+  it('refuses empty, oversized, and whitespace-containing inputs', () => {
+    expect(isAcceptableVideoUrl('')).toBe(false);
+    expect(isAcceptableVideoUrl('https://a.com/' + 'x'.repeat(VIDEO_URL_MAX_LEN))).toBe(false);
+    expect(isAcceptableVideoUrl('https://a.com/a b')).toBe(false);
+    expect(isAcceptableVideoUrl(' https://a.com/x.mp4')).toBe(false);
+  });
+
+  it('refuses provider hosts without an extractable id despite passing the shape floor', () => {
+    expect(isAcceptableVideoUrl('https://www.youtube.com/')).toBe(false);
+    expect(isAcceptableVideoUrl('https://vimeo.com/about')).toBe(false);
+  });
+
+  it('admits URLs at exactly the length cap', () => {
+    const prefix = 'https://a.com/';
+    const url = prefix + 'x'.repeat(VIDEO_URL_MAX_LEN - prefix.length);
+    expect(url.length).toBe(VIDEO_URL_MAX_LEN);
+    expect(isAcceptableVideoUrl(url)).toBe(true);
+  });
+});

--- a/shared/media-source.spec.ts
+++ b/shared/media-source.spec.ts
@@ -174,6 +174,18 @@ describe('classifyMediaSource', () => {
       'blob:https://example.com/2f9a1c3e',
       { kind: 'none', reason: 'unsupported' },
     ],
+    // non-special schemes may carry a provider-shaped authority; the
+    // scheme guard must win over host matching
+    [
+      'javascript scheme wearing a YouTube authority',
+      'javascript://youtube.com/watch?v=aqz-KE-bpKQ',
+      { kind: 'none', reason: 'unsupported' },
+    ],
+    [
+      'ftp scheme with a media extension',
+      'ftp://example.com/movie.mp4',
+      { kind: 'none', reason: 'unsupported' },
+    ],
   ];
 
   it.each(cases)('%s', (_name, input, want) => {

--- a/shared/media-source.spec.ts
+++ b/shared/media-source.spec.ts
@@ -14,7 +14,11 @@ describe('classifyMediaSource', () => {
     ['undefined', undefined, { kind: 'none', reason: 'empty' }],
 
     // -- YouTube --------------------------------------------------------
-    ['bare 11-char id (legacy rooms)', 'aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    [
+      'bare 11-char id (legacy rooms)',
+      'aqz-KE-bpKQ',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
     [
       'watch URL',
       'https://www.youtube.com/watch?v=aqz-KE-bpKQ',
@@ -25,11 +29,31 @@ describe('classifyMediaSource', () => {
       'https://www.youtube.com/watch?v=aqz-KE-bpKQ&list=PLxyz&index=2',
       { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
     ],
-    ['youtu.be with timestamp', 'https://youtu.be/aqz-KE-bpKQ?t=30', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
-    ['embed URL', 'https://www.youtube.com/embed/aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
-    ['shorts URL', 'https://www.youtube.com/shorts/aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
-    ['live URL', 'https://www.youtube.com/live/aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
-    ['mobile host', 'https://m.youtube.com/watch?v=aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    [
+      'youtu.be with timestamp',
+      'https://youtu.be/aqz-KE-bpKQ?t=30',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
+    [
+      'embed URL',
+      'https://www.youtube.com/embed/aqz-KE-bpKQ',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
+    [
+      'shorts URL',
+      'https://www.youtube.com/shorts/aqz-KE-bpKQ',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
+    [
+      'live URL',
+      'https://www.youtube.com/live/aqz-KE-bpKQ',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
+    [
+      'mobile host',
+      'https://m.youtube.com/watch?v=aqz-KE-bpKQ',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
     [
       'nocookie host',
       'https://www.youtube-nocookie.com/embed/aqz-KE-bpKQ',
@@ -41,7 +65,11 @@ describe('classifyMediaSource', () => {
       'https://www.youtube.com/watch?v=tooshort',
       { kind: 'none', reason: 'unsupported' },
     ],
-    ['YouTube homepage', 'https://www.youtube.com/', { kind: 'none', reason: 'unsupported' }],
+    [
+      'YouTube homepage',
+      'https://www.youtube.com/',
+      { kind: 'none', reason: 'unsupported' },
+    ],
     [
       'playlist pseudo-id videoseries',
       'https://www.youtube.com/embed/videoseries?list=PLxyz',
@@ -49,7 +77,11 @@ describe('classifyMediaSource', () => {
     ],
 
     // -- Vimeo ----------------------------------------------------------
-    ['vimeo canonical', 'https://vimeo.com/76979871', { kind: 'vimeo', videoId: '76979871' }],
+    [
+      'vimeo canonical',
+      'https://vimeo.com/76979871',
+      { kind: 'vimeo', videoId: '76979871' },
+    ],
     [
       'vimeo unlisted hash',
       'https://vimeo.com/76979871/9b1d4c2f8a',
@@ -60,10 +92,18 @@ describe('classifyMediaSource', () => {
       'https://player.vimeo.com/video/76979871?h=9b1d4c2f8a',
       { kind: 'vimeo', videoId: '76979871', hash: '9b1d4c2f8a' },
     ],
-    ['vimeo non-video page', 'https://vimeo.com/about', { kind: 'none', reason: 'unsupported' }],
+    [
+      'vimeo non-video page',
+      'https://vimeo.com/about',
+      { kind: 'none', reason: 'unsupported' },
+    ],
 
     // -- HLS ------------------------------------------------------------
-    ['m3u8', 'https://cdn.example.com/vod/master.m3u8', { kind: 'hls', url: 'https://cdn.example.com/vod/master.m3u8' }],
+    [
+      'm3u8',
+      'https://cdn.example.com/vod/master.m3u8',
+      { kind: 'hls', url: 'https://cdn.example.com/vod/master.m3u8' },
+    ],
     [
       'uppercase .M3U8 with query',
       'https://cdn.example.com/vod/master.M3U8?sig=abc',
@@ -79,18 +119,61 @@ describe('classifyMediaSource', () => {
     [
       'signed mp4 (query never interferes with extension)',
       'https://cdn.example.com/movie.mp4?X-Amz-Signature=abc123',
-      { kind: 'file', url: 'https://cdn.example.com/movie.mp4?X-Amz-Signature=abc123', container: 'mp4' },
+      {
+        kind: 'file',
+        url: 'https://cdn.example.com/movie.mp4?X-Amz-Signature=abc123',
+        container: 'mp4',
+      },
     ],
-    ['same-origin /media webm', '/media/clip.webm', { kind: 'file', url: '/media/clip.webm', container: 'webm' }],
-    ['relative media ogg', 'media/clip.ogg', { kind: 'file', url: 'media/clip.ogg', container: 'ogg' }],
+    [
+      'same-origin /media webm',
+      '/media/clip.webm',
+      { kind: 'file', url: '/media/clip.webm', container: 'webm' },
+    ],
+    [
+      'relative media ogg',
+      'media/clip.ogg',
+      { kind: 'file', url: 'media/clip.ogg', container: 'ogg' },
+    ],
 
     // -- attempt-and-fail-visibly fallback ------------------------------
     [
       'extensionless signed CDN URL',
       'https://cdn.example.com/stream/8f3ab21?token=eyJhbGciOiJI',
-      { kind: 'file', url: 'https://cdn.example.com/stream/8f3ab21?token=eyJhbGciOiJI', container: 'unknown' },
+      {
+        kind: 'file',
+        url: 'https://cdn.example.com/stream/8f3ab21?token=eyJhbGciOiJI',
+        container: 'unknown',
+      },
     ],
-    ['garbage text', 'watch this movie', { kind: 'file', url: 'watch this movie', container: 'unknown' }],
+    [
+      'garbage text',
+      'watch this movie',
+      { kind: 'file', url: 'watch this movie', container: 'unknown' },
+    ],
+
+    // -- refused: could not possibly be fetched by a media element ------
+    ['unparseable URL', 'http://[bad', { kind: 'none', reason: 'unsupported' }],
+    [
+      'javascript scheme',
+      'javascript:alert(1)',
+      { kind: 'none', reason: 'unsupported' },
+    ],
+    [
+      'javascript scheme hiding behind a media extension',
+      'javascript:x.mp4',
+      { kind: 'none', reason: 'unsupported' },
+    ],
+    [
+      'data scheme',
+      'data:text/html,<script>alert(1)</script>',
+      { kind: 'none', reason: 'unsupported' },
+    ],
+    [
+      'blob scheme',
+      'blob:https://example.com/2f9a1c3e',
+      { kind: 'none', reason: 'unsupported' },
+    ],
   ];
 
   it.each(cases)('%s', (_name, input, want) => {
@@ -100,13 +183,18 @@ describe('classifyMediaSource', () => {
   it('11 chars of the id charset classify as youtube even when unintended', () => {
     // "not-a-video" is exactly 11 chars of [A-Za-z0-9_-]: the legacy-room
     // rule admits it by design; the YT player's onError owns the failure
-    expect(classifyMediaSource('not-a-video')).toEqual({ kind: 'youtube', videoId: 'not-a-video' });
+    expect(classifyMediaSource('not-a-video')).toEqual({
+      kind: 'youtube',
+      videoId: 'not-a-video',
+    });
   });
 });
 
 describe('isAcceptableVideoUrl', () => {
   it('admits absolute http(s) URLs, /media/ paths, and bare YouTube ids', () => {
-    expect(isAcceptableVideoUrl('https://www.youtube.com/watch?v=aqz-KE-bpKQ')).toBe(true);
+    expect(
+      isAcceptableVideoUrl('https://www.youtube.com/watch?v=aqz-KE-bpKQ'),
+    ).toBe(true);
     expect(isAcceptableVideoUrl('http://cdn.example.com/movie.mp4')).toBe(true);
     expect(isAcceptableVideoUrl('/media/clip.webm')).toBe(true);
     expect(isAcceptableVideoUrl('media/clip.webm')).toBe(true);
@@ -114,8 +202,12 @@ describe('isAcceptableVideoUrl', () => {
   });
 
   it('admits extensionless signed links (playability is the player card, not validation)', () => {
-    expect(isAcceptableVideoUrl('https://cdn.example.com/stream/8f3ab21?token=abc')).toBe(true);
-    expect(isAcceptableVideoUrl('https://example.com/not-a-video-page')).toBe(true);
+    expect(
+      isAcceptableVideoUrl('https://cdn.example.com/stream/8f3ab21?token=abc'),
+    ).toBe(true);
+    expect(isAcceptableVideoUrl('https://example.com/not-a-video-page')).toBe(
+      true,
+    );
   });
 
   it('refuses single-token garbage at the shape floor', () => {
@@ -127,7 +219,9 @@ describe('isAcceptableVideoUrl', () => {
 
   it('refuses empty, oversized, and whitespace-containing inputs', () => {
     expect(isAcceptableVideoUrl('')).toBe(false);
-    expect(isAcceptableVideoUrl('https://a.com/' + 'x'.repeat(VIDEO_URL_MAX_LEN))).toBe(false);
+    expect(
+      isAcceptableVideoUrl('https://a.com/' + 'x'.repeat(VIDEO_URL_MAX_LEN)),
+    ).toBe(false);
     expect(isAcceptableVideoUrl('https://a.com/a b')).toBe(false);
     expect(isAcceptableVideoUrl(' https://a.com/x.mp4')).toBe(false);
   });

--- a/shared/media-source.ts
+++ b/shared/media-source.ts
@@ -1,0 +1,161 @@
+// Source classification and URL validation for room videos - the ONE place
+// that decides what a videoUrl means. Consumed by the player (which mount to
+// render), the REST DTOs, and the gateway's set-video guard; drift between
+// those three is impossible by construction because they all import this.
+//
+// Boundary: validation bounds SIZE and SHAPE, never playability.
+// `https://example.com/not-a-video` is valid input by design - unknown URLs
+// are attempted as HTML5 media and fail visibly in the player, because
+// signed CDN links (extensionless, query-string-authenticated) are
+// indistinguishable from garbage by inspection. The player's failure card
+// owns that outcome; this module only refuses inputs that could not
+// possibly be fetched or that no mount would accept.
+//
+// Pure and DOM-free (WHATWG URL only) so the same code runs in the backend
+// gateway, jest, and the browser bundle.
+
+export type MediaSource =
+  | { kind: 'none'; reason: 'empty' | 'unsupported' }
+  | { kind: 'youtube'; videoId: string }
+  | { kind: 'vimeo'; videoId: string; hash?: string } // hash: unlisted-video key
+  | { kind: 'hls'; url: string }
+  | { kind: 'file'; url: string; container: 'mp4' | 'webm' | 'ogg' | 'unknown' };
+
+/**
+ * Bounds what a videoUrl may look like at the door (REST create/update and
+ * the set-video control). The cap matters because the URL becomes
+ * Timeline.videoId and rides EVERY sync:timeline broadcast to every client
+ * in the room - it bounds store and wire, not just sanity. 2048 is the
+ * interoperable URL limit; signed CDN URLs (500-1500 chars) fit.
+ */
+export const VIDEO_URL_MAX_LEN = 2048;
+
+/**
+ * Shape floor: an absolute http(s) URL or a same-origin /media/ path.
+ * Single-token garbage ("hello") is refused here; extensionless signed
+ * links pass and are the player's problem (fail-visibly). Bare 11-char
+ * YouTube ids are additionally admitted by isAcceptableVideoUrl.
+ */
+export const VIDEO_URL_SHAPE = /^(https?:\/\/\S+|\/?media\/\S+)$/;
+
+const YT_ID = /^[A-Za-z0-9_-]{11}$/;
+
+// Dummy base so relative inputs ("/media/x.mp4") parse; the reserved
+// .invalid TLD guarantees the host never collides with a real provider.
+const RELATIVE_BASE = 'https://relative.invalid/';
+
+// Hostnames checked AFTER stripping a leading "www.".
+const YT_HOSTS = ['youtube.com', 'm.youtube.com', 'music.youtube.com', 'youtube-nocookie.com'];
+
+function hostOf(u: URL): string {
+  const h = u.hostname.toLowerCase();
+  return h.slice(0, 4) === 'www.' ? h.slice(4) : h;
+}
+
+function segmentsOf(u: URL): string[] {
+  return u.pathname.split('/').filter((s) => s.length > 0);
+}
+
+function extractYouTubeId(u: URL, host: string): string | null {
+  if (host === 'youtu.be') {
+    const seg = segmentsOf(u)[0];
+    return seg !== undefined ? seg : null;
+  }
+  const segs = segmentsOf(u);
+  if (segs[0] === 'watch') return u.searchParams.get('v');
+  if (
+    segs.length >= 2 &&
+    (segs[0] === 'embed' || segs[0] === 'shorts' || segs[0] === 'live' || segs[0] === 'v')
+  ) {
+    return segs[1];
+  }
+  return null;
+}
+
+function classifyVimeo(u: URL, host: string): MediaSource {
+  const segs = segmentsOf(u);
+  if (host === 'player.vimeo.com') {
+    if (segs[0] === 'video' && segs[1] !== undefined && /^\d+$/.test(segs[1])) {
+      const h = u.searchParams.get('h');
+      return h !== null && h !== ''
+        ? { kind: 'vimeo', videoId: segs[1], hash: h }
+        : { kind: 'vimeo', videoId: segs[1] };
+    }
+    return { kind: 'none', reason: 'unsupported' };
+  }
+  // vimeo.com/<digits>[/<unlisted-hash>]
+  if (segs[0] !== undefined && /^\d+$/.test(segs[0])) {
+    const h = segs[1];
+    return h !== undefined && /^[A-Za-z0-9]+$/.test(h)
+      ? { kind: 'vimeo', videoId: segs[0], hash: h }
+      : { kind: 'vimeo', videoId: segs[0] };
+  }
+  return { kind: 'none', reason: 'unsupported' };
+}
+
+/** Extension rules run on URL.pathname only - `?signature=` query strings never interfere. */
+function byExtension(u: URL, raw: string): MediaSource | null {
+  const p = u.pathname.toLowerCase();
+  if (p.slice(-5) === '.m3u8') return { kind: 'hls', url: raw };
+  if (p.slice(-4) === '.mp4') return { kind: 'file', url: raw, container: 'mp4' };
+  if (p.slice(-5) === '.webm') return { kind: 'file', url: raw, container: 'webm' };
+  if (p.slice(-4) === '.ogg') return { kind: 'file', url: raw, container: 'ogg' };
+  return null;
+}
+
+/**
+ * Classify a room's videoUrl into the source a player mount can act on.
+ * `url` fields carry the RAW input, never a re-encoded parse - signed URLs
+ * must reach the media element byte-for-byte.
+ *
+ * Ordered rules:
+ *  1. empty/whitespace -> none/empty ('' is the room's null sentinel)
+ *  2. bare 11-char id -> youtube (legacy rooms stored ids, not URLs)
+ *  3. YouTube/Vimeo by hostname; a provider host WITHOUT an extractable id
+ *     is none/unsupported - a <video> fetch against a provider page is
+ *     doomed, so don't attempt it
+ *  4. pathname extension: .m3u8 -> hls; .mp4/.webm/.ogg -> file
+ *  5. anything else that parsed -> file/unknown (attempt-and-fail-visibly)
+ */
+export function classifyMediaSource(raw: string | null | undefined): MediaSource {
+  const s = (raw !== null && raw !== undefined ? raw : '').trim();
+  if (s === '') return { kind: 'none', reason: 'empty' };
+  if (YT_ID.test(s)) return { kind: 'youtube', videoId: s };
+
+  let u: URL;
+  try {
+    u = new URL(s, RELATIVE_BASE);
+  } catch {
+    // not even parseable relative to a base (e.g. "http://[bad") - nothing
+    // could fetch this, so it is refused rather than attempted
+    return { kind: 'none', reason: 'unsupported' };
+  }
+
+  const host = hostOf(u);
+  if (host === 'youtu.be' || YT_HOSTS.indexOf(host) !== -1) {
+    const id = extractYouTubeId(u, host);
+    // "videoseries" is /embed/'s playlist pseudo-id: 11 chars of the id
+    // charset but never a video - loading it would only produce a player
+    // error, so refuse it as unsupported instead
+    if (id !== null && id !== 'videoseries' && YT_ID.test(id)) {
+      return { kind: 'youtube', videoId: id };
+    }
+    return { kind: 'none', reason: 'unsupported' };
+  }
+  if (host === 'vimeo.com' || host === 'player.vimeo.com') return classifyVimeo(u, host);
+
+  const ext = byExtension(u, s);
+  if (ext !== null) return ext;
+  return { kind: 'file', url: s, container: 'unknown' };
+}
+
+/**
+ * The admission rule for videoUrl at every write path (REST DTOs, gateway
+ * set-video guard, frontend form). Strict on the string AS GIVEN - callers
+ * trim before validating, and surrounding whitespace fails the anchors.
+ */
+export function isAcceptableVideoUrl(raw: string): boolean {
+  if (raw.length === 0 || raw.length > VIDEO_URL_MAX_LEN) return false;
+  if (!VIDEO_URL_SHAPE.test(raw) && !YT_ID.test(raw)) return false;
+  return classifyMediaSource(raw).kind !== 'none';
+}

--- a/shared/media-source.ts
+++ b/shared/media-source.ts
@@ -19,7 +19,11 @@ export type MediaSource =
   | { kind: 'youtube'; videoId: string }
   | { kind: 'vimeo'; videoId: string; hash?: string } // hash: unlisted-video key
   | { kind: 'hls'; url: string }
-  | { kind: 'file'; url: string; container: 'mp4' | 'webm' | 'ogg' | 'unknown' };
+  | {
+      kind: 'file';
+      url: string;
+      container: 'mp4' | 'webm' | 'ogg' | 'unknown';
+    };
 
 /**
  * Bounds what a videoUrl may look like at the door (REST create/update and
@@ -45,7 +49,12 @@ const YT_ID = /^[A-Za-z0-9_-]{11}$/;
 const RELATIVE_BASE = 'https://relative.invalid/';
 
 // Hostnames checked AFTER stripping a leading "www.".
-const YT_HOSTS = ['youtube.com', 'm.youtube.com', 'music.youtube.com', 'youtube-nocookie.com'];
+const YT_HOSTS = [
+  'youtube.com',
+  'm.youtube.com',
+  'music.youtube.com',
+  'youtube-nocookie.com',
+];
 
 function hostOf(u: URL): string {
   const h = u.hostname.toLowerCase();
@@ -65,7 +74,10 @@ function extractYouTubeId(u: URL, host: string): string | null {
   if (segs[0] === 'watch') return u.searchParams.get('v');
   if (
     segs.length >= 2 &&
-    (segs[0] === 'embed' || segs[0] === 'shorts' || segs[0] === 'live' || segs[0] === 'v')
+    (segs[0] === 'embed' ||
+      segs[0] === 'shorts' ||
+      segs[0] === 'live' ||
+      segs[0] === 'v')
   ) {
     return segs[1];
   }
@@ -96,10 +108,10 @@ function classifyVimeo(u: URL, host: string): MediaSource {
 /** Extension rules run on URL.pathname only - `?signature=` query strings never interfere. */
 function byExtension(u: URL, raw: string): MediaSource | null {
   const p = u.pathname.toLowerCase();
-  if (p.slice(-5) === '.m3u8') return { kind: 'hls', url: raw };
-  if (p.slice(-4) === '.mp4') return { kind: 'file', url: raw, container: 'mp4' };
-  if (p.slice(-5) === '.webm') return { kind: 'file', url: raw, container: 'webm' };
-  if (p.slice(-4) === '.ogg') return { kind: 'file', url: raw, container: 'ogg' };
+  if (p.endsWith('.m3u8')) return { kind: 'hls', url: raw };
+  if (p.endsWith('.mp4')) return { kind: 'file', url: raw, container: 'mp4' };
+  if (p.endsWith('.webm')) return { kind: 'file', url: raw, container: 'webm' };
+  if (p.endsWith('.ogg')) return { kind: 'file', url: raw, container: 'ogg' };
   return null;
 }
 
@@ -114,10 +126,14 @@ function byExtension(u: URL, raw: string): MediaSource | null {
  *  3. YouTube/Vimeo by hostname; a provider host WITHOUT an extractable id
  *     is none/unsupported - a <video> fetch against a provider page is
  *     doomed, so don't attempt it
- *  4. pathname extension: .m3u8 -> hls; .mp4/.webm/.ogg -> file
- *  5. anything else that parsed -> file/unknown (attempt-and-fail-visibly)
+ *  4. non-http(s) scheme -> none/unsupported (javascript:, data:, blob:
+ *     all parse, but must never become a media element src)
+ *  5. pathname extension: .m3u8 -> hls; .mp4/.webm/.ogg -> file
+ *  6. anything else that parsed -> file/unknown (attempt-and-fail-visibly)
  */
-export function classifyMediaSource(raw: string | null | undefined): MediaSource {
+export function classifyMediaSource(
+  raw: string | null | undefined,
+): MediaSource {
   const s = (raw !== null && raw !== undefined ? raw : '').trim();
   if (s === '') return { kind: 'none', reason: 'empty' };
   if (YT_ID.test(s)) return { kind: 'youtube', videoId: s };
@@ -142,7 +158,19 @@ export function classifyMediaSource(raw: string | null | undefined): MediaSource
     }
     return { kind: 'none', reason: 'unsupported' };
   }
-  if (host === 'vimeo.com' || host === 'player.vimeo.com') return classifyVimeo(u, host);
+  if (host === 'vimeo.com' || host === 'player.vimeo.com')
+    return classifyVimeo(u, host);
+
+  // Only schemes a media element can fetch may become a src: javascript:,
+  // data: and blob: all parse. isAcceptableVideoUrl also refuses them at
+  // the shape floor, but classifyMediaSource runs on STORED values too
+  // (legacy rooms predate admission), so the guard must live here as well.
+  // Before byExtension on purpose - javascript:x.mp4 must not classify by
+  // its extension. Relative inputs resolve against RELATIVE_BASE (https:)
+  // and pass untouched.
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+    return { kind: 'none', reason: 'unsupported' };
+  }
 
   const ext = byExtension(u, s);
   if (ext !== null) return ext;

--- a/shared/media-source.ts
+++ b/shared/media-source.ts
@@ -123,11 +123,11 @@ function byExtension(u: URL, raw: string): MediaSource | null {
  * Ordered rules:
  *  1. empty/whitespace -> none/empty ('' is the room's null sentinel)
  *  2. bare 11-char id -> youtube (legacy rooms stored ids, not URLs)
- *  3. YouTube/Vimeo by hostname; a provider host WITHOUT an extractable id
+ *  3. non-http(s) scheme -> none/unsupported (javascript:, data:, blob:
+ *     all parse, but must never become a media element src)
+ *  4. YouTube/Vimeo by hostname; a provider host WITHOUT an extractable id
  *     is none/unsupported - a <video> fetch against a provider page is
  *     doomed, so don't attempt it
- *  4. non-http(s) scheme -> none/unsupported (javascript:, data:, blob:
- *     all parse, but must never become a media element src)
  *  5. pathname extension: .m3u8 -> hls; .mp4/.webm/.ogg -> file
  *  6. anything else that parsed -> file/unknown (attempt-and-fail-visibly)
  */
@@ -147,6 +147,17 @@ export function classifyMediaSource(
     return { kind: 'none', reason: 'unsupported' };
   }
 
+  // Only schemes a media element can fetch may classify at all: javascript:,
+  // data: and blob: all parse - some even with a provider-shaped authority
+  // (javascript://youtube.com/watch?v=x has hostname "youtube.com"), so the
+  // guard runs before ANY host matching. isAcceptableVideoUrl also refuses
+  // these at the shape floor, but classifyMediaSource runs on STORED values
+  // too (legacy rooms predate admission), so the refusal must live here as
+  // well. Relative inputs resolve against RELATIVE_BASE (https:) and pass.
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+    return { kind: 'none', reason: 'unsupported' };
+  }
+
   const host = hostOf(u);
   if (host === 'youtu.be' || YT_HOSTS.indexOf(host) !== -1) {
     const id = extractYouTubeId(u, host);
@@ -160,17 +171,6 @@ export function classifyMediaSource(
   }
   if (host === 'vimeo.com' || host === 'player.vimeo.com')
     return classifyVimeo(u, host);
-
-  // Only schemes a media element can fetch may become a src: javascript:,
-  // data: and blob: all parse. isAcceptableVideoUrl also refuses them at
-  // the shape floor, but classifyMediaSource runs on STORED values too
-  // (legacy rooms predate admission), so the guard must live here as well.
-  // Before byExtension on purpose - javascript:x.mp4 must not classify by
-  // its extension. Relative inputs resolve against RELATIVE_BASE (https:)
-  // and pass untouched.
-  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
-    return { kind: 'none', reason: 'unsupported' };
-  }
 
   const ext = byExtension(u, s);
   if (ext !== null) return ext;

--- a/video-sync-backend/src/shared/media-source.spec.ts
+++ b/video-sync-backend/src/shared/media-source.spec.ts
@@ -1,0 +1,148 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+import {
+  MediaSource,
+  VIDEO_URL_MAX_LEN,
+  classifyMediaSource,
+  isAcceptableVideoUrl,
+} from './media-source';
+
+describe('classifyMediaSource', () => {
+  const cases: Array<[string, string | null | undefined, MediaSource]> = [
+    // -- null sentinel --------------------------------------------------
+    ['empty string', '', { kind: 'none', reason: 'empty' }],
+    ['whitespace only', '   ', { kind: 'none', reason: 'empty' }],
+    ['null', null, { kind: 'none', reason: 'empty' }],
+    ['undefined', undefined, { kind: 'none', reason: 'empty' }],
+
+    // -- YouTube --------------------------------------------------------
+    ['bare 11-char id (legacy rooms)', 'aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    [
+      'watch URL',
+      'https://www.youtube.com/watch?v=aqz-KE-bpKQ',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
+    [
+      'watch URL with playlist params',
+      'https://www.youtube.com/watch?v=aqz-KE-bpKQ&list=PLxyz&index=2',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
+    ['youtu.be with timestamp', 'https://youtu.be/aqz-KE-bpKQ?t=30', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    ['embed URL', 'https://www.youtube.com/embed/aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    ['shorts URL', 'https://www.youtube.com/shorts/aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    ['live URL', 'https://www.youtube.com/live/aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    ['mobile host', 'https://m.youtube.com/watch?v=aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    [
+      'nocookie host',
+      'https://www.youtube-nocookie.com/embed/aqz-KE-bpKQ',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
+    // a YouTube host without a valid id is a doomed fetch, not a file URL
+    [
+      'watch URL with malformed id',
+      'https://www.youtube.com/watch?v=tooshort',
+      { kind: 'none', reason: 'unsupported' },
+    ],
+    ['YouTube homepage', 'https://www.youtube.com/', { kind: 'none', reason: 'unsupported' }],
+    [
+      'playlist pseudo-id videoseries',
+      'https://www.youtube.com/embed/videoseries?list=PLxyz',
+      { kind: 'none', reason: 'unsupported' },
+    ],
+
+    // -- Vimeo ----------------------------------------------------------
+    ['vimeo canonical', 'https://vimeo.com/76979871', { kind: 'vimeo', videoId: '76979871' }],
+    [
+      'vimeo unlisted hash',
+      'https://vimeo.com/76979871/9b1d4c2f8a',
+      { kind: 'vimeo', videoId: '76979871', hash: '9b1d4c2f8a' },
+    ],
+    [
+      'player.vimeo.com with h param',
+      'https://player.vimeo.com/video/76979871?h=9b1d4c2f8a',
+      { kind: 'vimeo', videoId: '76979871', hash: '9b1d4c2f8a' },
+    ],
+    ['vimeo non-video page', 'https://vimeo.com/about', { kind: 'none', reason: 'unsupported' }],
+
+    // -- HLS ------------------------------------------------------------
+    ['m3u8', 'https://cdn.example.com/vod/master.m3u8', { kind: 'hls', url: 'https://cdn.example.com/vod/master.m3u8' }],
+    [
+      'uppercase .M3U8 with query',
+      'https://cdn.example.com/vod/master.M3U8?sig=abc',
+      { kind: 'hls', url: 'https://cdn.example.com/vod/master.M3U8?sig=abc' },
+    ],
+    [
+      'movie.mp4.m3u8 is hls (last extension wins)',
+      'https://cdn.example.com/movie.mp4.m3u8',
+      { kind: 'hls', url: 'https://cdn.example.com/movie.mp4.m3u8' },
+    ],
+
+    // -- direct files ---------------------------------------------------
+    [
+      'signed mp4 (query never interferes with extension)',
+      'https://cdn.example.com/movie.mp4?X-Amz-Signature=abc123',
+      { kind: 'file', url: 'https://cdn.example.com/movie.mp4?X-Amz-Signature=abc123', container: 'mp4' },
+    ],
+    ['same-origin /media webm', '/media/clip.webm', { kind: 'file', url: '/media/clip.webm', container: 'webm' }],
+    ['relative media ogg', 'media/clip.ogg', { kind: 'file', url: 'media/clip.ogg', container: 'ogg' }],
+
+    // -- attempt-and-fail-visibly fallback ------------------------------
+    [
+      'extensionless signed CDN URL',
+      'https://cdn.example.com/stream/8f3ab21?token=eyJhbGciOiJI',
+      { kind: 'file', url: 'https://cdn.example.com/stream/8f3ab21?token=eyJhbGciOiJI', container: 'unknown' },
+    ],
+    ['garbage text', 'watch this movie', { kind: 'file', url: 'watch this movie', container: 'unknown' }],
+  ];
+
+  it.each(cases)('%s', (_name, input, want) => {
+    expect(classifyMediaSource(input)).toEqual(want);
+  });
+
+  it('11 chars of the id charset classify as youtube even when unintended', () => {
+    // "not-a-video" is exactly 11 chars of [A-Za-z0-9_-]: the legacy-room
+    // rule admits it by design; the YT player's onError owns the failure
+    expect(classifyMediaSource('not-a-video')).toEqual({ kind: 'youtube', videoId: 'not-a-video' });
+  });
+});
+
+describe('isAcceptableVideoUrl', () => {
+  it('admits absolute http(s) URLs, /media/ paths, and bare YouTube ids', () => {
+    expect(isAcceptableVideoUrl('https://www.youtube.com/watch?v=aqz-KE-bpKQ')).toBe(true);
+    expect(isAcceptableVideoUrl('http://cdn.example.com/movie.mp4')).toBe(true);
+    expect(isAcceptableVideoUrl('/media/clip.webm')).toBe(true);
+    expect(isAcceptableVideoUrl('media/clip.webm')).toBe(true);
+    expect(isAcceptableVideoUrl('aqz-KE-bpKQ')).toBe(true);
+  });
+
+  it('admits extensionless signed links (playability is the player card, not validation)', () => {
+    expect(isAcceptableVideoUrl('https://cdn.example.com/stream/8f3ab21?token=abc')).toBe(true);
+    expect(isAcceptableVideoUrl('https://example.com/not-a-video-page')).toBe(true);
+  });
+
+  it('refuses single-token garbage at the shape floor', () => {
+    expect(isAcceptableVideoUrl('hello')).toBe(false);
+    expect(isAcceptableVideoUrl('watch this movie')).toBe(false);
+    expect(isAcceptableVideoUrl('javascript:alert(1)')).toBe(false);
+    expect(isAcceptableVideoUrl('ftp://example.com/movie.mp4')).toBe(false);
+  });
+
+  it('refuses empty, oversized, and whitespace-containing inputs', () => {
+    expect(isAcceptableVideoUrl('')).toBe(false);
+    expect(isAcceptableVideoUrl('https://a.com/' + 'x'.repeat(VIDEO_URL_MAX_LEN))).toBe(false);
+    expect(isAcceptableVideoUrl('https://a.com/a b')).toBe(false);
+    expect(isAcceptableVideoUrl(' https://a.com/x.mp4')).toBe(false);
+  });
+
+  it('refuses provider hosts without an extractable id despite passing the shape floor', () => {
+    expect(isAcceptableVideoUrl('https://www.youtube.com/')).toBe(false);
+    expect(isAcceptableVideoUrl('https://vimeo.com/about')).toBe(false);
+  });
+
+  it('admits URLs at exactly the length cap', () => {
+    const prefix = 'https://a.com/';
+    const url = prefix + 'x'.repeat(VIDEO_URL_MAX_LEN - prefix.length);
+    expect(url.length).toBe(VIDEO_URL_MAX_LEN);
+    expect(isAcceptableVideoUrl(url)).toBe(true);
+  });
+});

--- a/video-sync-backend/src/shared/media-source.spec.ts
+++ b/video-sync-backend/src/shared/media-source.spec.ts
@@ -176,6 +176,18 @@ describe('classifyMediaSource', () => {
       'blob:https://example.com/2f9a1c3e',
       { kind: 'none', reason: 'unsupported' },
     ],
+    // non-special schemes may carry a provider-shaped authority; the
+    // scheme guard must win over host matching
+    [
+      'javascript scheme wearing a YouTube authority',
+      'javascript://youtube.com/watch?v=aqz-KE-bpKQ',
+      { kind: 'none', reason: 'unsupported' },
+    ],
+    [
+      'ftp scheme with a media extension',
+      'ftp://example.com/movie.mp4',
+      { kind: 'none', reason: 'unsupported' },
+    ],
   ];
 
   it.each(cases)('%s', (_name, input, want) => {

--- a/video-sync-backend/src/shared/media-source.spec.ts
+++ b/video-sync-backend/src/shared/media-source.spec.ts
@@ -16,7 +16,11 @@ describe('classifyMediaSource', () => {
     ['undefined', undefined, { kind: 'none', reason: 'empty' }],
 
     // -- YouTube --------------------------------------------------------
-    ['bare 11-char id (legacy rooms)', 'aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    [
+      'bare 11-char id (legacy rooms)',
+      'aqz-KE-bpKQ',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
     [
       'watch URL',
       'https://www.youtube.com/watch?v=aqz-KE-bpKQ',
@@ -27,11 +31,31 @@ describe('classifyMediaSource', () => {
       'https://www.youtube.com/watch?v=aqz-KE-bpKQ&list=PLxyz&index=2',
       { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
     ],
-    ['youtu.be with timestamp', 'https://youtu.be/aqz-KE-bpKQ?t=30', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
-    ['embed URL', 'https://www.youtube.com/embed/aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
-    ['shorts URL', 'https://www.youtube.com/shorts/aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
-    ['live URL', 'https://www.youtube.com/live/aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
-    ['mobile host', 'https://m.youtube.com/watch?v=aqz-KE-bpKQ', { kind: 'youtube', videoId: 'aqz-KE-bpKQ' }],
+    [
+      'youtu.be with timestamp',
+      'https://youtu.be/aqz-KE-bpKQ?t=30',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
+    [
+      'embed URL',
+      'https://www.youtube.com/embed/aqz-KE-bpKQ',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
+    [
+      'shorts URL',
+      'https://www.youtube.com/shorts/aqz-KE-bpKQ',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
+    [
+      'live URL',
+      'https://www.youtube.com/live/aqz-KE-bpKQ',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
+    [
+      'mobile host',
+      'https://m.youtube.com/watch?v=aqz-KE-bpKQ',
+      { kind: 'youtube', videoId: 'aqz-KE-bpKQ' },
+    ],
     [
       'nocookie host',
       'https://www.youtube-nocookie.com/embed/aqz-KE-bpKQ',
@@ -43,7 +67,11 @@ describe('classifyMediaSource', () => {
       'https://www.youtube.com/watch?v=tooshort',
       { kind: 'none', reason: 'unsupported' },
     ],
-    ['YouTube homepage', 'https://www.youtube.com/', { kind: 'none', reason: 'unsupported' }],
+    [
+      'YouTube homepage',
+      'https://www.youtube.com/',
+      { kind: 'none', reason: 'unsupported' },
+    ],
     [
       'playlist pseudo-id videoseries',
       'https://www.youtube.com/embed/videoseries?list=PLxyz',
@@ -51,7 +79,11 @@ describe('classifyMediaSource', () => {
     ],
 
     // -- Vimeo ----------------------------------------------------------
-    ['vimeo canonical', 'https://vimeo.com/76979871', { kind: 'vimeo', videoId: '76979871' }],
+    [
+      'vimeo canonical',
+      'https://vimeo.com/76979871',
+      { kind: 'vimeo', videoId: '76979871' },
+    ],
     [
       'vimeo unlisted hash',
       'https://vimeo.com/76979871/9b1d4c2f8a',
@@ -62,10 +94,18 @@ describe('classifyMediaSource', () => {
       'https://player.vimeo.com/video/76979871?h=9b1d4c2f8a',
       { kind: 'vimeo', videoId: '76979871', hash: '9b1d4c2f8a' },
     ],
-    ['vimeo non-video page', 'https://vimeo.com/about', { kind: 'none', reason: 'unsupported' }],
+    [
+      'vimeo non-video page',
+      'https://vimeo.com/about',
+      { kind: 'none', reason: 'unsupported' },
+    ],
 
     // -- HLS ------------------------------------------------------------
-    ['m3u8', 'https://cdn.example.com/vod/master.m3u8', { kind: 'hls', url: 'https://cdn.example.com/vod/master.m3u8' }],
+    [
+      'm3u8',
+      'https://cdn.example.com/vod/master.m3u8',
+      { kind: 'hls', url: 'https://cdn.example.com/vod/master.m3u8' },
+    ],
     [
       'uppercase .M3U8 with query',
       'https://cdn.example.com/vod/master.M3U8?sig=abc',
@@ -81,18 +121,61 @@ describe('classifyMediaSource', () => {
     [
       'signed mp4 (query never interferes with extension)',
       'https://cdn.example.com/movie.mp4?X-Amz-Signature=abc123',
-      { kind: 'file', url: 'https://cdn.example.com/movie.mp4?X-Amz-Signature=abc123', container: 'mp4' },
+      {
+        kind: 'file',
+        url: 'https://cdn.example.com/movie.mp4?X-Amz-Signature=abc123',
+        container: 'mp4',
+      },
     ],
-    ['same-origin /media webm', '/media/clip.webm', { kind: 'file', url: '/media/clip.webm', container: 'webm' }],
-    ['relative media ogg', 'media/clip.ogg', { kind: 'file', url: 'media/clip.ogg', container: 'ogg' }],
+    [
+      'same-origin /media webm',
+      '/media/clip.webm',
+      { kind: 'file', url: '/media/clip.webm', container: 'webm' },
+    ],
+    [
+      'relative media ogg',
+      'media/clip.ogg',
+      { kind: 'file', url: 'media/clip.ogg', container: 'ogg' },
+    ],
 
     // -- attempt-and-fail-visibly fallback ------------------------------
     [
       'extensionless signed CDN URL',
       'https://cdn.example.com/stream/8f3ab21?token=eyJhbGciOiJI',
-      { kind: 'file', url: 'https://cdn.example.com/stream/8f3ab21?token=eyJhbGciOiJI', container: 'unknown' },
+      {
+        kind: 'file',
+        url: 'https://cdn.example.com/stream/8f3ab21?token=eyJhbGciOiJI',
+        container: 'unknown',
+      },
     ],
-    ['garbage text', 'watch this movie', { kind: 'file', url: 'watch this movie', container: 'unknown' }],
+    [
+      'garbage text',
+      'watch this movie',
+      { kind: 'file', url: 'watch this movie', container: 'unknown' },
+    ],
+
+    // -- refused: could not possibly be fetched by a media element ------
+    ['unparseable URL', 'http://[bad', { kind: 'none', reason: 'unsupported' }],
+    [
+      'javascript scheme',
+      'javascript:alert(1)',
+      { kind: 'none', reason: 'unsupported' },
+    ],
+    [
+      'javascript scheme hiding behind a media extension',
+      'javascript:x.mp4',
+      { kind: 'none', reason: 'unsupported' },
+    ],
+    [
+      'data scheme',
+      'data:text/html,<script>alert(1)</script>',
+      { kind: 'none', reason: 'unsupported' },
+    ],
+    [
+      'blob scheme',
+      'blob:https://example.com/2f9a1c3e',
+      { kind: 'none', reason: 'unsupported' },
+    ],
   ];
 
   it.each(cases)('%s', (_name, input, want) => {
@@ -102,13 +185,18 @@ describe('classifyMediaSource', () => {
   it('11 chars of the id charset classify as youtube even when unintended', () => {
     // "not-a-video" is exactly 11 chars of [A-Za-z0-9_-]: the legacy-room
     // rule admits it by design; the YT player's onError owns the failure
-    expect(classifyMediaSource('not-a-video')).toEqual({ kind: 'youtube', videoId: 'not-a-video' });
+    expect(classifyMediaSource('not-a-video')).toEqual({
+      kind: 'youtube',
+      videoId: 'not-a-video',
+    });
   });
 });
 
 describe('isAcceptableVideoUrl', () => {
   it('admits absolute http(s) URLs, /media/ paths, and bare YouTube ids', () => {
-    expect(isAcceptableVideoUrl('https://www.youtube.com/watch?v=aqz-KE-bpKQ')).toBe(true);
+    expect(
+      isAcceptableVideoUrl('https://www.youtube.com/watch?v=aqz-KE-bpKQ'),
+    ).toBe(true);
     expect(isAcceptableVideoUrl('http://cdn.example.com/movie.mp4')).toBe(true);
     expect(isAcceptableVideoUrl('/media/clip.webm')).toBe(true);
     expect(isAcceptableVideoUrl('media/clip.webm')).toBe(true);
@@ -116,8 +204,12 @@ describe('isAcceptableVideoUrl', () => {
   });
 
   it('admits extensionless signed links (playability is the player card, not validation)', () => {
-    expect(isAcceptableVideoUrl('https://cdn.example.com/stream/8f3ab21?token=abc')).toBe(true);
-    expect(isAcceptableVideoUrl('https://example.com/not-a-video-page')).toBe(true);
+    expect(
+      isAcceptableVideoUrl('https://cdn.example.com/stream/8f3ab21?token=abc'),
+    ).toBe(true);
+    expect(isAcceptableVideoUrl('https://example.com/not-a-video-page')).toBe(
+      true,
+    );
   });
 
   it('refuses single-token garbage at the shape floor', () => {
@@ -129,7 +221,9 @@ describe('isAcceptableVideoUrl', () => {
 
   it('refuses empty, oversized, and whitespace-containing inputs', () => {
     expect(isAcceptableVideoUrl('')).toBe(false);
-    expect(isAcceptableVideoUrl('https://a.com/' + 'x'.repeat(VIDEO_URL_MAX_LEN))).toBe(false);
+    expect(
+      isAcceptableVideoUrl('https://a.com/' + 'x'.repeat(VIDEO_URL_MAX_LEN)),
+    ).toBe(false);
     expect(isAcceptableVideoUrl('https://a.com/a b')).toBe(false);
     expect(isAcceptableVideoUrl(' https://a.com/x.mp4')).toBe(false);
   });

--- a/video-sync-backend/src/shared/media-source.ts
+++ b/video-sync-backend/src/shared/media-source.ts
@@ -125,11 +125,11 @@ function byExtension(u: URL, raw: string): MediaSource | null {
  * Ordered rules:
  *  1. empty/whitespace -> none/empty ('' is the room's null sentinel)
  *  2. bare 11-char id -> youtube (legacy rooms stored ids, not URLs)
- *  3. YouTube/Vimeo by hostname; a provider host WITHOUT an extractable id
+ *  3. non-http(s) scheme -> none/unsupported (javascript:, data:, blob:
+ *     all parse, but must never become a media element src)
+ *  4. YouTube/Vimeo by hostname; a provider host WITHOUT an extractable id
  *     is none/unsupported - a <video> fetch against a provider page is
  *     doomed, so don't attempt it
- *  4. non-http(s) scheme -> none/unsupported (javascript:, data:, blob:
- *     all parse, but must never become a media element src)
  *  5. pathname extension: .m3u8 -> hls; .mp4/.webm/.ogg -> file
  *  6. anything else that parsed -> file/unknown (attempt-and-fail-visibly)
  */
@@ -149,6 +149,17 @@ export function classifyMediaSource(
     return { kind: 'none', reason: 'unsupported' };
   }
 
+  // Only schemes a media element can fetch may classify at all: javascript:,
+  // data: and blob: all parse - some even with a provider-shaped authority
+  // (javascript://youtube.com/watch?v=x has hostname "youtube.com"), so the
+  // guard runs before ANY host matching. isAcceptableVideoUrl also refuses
+  // these at the shape floor, but classifyMediaSource runs on STORED values
+  // too (legacy rooms predate admission), so the refusal must live here as
+  // well. Relative inputs resolve against RELATIVE_BASE (https:) and pass.
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+    return { kind: 'none', reason: 'unsupported' };
+  }
+
   const host = hostOf(u);
   if (host === 'youtu.be' || YT_HOSTS.indexOf(host) !== -1) {
     const id = extractYouTubeId(u, host);
@@ -162,17 +173,6 @@ export function classifyMediaSource(
   }
   if (host === 'vimeo.com' || host === 'player.vimeo.com')
     return classifyVimeo(u, host);
-
-  // Only schemes a media element can fetch may become a src: javascript:,
-  // data: and blob: all parse. isAcceptableVideoUrl also refuses them at
-  // the shape floor, but classifyMediaSource runs on STORED values too
-  // (legacy rooms predate admission), so the guard must live here as well.
-  // Before byExtension on purpose - javascript:x.mp4 must not classify by
-  // its extension. Relative inputs resolve against RELATIVE_BASE (https:)
-  // and pass untouched.
-  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
-    return { kind: 'none', reason: 'unsupported' };
-  }
 
   const ext = byExtension(u, s);
   if (ext !== null) return ext;

--- a/video-sync-backend/src/shared/media-source.ts
+++ b/video-sync-backend/src/shared/media-source.ts
@@ -1,0 +1,163 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+// Source classification and URL validation for room videos - the ONE place
+// that decides what a videoUrl means. Consumed by the player (which mount to
+// render), the REST DTOs, and the gateway's set-video guard; drift between
+// those three is impossible by construction because they all import this.
+//
+// Boundary: validation bounds SIZE and SHAPE, never playability.
+// `https://example.com/not-a-video` is valid input by design - unknown URLs
+// are attempted as HTML5 media and fail visibly in the player, because
+// signed CDN links (extensionless, query-string-authenticated) are
+// indistinguishable from garbage by inspection. The player's failure card
+// owns that outcome; this module only refuses inputs that could not
+// possibly be fetched or that no mount would accept.
+//
+// Pure and DOM-free (WHATWG URL only) so the same code runs in the backend
+// gateway, jest, and the browser bundle.
+
+export type MediaSource =
+  | { kind: 'none'; reason: 'empty' | 'unsupported' }
+  | { kind: 'youtube'; videoId: string }
+  | { kind: 'vimeo'; videoId: string; hash?: string } // hash: unlisted-video key
+  | { kind: 'hls'; url: string }
+  | { kind: 'file'; url: string; container: 'mp4' | 'webm' | 'ogg' | 'unknown' };
+
+/**
+ * Bounds what a videoUrl may look like at the door (REST create/update and
+ * the set-video control). The cap matters because the URL becomes
+ * Timeline.videoId and rides EVERY sync:timeline broadcast to every client
+ * in the room - it bounds store and wire, not just sanity. 2048 is the
+ * interoperable URL limit; signed CDN URLs (500-1500 chars) fit.
+ */
+export const VIDEO_URL_MAX_LEN = 2048;
+
+/**
+ * Shape floor: an absolute http(s) URL or a same-origin /media/ path.
+ * Single-token garbage ("hello") is refused here; extensionless signed
+ * links pass and are the player's problem (fail-visibly). Bare 11-char
+ * YouTube ids are additionally admitted by isAcceptableVideoUrl.
+ */
+export const VIDEO_URL_SHAPE = /^(https?:\/\/\S+|\/?media\/\S+)$/;
+
+const YT_ID = /^[A-Za-z0-9_-]{11}$/;
+
+// Dummy base so relative inputs ("/media/x.mp4") parse; the reserved
+// .invalid TLD guarantees the host never collides with a real provider.
+const RELATIVE_BASE = 'https://relative.invalid/';
+
+// Hostnames checked AFTER stripping a leading "www.".
+const YT_HOSTS = ['youtube.com', 'm.youtube.com', 'music.youtube.com', 'youtube-nocookie.com'];
+
+function hostOf(u: URL): string {
+  const h = u.hostname.toLowerCase();
+  return h.slice(0, 4) === 'www.' ? h.slice(4) : h;
+}
+
+function segmentsOf(u: URL): string[] {
+  return u.pathname.split('/').filter((s) => s.length > 0);
+}
+
+function extractYouTubeId(u: URL, host: string): string | null {
+  if (host === 'youtu.be') {
+    const seg = segmentsOf(u)[0];
+    return seg !== undefined ? seg : null;
+  }
+  const segs = segmentsOf(u);
+  if (segs[0] === 'watch') return u.searchParams.get('v');
+  if (
+    segs.length >= 2 &&
+    (segs[0] === 'embed' || segs[0] === 'shorts' || segs[0] === 'live' || segs[0] === 'v')
+  ) {
+    return segs[1];
+  }
+  return null;
+}
+
+function classifyVimeo(u: URL, host: string): MediaSource {
+  const segs = segmentsOf(u);
+  if (host === 'player.vimeo.com') {
+    if (segs[0] === 'video' && segs[1] !== undefined && /^\d+$/.test(segs[1])) {
+      const h = u.searchParams.get('h');
+      return h !== null && h !== ''
+        ? { kind: 'vimeo', videoId: segs[1], hash: h }
+        : { kind: 'vimeo', videoId: segs[1] };
+    }
+    return { kind: 'none', reason: 'unsupported' };
+  }
+  // vimeo.com/<digits>[/<unlisted-hash>]
+  if (segs[0] !== undefined && /^\d+$/.test(segs[0])) {
+    const h = segs[1];
+    return h !== undefined && /^[A-Za-z0-9]+$/.test(h)
+      ? { kind: 'vimeo', videoId: segs[0], hash: h }
+      : { kind: 'vimeo', videoId: segs[0] };
+  }
+  return { kind: 'none', reason: 'unsupported' };
+}
+
+/** Extension rules run on URL.pathname only - `?signature=` query strings never interfere. */
+function byExtension(u: URL, raw: string): MediaSource | null {
+  const p = u.pathname.toLowerCase();
+  if (p.slice(-5) === '.m3u8') return { kind: 'hls', url: raw };
+  if (p.slice(-4) === '.mp4') return { kind: 'file', url: raw, container: 'mp4' };
+  if (p.slice(-5) === '.webm') return { kind: 'file', url: raw, container: 'webm' };
+  if (p.slice(-4) === '.ogg') return { kind: 'file', url: raw, container: 'ogg' };
+  return null;
+}
+
+/**
+ * Classify a room's videoUrl into the source a player mount can act on.
+ * `url` fields carry the RAW input, never a re-encoded parse - signed URLs
+ * must reach the media element byte-for-byte.
+ *
+ * Ordered rules:
+ *  1. empty/whitespace -> none/empty ('' is the room's null sentinel)
+ *  2. bare 11-char id -> youtube (legacy rooms stored ids, not URLs)
+ *  3. YouTube/Vimeo by hostname; a provider host WITHOUT an extractable id
+ *     is none/unsupported - a <video> fetch against a provider page is
+ *     doomed, so don't attempt it
+ *  4. pathname extension: .m3u8 -> hls; .mp4/.webm/.ogg -> file
+ *  5. anything else that parsed -> file/unknown (attempt-and-fail-visibly)
+ */
+export function classifyMediaSource(raw: string | null | undefined): MediaSource {
+  const s = (raw !== null && raw !== undefined ? raw : '').trim();
+  if (s === '') return { kind: 'none', reason: 'empty' };
+  if (YT_ID.test(s)) return { kind: 'youtube', videoId: s };
+
+  let u: URL;
+  try {
+    u = new URL(s, RELATIVE_BASE);
+  } catch {
+    // not even parseable relative to a base (e.g. "http://[bad") - nothing
+    // could fetch this, so it is refused rather than attempted
+    return { kind: 'none', reason: 'unsupported' };
+  }
+
+  const host = hostOf(u);
+  if (host === 'youtu.be' || YT_HOSTS.indexOf(host) !== -1) {
+    const id = extractYouTubeId(u, host);
+    // "videoseries" is /embed/'s playlist pseudo-id: 11 chars of the id
+    // charset but never a video - loading it would only produce a player
+    // error, so refuse it as unsupported instead
+    if (id !== null && id !== 'videoseries' && YT_ID.test(id)) {
+      return { kind: 'youtube', videoId: id };
+    }
+    return { kind: 'none', reason: 'unsupported' };
+  }
+  if (host === 'vimeo.com' || host === 'player.vimeo.com') return classifyVimeo(u, host);
+
+  const ext = byExtension(u, s);
+  if (ext !== null) return ext;
+  return { kind: 'file', url: s, container: 'unknown' };
+}
+
+/**
+ * The admission rule for videoUrl at every write path (REST DTOs, gateway
+ * set-video guard, frontend form). Strict on the string AS GIVEN - callers
+ * trim before validating, and surrounding whitespace fails the anchors.
+ */
+export function isAcceptableVideoUrl(raw: string): boolean {
+  if (raw.length === 0 || raw.length > VIDEO_URL_MAX_LEN) return false;
+  if (!VIDEO_URL_SHAPE.test(raw) && !YT_ID.test(raw)) return false;
+  return classifyMediaSource(raw).kind !== 'none';
+}

--- a/video-sync-backend/src/shared/media-source.ts
+++ b/video-sync-backend/src/shared/media-source.ts
@@ -21,7 +21,11 @@ export type MediaSource =
   | { kind: 'youtube'; videoId: string }
   | { kind: 'vimeo'; videoId: string; hash?: string } // hash: unlisted-video key
   | { kind: 'hls'; url: string }
-  | { kind: 'file'; url: string; container: 'mp4' | 'webm' | 'ogg' | 'unknown' };
+  | {
+      kind: 'file';
+      url: string;
+      container: 'mp4' | 'webm' | 'ogg' | 'unknown';
+    };
 
 /**
  * Bounds what a videoUrl may look like at the door (REST create/update and
@@ -47,7 +51,12 @@ const YT_ID = /^[A-Za-z0-9_-]{11}$/;
 const RELATIVE_BASE = 'https://relative.invalid/';
 
 // Hostnames checked AFTER stripping a leading "www.".
-const YT_HOSTS = ['youtube.com', 'm.youtube.com', 'music.youtube.com', 'youtube-nocookie.com'];
+const YT_HOSTS = [
+  'youtube.com',
+  'm.youtube.com',
+  'music.youtube.com',
+  'youtube-nocookie.com',
+];
 
 function hostOf(u: URL): string {
   const h = u.hostname.toLowerCase();
@@ -67,7 +76,10 @@ function extractYouTubeId(u: URL, host: string): string | null {
   if (segs[0] === 'watch') return u.searchParams.get('v');
   if (
     segs.length >= 2 &&
-    (segs[0] === 'embed' || segs[0] === 'shorts' || segs[0] === 'live' || segs[0] === 'v')
+    (segs[0] === 'embed' ||
+      segs[0] === 'shorts' ||
+      segs[0] === 'live' ||
+      segs[0] === 'v')
   ) {
     return segs[1];
   }
@@ -98,10 +110,10 @@ function classifyVimeo(u: URL, host: string): MediaSource {
 /** Extension rules run on URL.pathname only - `?signature=` query strings never interfere. */
 function byExtension(u: URL, raw: string): MediaSource | null {
   const p = u.pathname.toLowerCase();
-  if (p.slice(-5) === '.m3u8') return { kind: 'hls', url: raw };
-  if (p.slice(-4) === '.mp4') return { kind: 'file', url: raw, container: 'mp4' };
-  if (p.slice(-5) === '.webm') return { kind: 'file', url: raw, container: 'webm' };
-  if (p.slice(-4) === '.ogg') return { kind: 'file', url: raw, container: 'ogg' };
+  if (p.endsWith('.m3u8')) return { kind: 'hls', url: raw };
+  if (p.endsWith('.mp4')) return { kind: 'file', url: raw, container: 'mp4' };
+  if (p.endsWith('.webm')) return { kind: 'file', url: raw, container: 'webm' };
+  if (p.endsWith('.ogg')) return { kind: 'file', url: raw, container: 'ogg' };
   return null;
 }
 
@@ -116,10 +128,14 @@ function byExtension(u: URL, raw: string): MediaSource | null {
  *  3. YouTube/Vimeo by hostname; a provider host WITHOUT an extractable id
  *     is none/unsupported - a <video> fetch against a provider page is
  *     doomed, so don't attempt it
- *  4. pathname extension: .m3u8 -> hls; .mp4/.webm/.ogg -> file
- *  5. anything else that parsed -> file/unknown (attempt-and-fail-visibly)
+ *  4. non-http(s) scheme -> none/unsupported (javascript:, data:, blob:
+ *     all parse, but must never become a media element src)
+ *  5. pathname extension: .m3u8 -> hls; .mp4/.webm/.ogg -> file
+ *  6. anything else that parsed -> file/unknown (attempt-and-fail-visibly)
  */
-export function classifyMediaSource(raw: string | null | undefined): MediaSource {
+export function classifyMediaSource(
+  raw: string | null | undefined,
+): MediaSource {
   const s = (raw !== null && raw !== undefined ? raw : '').trim();
   if (s === '') return { kind: 'none', reason: 'empty' };
   if (YT_ID.test(s)) return { kind: 'youtube', videoId: s };
@@ -144,7 +160,19 @@ export function classifyMediaSource(raw: string | null | undefined): MediaSource
     }
     return { kind: 'none', reason: 'unsupported' };
   }
-  if (host === 'vimeo.com' || host === 'player.vimeo.com') return classifyVimeo(u, host);
+  if (host === 'vimeo.com' || host === 'player.vimeo.com')
+    return classifyVimeo(u, host);
+
+  // Only schemes a media element can fetch may become a src: javascript:,
+  // data: and blob: all parse. isAcceptableVideoUrl also refuses them at
+  // the shape floor, but classifyMediaSource runs on STORED values too
+  // (legacy rooms predate admission), so the guard must live here as well.
+  // Before byExtension on purpose - javascript:x.mp4 must not classify by
+  // its extension. Relative inputs resolve against RELATIVE_BASE (https:)
+  // and pass untouched.
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+    return { kind: 'none', reason: 'unsupported' };
+  }
 
   const ext = byExtension(u, s);
   if (ext !== null) return ext;

--- a/video-sync-backend/src/sync/lua/common.lua
+++ b/video-sync-backend/src/sync/lua/common.lua
@@ -10,8 +10,12 @@ local function load_tl(key)
   return tl
 end
 local function save_tl(key, tl, ttl)
+  -- videoId falls back to '' (the established nil-encoding) like log_tl
+  -- below: a table missing the field would make HSET raise mid-script,
+  -- losing the control - and an ioredis resend would repeat it
+  -- deterministically, bricking the room until the key's TTL
   redis.call('HSET', key,
-    'seq', tl.seq, 'storeEpoch', tl.storeEpoch, 'videoId', tl.videoId,
+    'seq', tl.seq, 'storeEpoch', tl.storeEpoch, 'videoId', tl.videoId or '',
     'isPlaying', tl.isPlaying, 'mediaTime', tl.mediaTime,
     'stampedAt', tl.stampedAt, 'reason', tl.reason, 'by', tl.by or '',
     -- which aligned time window the repair sweep last committed in. Persisted

--- a/video-sync-frontend/src/shared/media-source.ts
+++ b/video-sync-frontend/src/shared/media-source.ts
@@ -125,11 +125,11 @@ function byExtension(u: URL, raw: string): MediaSource | null {
  * Ordered rules:
  *  1. empty/whitespace -> none/empty ('' is the room's null sentinel)
  *  2. bare 11-char id -> youtube (legacy rooms stored ids, not URLs)
- *  3. YouTube/Vimeo by hostname; a provider host WITHOUT an extractable id
+ *  3. non-http(s) scheme -> none/unsupported (javascript:, data:, blob:
+ *     all parse, but must never become a media element src)
+ *  4. YouTube/Vimeo by hostname; a provider host WITHOUT an extractable id
  *     is none/unsupported - a <video> fetch against a provider page is
  *     doomed, so don't attempt it
- *  4. non-http(s) scheme -> none/unsupported (javascript:, data:, blob:
- *     all parse, but must never become a media element src)
  *  5. pathname extension: .m3u8 -> hls; .mp4/.webm/.ogg -> file
  *  6. anything else that parsed -> file/unknown (attempt-and-fail-visibly)
  */
@@ -149,6 +149,17 @@ export function classifyMediaSource(
     return { kind: 'none', reason: 'unsupported' };
   }
 
+  // Only schemes a media element can fetch may classify at all: javascript:,
+  // data: and blob: all parse - some even with a provider-shaped authority
+  // (javascript://youtube.com/watch?v=x has hostname "youtube.com"), so the
+  // guard runs before ANY host matching. isAcceptableVideoUrl also refuses
+  // these at the shape floor, but classifyMediaSource runs on STORED values
+  // too (legacy rooms predate admission), so the refusal must live here as
+  // well. Relative inputs resolve against RELATIVE_BASE (https:) and pass.
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+    return { kind: 'none', reason: 'unsupported' };
+  }
+
   const host = hostOf(u);
   if (host === 'youtu.be' || YT_HOSTS.indexOf(host) !== -1) {
     const id = extractYouTubeId(u, host);
@@ -162,17 +173,6 @@ export function classifyMediaSource(
   }
   if (host === 'vimeo.com' || host === 'player.vimeo.com')
     return classifyVimeo(u, host);
-
-  // Only schemes a media element can fetch may become a src: javascript:,
-  // data: and blob: all parse. isAcceptableVideoUrl also refuses them at
-  // the shape floor, but classifyMediaSource runs on STORED values too
-  // (legacy rooms predate admission), so the guard must live here as well.
-  // Before byExtension on purpose - javascript:x.mp4 must not classify by
-  // its extension. Relative inputs resolve against RELATIVE_BASE (https:)
-  // and pass untouched.
-  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
-    return { kind: 'none', reason: 'unsupported' };
-  }
 
   const ext = byExtension(u, s);
   if (ext !== null) return ext;

--- a/video-sync-frontend/src/shared/media-source.ts
+++ b/video-sync-frontend/src/shared/media-source.ts
@@ -1,0 +1,163 @@
+// GENERATED FILE — do not edit here.
+// Canonical source: /shared/. Regenerate: node scripts/sync-shared.mjs
+// Source classification and URL validation for room videos - the ONE place
+// that decides what a videoUrl means. Consumed by the player (which mount to
+// render), the REST DTOs, and the gateway's set-video guard; drift between
+// those three is impossible by construction because they all import this.
+//
+// Boundary: validation bounds SIZE and SHAPE, never playability.
+// `https://example.com/not-a-video` is valid input by design - unknown URLs
+// are attempted as HTML5 media and fail visibly in the player, because
+// signed CDN links (extensionless, query-string-authenticated) are
+// indistinguishable from garbage by inspection. The player's failure card
+// owns that outcome; this module only refuses inputs that could not
+// possibly be fetched or that no mount would accept.
+//
+// Pure and DOM-free (WHATWG URL only) so the same code runs in the backend
+// gateway, jest, and the browser bundle.
+
+export type MediaSource =
+  | { kind: 'none'; reason: 'empty' | 'unsupported' }
+  | { kind: 'youtube'; videoId: string }
+  | { kind: 'vimeo'; videoId: string; hash?: string } // hash: unlisted-video key
+  | { kind: 'hls'; url: string }
+  | { kind: 'file'; url: string; container: 'mp4' | 'webm' | 'ogg' | 'unknown' };
+
+/**
+ * Bounds what a videoUrl may look like at the door (REST create/update and
+ * the set-video control). The cap matters because the URL becomes
+ * Timeline.videoId and rides EVERY sync:timeline broadcast to every client
+ * in the room - it bounds store and wire, not just sanity. 2048 is the
+ * interoperable URL limit; signed CDN URLs (500-1500 chars) fit.
+ */
+export const VIDEO_URL_MAX_LEN = 2048;
+
+/**
+ * Shape floor: an absolute http(s) URL or a same-origin /media/ path.
+ * Single-token garbage ("hello") is refused here; extensionless signed
+ * links pass and are the player's problem (fail-visibly). Bare 11-char
+ * YouTube ids are additionally admitted by isAcceptableVideoUrl.
+ */
+export const VIDEO_URL_SHAPE = /^(https?:\/\/\S+|\/?media\/\S+)$/;
+
+const YT_ID = /^[A-Za-z0-9_-]{11}$/;
+
+// Dummy base so relative inputs ("/media/x.mp4") parse; the reserved
+// .invalid TLD guarantees the host never collides with a real provider.
+const RELATIVE_BASE = 'https://relative.invalid/';
+
+// Hostnames checked AFTER stripping a leading "www.".
+const YT_HOSTS = ['youtube.com', 'm.youtube.com', 'music.youtube.com', 'youtube-nocookie.com'];
+
+function hostOf(u: URL): string {
+  const h = u.hostname.toLowerCase();
+  return h.slice(0, 4) === 'www.' ? h.slice(4) : h;
+}
+
+function segmentsOf(u: URL): string[] {
+  return u.pathname.split('/').filter((s) => s.length > 0);
+}
+
+function extractYouTubeId(u: URL, host: string): string | null {
+  if (host === 'youtu.be') {
+    const seg = segmentsOf(u)[0];
+    return seg !== undefined ? seg : null;
+  }
+  const segs = segmentsOf(u);
+  if (segs[0] === 'watch') return u.searchParams.get('v');
+  if (
+    segs.length >= 2 &&
+    (segs[0] === 'embed' || segs[0] === 'shorts' || segs[0] === 'live' || segs[0] === 'v')
+  ) {
+    return segs[1];
+  }
+  return null;
+}
+
+function classifyVimeo(u: URL, host: string): MediaSource {
+  const segs = segmentsOf(u);
+  if (host === 'player.vimeo.com') {
+    if (segs[0] === 'video' && segs[1] !== undefined && /^\d+$/.test(segs[1])) {
+      const h = u.searchParams.get('h');
+      return h !== null && h !== ''
+        ? { kind: 'vimeo', videoId: segs[1], hash: h }
+        : { kind: 'vimeo', videoId: segs[1] };
+    }
+    return { kind: 'none', reason: 'unsupported' };
+  }
+  // vimeo.com/<digits>[/<unlisted-hash>]
+  if (segs[0] !== undefined && /^\d+$/.test(segs[0])) {
+    const h = segs[1];
+    return h !== undefined && /^[A-Za-z0-9]+$/.test(h)
+      ? { kind: 'vimeo', videoId: segs[0], hash: h }
+      : { kind: 'vimeo', videoId: segs[0] };
+  }
+  return { kind: 'none', reason: 'unsupported' };
+}
+
+/** Extension rules run on URL.pathname only - `?signature=` query strings never interfere. */
+function byExtension(u: URL, raw: string): MediaSource | null {
+  const p = u.pathname.toLowerCase();
+  if (p.slice(-5) === '.m3u8') return { kind: 'hls', url: raw };
+  if (p.slice(-4) === '.mp4') return { kind: 'file', url: raw, container: 'mp4' };
+  if (p.slice(-5) === '.webm') return { kind: 'file', url: raw, container: 'webm' };
+  if (p.slice(-4) === '.ogg') return { kind: 'file', url: raw, container: 'ogg' };
+  return null;
+}
+
+/**
+ * Classify a room's videoUrl into the source a player mount can act on.
+ * `url` fields carry the RAW input, never a re-encoded parse - signed URLs
+ * must reach the media element byte-for-byte.
+ *
+ * Ordered rules:
+ *  1. empty/whitespace -> none/empty ('' is the room's null sentinel)
+ *  2. bare 11-char id -> youtube (legacy rooms stored ids, not URLs)
+ *  3. YouTube/Vimeo by hostname; a provider host WITHOUT an extractable id
+ *     is none/unsupported - a <video> fetch against a provider page is
+ *     doomed, so don't attempt it
+ *  4. pathname extension: .m3u8 -> hls; .mp4/.webm/.ogg -> file
+ *  5. anything else that parsed -> file/unknown (attempt-and-fail-visibly)
+ */
+export function classifyMediaSource(raw: string | null | undefined): MediaSource {
+  const s = (raw !== null && raw !== undefined ? raw : '').trim();
+  if (s === '') return { kind: 'none', reason: 'empty' };
+  if (YT_ID.test(s)) return { kind: 'youtube', videoId: s };
+
+  let u: URL;
+  try {
+    u = new URL(s, RELATIVE_BASE);
+  } catch {
+    // not even parseable relative to a base (e.g. "http://[bad") - nothing
+    // could fetch this, so it is refused rather than attempted
+    return { kind: 'none', reason: 'unsupported' };
+  }
+
+  const host = hostOf(u);
+  if (host === 'youtu.be' || YT_HOSTS.indexOf(host) !== -1) {
+    const id = extractYouTubeId(u, host);
+    // "videoseries" is /embed/'s playlist pseudo-id: 11 chars of the id
+    // charset but never a video - loading it would only produce a player
+    // error, so refuse it as unsupported instead
+    if (id !== null && id !== 'videoseries' && YT_ID.test(id)) {
+      return { kind: 'youtube', videoId: id };
+    }
+    return { kind: 'none', reason: 'unsupported' };
+  }
+  if (host === 'vimeo.com' || host === 'player.vimeo.com') return classifyVimeo(u, host);
+
+  const ext = byExtension(u, s);
+  if (ext !== null) return ext;
+  return { kind: 'file', url: s, container: 'unknown' };
+}
+
+/**
+ * The admission rule for videoUrl at every write path (REST DTOs, gateway
+ * set-video guard, frontend form). Strict on the string AS GIVEN - callers
+ * trim before validating, and surrounding whitespace fails the anchors.
+ */
+export function isAcceptableVideoUrl(raw: string): boolean {
+  if (raw.length === 0 || raw.length > VIDEO_URL_MAX_LEN) return false;
+  if (!VIDEO_URL_SHAPE.test(raw) && !YT_ID.test(raw)) return false;
+  return classifyMediaSource(raw).kind !== 'none';
+}

--- a/video-sync-frontend/src/shared/media-source.ts
+++ b/video-sync-frontend/src/shared/media-source.ts
@@ -21,7 +21,11 @@ export type MediaSource =
   | { kind: 'youtube'; videoId: string }
   | { kind: 'vimeo'; videoId: string; hash?: string } // hash: unlisted-video key
   | { kind: 'hls'; url: string }
-  | { kind: 'file'; url: string; container: 'mp4' | 'webm' | 'ogg' | 'unknown' };
+  | {
+      kind: 'file';
+      url: string;
+      container: 'mp4' | 'webm' | 'ogg' | 'unknown';
+    };
 
 /**
  * Bounds what a videoUrl may look like at the door (REST create/update and
@@ -47,7 +51,12 @@ const YT_ID = /^[A-Za-z0-9_-]{11}$/;
 const RELATIVE_BASE = 'https://relative.invalid/';
 
 // Hostnames checked AFTER stripping a leading "www.".
-const YT_HOSTS = ['youtube.com', 'm.youtube.com', 'music.youtube.com', 'youtube-nocookie.com'];
+const YT_HOSTS = [
+  'youtube.com',
+  'm.youtube.com',
+  'music.youtube.com',
+  'youtube-nocookie.com',
+];
 
 function hostOf(u: URL): string {
   const h = u.hostname.toLowerCase();
@@ -67,7 +76,10 @@ function extractYouTubeId(u: URL, host: string): string | null {
   if (segs[0] === 'watch') return u.searchParams.get('v');
   if (
     segs.length >= 2 &&
-    (segs[0] === 'embed' || segs[0] === 'shorts' || segs[0] === 'live' || segs[0] === 'v')
+    (segs[0] === 'embed' ||
+      segs[0] === 'shorts' ||
+      segs[0] === 'live' ||
+      segs[0] === 'v')
   ) {
     return segs[1];
   }
@@ -98,10 +110,10 @@ function classifyVimeo(u: URL, host: string): MediaSource {
 /** Extension rules run on URL.pathname only - `?signature=` query strings never interfere. */
 function byExtension(u: URL, raw: string): MediaSource | null {
   const p = u.pathname.toLowerCase();
-  if (p.slice(-5) === '.m3u8') return { kind: 'hls', url: raw };
-  if (p.slice(-4) === '.mp4') return { kind: 'file', url: raw, container: 'mp4' };
-  if (p.slice(-5) === '.webm') return { kind: 'file', url: raw, container: 'webm' };
-  if (p.slice(-4) === '.ogg') return { kind: 'file', url: raw, container: 'ogg' };
+  if (p.endsWith('.m3u8')) return { kind: 'hls', url: raw };
+  if (p.endsWith('.mp4')) return { kind: 'file', url: raw, container: 'mp4' };
+  if (p.endsWith('.webm')) return { kind: 'file', url: raw, container: 'webm' };
+  if (p.endsWith('.ogg')) return { kind: 'file', url: raw, container: 'ogg' };
   return null;
 }
 
@@ -116,10 +128,14 @@ function byExtension(u: URL, raw: string): MediaSource | null {
  *  3. YouTube/Vimeo by hostname; a provider host WITHOUT an extractable id
  *     is none/unsupported - a <video> fetch against a provider page is
  *     doomed, so don't attempt it
- *  4. pathname extension: .m3u8 -> hls; .mp4/.webm/.ogg -> file
- *  5. anything else that parsed -> file/unknown (attempt-and-fail-visibly)
+ *  4. non-http(s) scheme -> none/unsupported (javascript:, data:, blob:
+ *     all parse, but must never become a media element src)
+ *  5. pathname extension: .m3u8 -> hls; .mp4/.webm/.ogg -> file
+ *  6. anything else that parsed -> file/unknown (attempt-and-fail-visibly)
  */
-export function classifyMediaSource(raw: string | null | undefined): MediaSource {
+export function classifyMediaSource(
+  raw: string | null | undefined,
+): MediaSource {
   const s = (raw !== null && raw !== undefined ? raw : '').trim();
   if (s === '') return { kind: 'none', reason: 'empty' };
   if (YT_ID.test(s)) return { kind: 'youtube', videoId: s };
@@ -144,7 +160,19 @@ export function classifyMediaSource(raw: string | null | undefined): MediaSource
     }
     return { kind: 'none', reason: 'unsupported' };
   }
-  if (host === 'vimeo.com' || host === 'player.vimeo.com') return classifyVimeo(u, host);
+  if (host === 'vimeo.com' || host === 'player.vimeo.com')
+    return classifyVimeo(u, host);
+
+  // Only schemes a media element can fetch may become a src: javascript:,
+  // data: and blob: all parse. isAcceptableVideoUrl also refuses them at
+  // the shape floor, but classifyMediaSource runs on STORED values too
+  // (legacy rooms predate admission), so the guard must live here as well.
+  // Before byExtension on purpose - javascript:x.mp4 must not classify by
+  // its extension. Relative inputs resolve against RELATIVE_BASE (https:)
+  // and pass untouched.
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+    return { kind: 'none', reason: 'unsupported' };
+  }
 
   const ext = byExtension(u, s);
   if (ext !== null) return ext;


### PR DESCRIPTION
Step 1 of the multi-source player program: a shared module that is the ONE
place deciding what a room's `videoUrl` means. The player (which mount to
render), the REST DTOs, and the gateway's set-video guard will all import
this — drift between the three becomes impossible by construction. Nothing
consumes it yet; this PR is deliberately zero-behavior-change so the
classifier's semantics get reviewed on their own.

**The boundary that matters: validation bounds SIZE and SHAPE, never
playability.** `https://example.com/not-a-video` is valid input *by design* —
signed CDN links (extensionless, query-string-authenticated) are
indistinguishable from garbage by inspection, so unknown URLs are attempted
as HTML5 media and fail visibly in the player. The module only refuses
inputs that could not possibly be fetched (single-token garbage, unparseable
URLs) or that no mount would accept (a provider host without an extractable
id — a `<video>` fetch against a YouTube page is doomed).

Classification rules, in order:

1. empty/whitespace → `none/empty` (`''` is the room's null sentinel)
2. bare 11-char id → `youtube` (legacy rooms stored ids, not URLs)
3. YouTube/Vimeo by hostname, ids extracted from all the URL shapes
   (`watch?v=`, `youtu.be`, `/embed/`, `/shorts/`, `/live/`, Vimeo unlisted
   hashes); `videoseries` is refused — it's `/embed/`'s playlist pseudo-id,
   11 chars of the id charset but never a video
4. pathname extension → `hls` (.m3u8) or `file` (.mp4/.webm/.ogg); extension
   rules run on `URL.pathname` only, so `?signature=` never interferes
5. anything else that parsed → `file/unknown` (attempt-and-fail-visibly)

`url` fields carry the RAW input, never a re-encoded parse — signed URLs
must reach the media element byte-for-byte. The 2048 cap bounds store and
wire, not just sanity: the URL becomes `Timeline.videoId` and rides every
`sync:timeline` broadcast. Pure and DOM-free (WHATWG URL only) so the same
code runs in the NestJS gateway, jest, and the browser bundle; mirrored by
the existing `sync-shared.mjs` script (specs excluded from the CRA copy).

**Also: `save_tl` hardening in `common.lua`.** `tl.videoId` now falls back
to `''` — the established nil-encoding already used by `tl.by` and `log_tl`.
Without it, a timeline table missing the field makes HSET raise mid-script,
losing the control — and an ioredis resend would repeat it
deterministically, bricking the room until the key's TTL.

35-case spec covers every rule plus the admission-rule edges (length cap
boundary, whitespace anchors, provider-host-without-id). Full backend suite:
105 tests green. Frontend `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing YouTube, Vimeo, HLS, direct video files, relative media paths, and legacy YouTube IDs.
  * Added validation for video URLs, including format checks and a 2,048-character limit.
  * Improved handling of unknown but valid media URLs.

* **Bug Fixes**
  * Prevented failures when timeline entries do not include a video ID.

* **Tests**
  * Added comprehensive coverage for supported formats, malformed URLs, unsupported schemes, whitespace, and boundary conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->