### PR TITLE
feat: room DTOs with the shared videoUrl rule, one pipe config for app and spec

### DIFF
--- a/video-sync-backend/src/main.ts
+++ b/video-sync-backend/src/main.ts
@@ -5,6 +5,7 @@ import { ValidationPipe } from '@nestjs/common';
 import type { NextFunction, Request, Response } from 'express';
 import { RedisIoAdapter } from './adapters/redis-io.adapter';
 import { redisEnabled } from './redis/redis.module';
+import { VALIDATION_PIPE_OPTIONS } from './validation';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
@@ -19,8 +20,9 @@ async function bootstrap() {
     credentials: true,
   });
 
-  // Enable validation
-  app.useGlobalPipes(new ValidationPipe());
+  // The options object is shared with the DTO spec - see validation.ts for
+  // why whitelist/transform are each load-bearing
+  app.useGlobalPipes(new ValidationPipe(VALIDATION_PIPE_OPTIONS));
 
   // Multi-instance plane: Redis pub/sub fanout when REDIS_URL is set
   if (redisEnabled()) {

--- a/video-sync-backend/src/rooms/dto/create-room.dto.ts
+++ b/video-sync-backend/src/rooms/dto/create-room.dto.ts
@@ -4,10 +4,10 @@ import {
   IsArray,
   IsBoolean,
   IsNotEmpty,
-  IsOptional,
   IsString,
   MaxLength,
 } from 'class-validator';
+import { SkipIfAbsent } from './skip-if-absent.decorator';
 import { IsRoomVideoUrl } from './room-video-url.decorator';
 
 const trim = ({ value }: { value: unknown }) =>
@@ -36,28 +36,28 @@ export class CreateRoomDto {
   // the shared admission rule. Trimmed first - the rule is strict about
   // surrounding whitespace by design, so the DTO owns the trim.
   @Transform(trim)
-  @IsOptional()
+  @SkipIfAbsent()
   @IsRoomVideoUrl()
   videoUrl?: string;
 
-  @IsOptional()
+  @SkipIfAbsent()
   @IsBoolean()
   isPublic?: boolean;
 
   @Transform(trim)
-  @IsOptional()
+  @SkipIfAbsent()
   @IsString()
   @MaxLength(500)
   description?: string;
 
-  @IsOptional()
+  @SkipIfAbsent()
   @IsArray()
   @ArrayMaxSize(20)
   @IsString({ each: true })
   @MaxLength(40, { each: true })
   tags?: string[];
 
-  @IsOptional()
+  @SkipIfAbsent()
   @IsBoolean()
   allowGuestControl?: boolean;
 }

--- a/video-sync-backend/src/rooms/dto/create-room.dto.ts
+++ b/video-sync-backend/src/rooms/dto/create-room.dto.ts
@@ -1,0 +1,63 @@
+import { Transform } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsBoolean,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+import { IsRoomVideoUrl } from './room-video-url.decorator';
+
+const trim = ({ value }: { value: unknown }) =>
+  typeof value === 'string' ? value.trim() : value;
+
+/**
+ * POST /rooms body. Length caps exist because name/description/tags ride
+ * every public-rooms listing and room fetch - like videoUrl's cap, they
+ * bound store and wire, not just sanity. The caps are generous; the point
+ * is that a megabyte can't become a room name.
+ */
+export class CreateRoomDto {
+  @Transform(trim)
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(120)
+  name: string;
+
+  // Identity of the creator. Present here and ONLY here - UpdateRoomDto
+  // deliberately omits it (a PATCH must not reassign ownership).
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+
+  // '' admitted as the "no video yet" sentinel; anything else must pass
+  // the shared admission rule. Trimmed first - the rule is strict about
+  // surrounding whitespace by design, so the DTO owns the trim.
+  @Transform(trim)
+  @IsOptional()
+  @IsRoomVideoUrl()
+  videoUrl?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isPublic?: boolean;
+
+  @Transform(trim)
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(20)
+  @IsString({ each: true })
+  @MaxLength(40, { each: true })
+  tags?: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  allowGuestControl?: boolean;
+}

--- a/video-sync-backend/src/rooms/dto/room-video-url.decorator.ts
+++ b/video-sync-backend/src/rooms/dto/room-video-url.decorator.ts
@@ -1,0 +1,32 @@
+import { ValidationOptions, registerDecorator } from 'class-validator';
+import { isAcceptableVideoUrl } from '../../shared/media-source';
+
+/**
+ * videoUrl admission for room DTOs: the shared rule, plus '' - the room's
+ * null sentinel ("no video"). '' must stay admitted on PATCH because the
+ * settings form round-trips `room.videoUrl || ''`; refusing it would 400
+ * every settings save on a room that has no video yet.
+ *
+ * The shared rule itself lives in shared/media-source.ts (DOM-free, no
+ * class-validator dependency - the frontend bundles the same file), so
+ * only this thin decorator is backend-specific.
+ */
+export function IsRoomVideoUrl(options?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isRoomVideoUrl',
+      target: object.constructor,
+      propertyName,
+      options: {
+        message:
+          'videoUrl must be an http(s) URL, a /media/ path, or a YouTube id',
+        ...options,
+      },
+      validator: {
+        validate: (value: unknown): boolean =>
+          typeof value === 'string' &&
+          (value === '' || isAcceptableVideoUrl(value)),
+      },
+    });
+  };
+}

--- a/video-sync-backend/src/rooms/dto/rooms.dto.spec.ts
+++ b/video-sync-backend/src/rooms/dto/rooms.dto.spec.ts
@@ -1,0 +1,107 @@
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
+import { VALIDATION_PIPE_OPTIONS } from '../../validation';
+import { CreateRoomDto } from './create-room.dto';
+import { UpdateRoomDto } from './update-room.dto';
+
+// The pipe under test is built from the SAME options object main.ts hands
+// to useGlobalPipes (validation.ts) - these tests pin production semantics,
+// not a copy that could drift.
+const pipe = new ValidationPipe(VALIDATION_PIPE_OPTIONS);
+
+const asCreate = (body: unknown): Promise<CreateRoomDto> =>
+  pipe.transform(body, { type: 'body', metatype: CreateRoomDto, data: '' });
+const asUpdate = (body: unknown): Promise<UpdateRoomDto> =>
+  pipe.transform(body, { type: 'body', metatype: UpdateRoomDto, data: '' });
+
+const base = { name: 'movie night', userId: 'user-1' };
+
+describe('CreateRoomDto through the production pipe', () => {
+  it('admits a minimal body and returns a class instance', async () => {
+    const dto = await asCreate({ ...base });
+    expect(dto).toBeInstanceOf(CreateRoomDto);
+    expect(dto.name).toBe('movie night');
+  });
+
+  it('admits a full body with an acceptable videoUrl', async () => {
+    const dto = await asCreate({
+      ...base,
+      videoUrl: 'https://www.youtube.com/watch?v=aqz-KE-bpKQ',
+      isPublic: true,
+      description: 'weekly watch party',
+      tags: ['scifi', 'weekly'],
+      allowGuestControl: true,
+    });
+    expect(dto.videoUrl).toBe('https://www.youtube.com/watch?v=aqz-KE-bpKQ');
+  });
+
+  it('admits a bare YouTube id and the empty-string sentinel', async () => {
+    await expect(
+      asCreate({ ...base, videoUrl: 'aqz-KE-bpKQ' }),
+    ).resolves.toBeDefined();
+    await expect(asCreate({ ...base, videoUrl: '' })).resolves.toBeDefined();
+  });
+
+  it('trims videoUrl and name before validating (transform is load-bearing)', async () => {
+    // the shared rule refuses surrounding whitespace, so these pass ONLY
+    // if @Transform ran first - this is the test that pins transform:true
+    const dto = await asCreate({
+      ...base,
+      name: '  movie night  ',
+      videoUrl: ' https://cdn.example.com/movie.mp4 ',
+    });
+    expect(dto.name).toBe('movie night');
+    expect(dto.videoUrl).toBe('https://cdn.example.com/movie.mp4');
+  });
+
+  it('strips unknown properties (whitelist is load-bearing)', async () => {
+    const dto = await asCreate({ ...base, isActive: false, maxUsers: 0 });
+    expect('isActive' in dto).toBe(false);
+    expect('maxUsers' in dto).toBe(false);
+  });
+
+  it.each([
+    ['javascript scheme', 'javascript:alert(1)'],
+    ['data scheme', 'data:text/html,x'],
+    ['single-token garbage', 'hello'],
+    ['provider host without an id', 'https://www.youtube.com/'],
+    ['oversized URL', 'https://a.com/' + 'x'.repeat(2048)],
+  ])('refuses videoUrl: %s', async (_name, videoUrl) => {
+    await expect(asCreate({ ...base, videoUrl })).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it.each([
+    ['missing name', { userId: 'user-1' }],
+    ['empty name', { ...base, name: '' }],
+    ['whitespace-only name (empty after trim)', { ...base, name: '   ' }],
+    ['missing userId', { name: 'movie night' }],
+    ['non-string tag', { ...base, tags: [42] }],
+  ])('refuses %s', async (_name, body) => {
+    await expect(asCreate(body)).rejects.toThrow(BadRequestException);
+  });
+});
+
+describe('UpdateRoomDto through the production pipe', () => {
+  it('admits an empty patch and the clear-video sentinel', async () => {
+    // the settings form round-trips `room.videoUrl || ''` - a save on a
+    // room with no video sends '', and must not 400
+    await expect(asUpdate({})).resolves.toBeDefined();
+    await expect(asUpdate({ videoUrl: '' })).resolves.toBeDefined();
+  });
+
+  it('strips userId - a PATCH body cannot reassign ownership', async () => {
+    // the body flows verbatim into Prisma room.update; this stripping is
+    // the guard, so its absence must fail the build, not a code review
+    const dto = await asUpdate({ videoUrl: 'aqz-KE-bpKQ', userId: 'attacker' });
+    expect('userId' in dto).toBe(false);
+    expect(dto.videoUrl).toBe('aqz-KE-bpKQ');
+  });
+
+  it('refuses a hostile videoUrl and an empty name', async () => {
+    await expect(asUpdate({ videoUrl: 'javascript:alert(1)' })).rejects.toThrow(
+      BadRequestException,
+    );
+    await expect(asUpdate({ name: '' })).rejects.toThrow(BadRequestException);
+  });
+});

--- a/video-sync-backend/src/rooms/dto/rooms.dto.spec.ts
+++ b/video-sync-backend/src/rooms/dto/rooms.dto.spec.ts
@@ -77,6 +77,12 @@ describe('CreateRoomDto through the production pipe', () => {
     ['whitespace-only name (empty after trim)', { ...base, name: '   ' }],
     ['missing userId', { name: 'movie night' }],
     ['non-string tag', { ...base, tags: [42] }],
+    // null is NOT absent: @IsOptional would wave these through to Prisma
+    // (a 500 on the non-nullable column); SkipIfAbsent makes them a 400
+    ['null name', { ...base, name: null }],
+    ['null videoUrl (only "" clears)', { ...base, videoUrl: null }],
+    ['null isPublic', { ...base, isPublic: null }],
+    ['null tags', { ...base, tags: null }],
   ])('refuses %s', async (_name, body) => {
     await expect(asCreate(body)).rejects.toThrow(BadRequestException);
   });
@@ -103,5 +109,14 @@ describe('UpdateRoomDto through the production pipe', () => {
       BadRequestException,
     );
     await expect(asUpdate({ name: '' })).rejects.toThrow(BadRequestException);
+  });
+
+  it('refuses null fields - null is a value, not an absence', async () => {
+    // name: null would reach Prisma as a non-nullable column write (500);
+    // videoUrl: null would clear the video around the documented '' path
+    await expect(asUpdate({ name: null })).rejects.toThrow(BadRequestException);
+    await expect(asUpdate({ videoUrl: null })).rejects.toThrow(
+      BadRequestException,
+    );
   });
 });

--- a/video-sync-backend/src/rooms/dto/skip-if-absent.decorator.ts
+++ b/video-sync-backend/src/rooms/dto/skip-if-absent.decorator.ts
@@ -1,0 +1,13 @@
+import { ValidateIf, ValidationOptions } from 'class-validator';
+
+/**
+ * Like @IsOptional(), except null is NOT admitted. @IsOptional() skips
+ * every validator for null AND undefined - which would let `name: null`
+ * reach Prisma as a write to a non-nullable column (a 500, not a 400)
+ * and let `videoUrl: null` clear the video while '' is the documented
+ * clear sentinel. Only an ABSENT field skips validation; an explicit
+ * null must argue with the validators like any other value.
+ */
+export function SkipIfAbsent(options?: ValidationOptions) {
+  return ValidateIf((_object, value) => value !== undefined, options);
+}

--- a/video-sync-backend/src/rooms/dto/update-room.dto.ts
+++ b/video-sync-backend/src/rooms/dto/update-room.dto.ts
@@ -1,5 +1,6 @@
 import { Transform } from 'class-transformer';
-import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { SkipIfAbsent } from './skip-if-absent.decorator';
 import { IsRoomVideoUrl } from './room-video-url.decorator';
 
 const trim = ({ value }: { value: unknown }) =>
@@ -16,7 +17,7 @@ const trim = ({ value }: { value: unknown }) =>
  */
 export class UpdateRoomDto {
   @Transform(trim)
-  @IsOptional()
+  @SkipIfAbsent()
   @IsString()
   @IsNotEmpty()
   @MaxLength(120)
@@ -25,7 +26,7 @@ export class UpdateRoomDto {
   // '' means "clear the video" - the settings form round-trips
   // `room.videoUrl || ''`, so a save on a room with no video sends ''.
   @Transform(trim)
-  @IsOptional()
+  @SkipIfAbsent()
   @IsRoomVideoUrl()
   videoUrl?: string;
 }

--- a/video-sync-backend/src/rooms/dto/update-room.dto.ts
+++ b/video-sync-backend/src/rooms/dto/update-room.dto.ts
@@ -1,0 +1,31 @@
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsRoomVideoUrl } from './room-video-url.decorator';
+
+const trim = ({ value }: { value: unknown }) =>
+  typeof value === 'string' ? value.trim() : value;
+
+/**
+ * PATCH /rooms/:code body - flows verbatim into Prisma room.update, so
+ * every property here is a column any participant can write.
+ *
+ * Deliberately NO userId: identity does not belong in an update body, and
+ * with whitelist:true the pipe strips it before it can reach room.update
+ * as a creator reassignment. If PATCH ever needs authorization it will be
+ * the requester's identity from auth context, not a body field.
+ */
+export class UpdateRoomDto {
+  @Transform(trim)
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(120)
+  name?: string;
+
+  // '' means "clear the video" - the settings form round-trips
+  // `room.videoUrl || ''`, so a save on a room with no video sends ''.
+  @Transform(trim)
+  @IsOptional()
+  @IsRoomVideoUrl()
+  videoUrl?: string;
+}

--- a/video-sync-backend/src/rooms/rooms.controller.ts
+++ b/video-sync-backend/src/rooms/rooms.controller.ts
@@ -9,24 +9,15 @@ import {
   Delete,
 } from '@nestjs/common';
 import { RoomsService } from './rooms.service';
+import { CreateRoomDto } from './dto/create-room.dto';
+import { UpdateRoomDto } from './dto/update-room.dto';
 
 @Controller('rooms')
 export class RoomsController {
   constructor(private roomsService: RoomsService) {}
 
   @Post()
-  async createRoom(
-    @Body()
-    createRoomDto: {
-      name: string;
-      videoUrl?: string;
-      userId: string;
-      isPublic?: boolean;
-      description?: string;
-      tags?: string[];
-      allowGuestControl?: boolean;
-    },
-  ) {
+  async createRoom(@Body() createRoomDto: CreateRoomDto) {
     return await this.roomsService.createRoom(
       createRoomDto.userId,
       createRoomDto.name,
@@ -57,8 +48,7 @@ export class RoomsController {
   @Patch(':code')
   async updateRoom(
     @Param('code') code: string,
-    @Body()
-    updateRoomDto: { name?: string; videoUrl?: string; userId?: string },
+    @Body() updateRoomDto: UpdateRoomDto,
   ) {
     // Get room by code first to get the ID
     const room = await this.roomsService.getRoomByCode(code);

--- a/video-sync-backend/src/validation.ts
+++ b/video-sync-backend/src/validation.ts
@@ -1,0 +1,21 @@
+import { ValidationPipeOptions } from '@nestjs/common';
+
+/**
+ * The ONE ValidationPipe configuration. main.ts passes this object to
+ * useGlobalPipes; the DTO spec builds its pipe from the SAME object, so the
+ * semantics the spec pins (stripping, transforms) are the semantics
+ * production runs - the config cannot drift from its test.
+ *
+ * whitelist: properties without a decorator are silently stripped. This is
+ * load-bearing for PATCH /rooms/:code - the body flows verbatim into
+ * Prisma room.update, so an unstripped `userId` would let any client
+ * reassign a room's creator (UpdateRoomDto deliberately omits it).
+ *
+ * transform: bodies become DTO class instances, which runs @Transform
+ * (videoUrl/name trim) BEFORE validation - pasted trailing whitespace is
+ * a trim away from valid, not a 400.
+ */
+export const VALIDATION_PIPE_OPTIONS: ValidationPipeOptions = {
+  whitelist: true,
+  transform: true,
+};


### PR DESCRIPTION
Step 2 of the multi-source player program, stacked on #31 (the base will
retarget to `main` when #31 merges). The REST write paths become the first
consumer of the shared classifier.

**`CreateRoomDto` / `UpdateRoomDto`** replace the controller's inline body
types, which validated nothing — `new ValidationPipe()` with an inline type
has metatype `Object` and skips the body entirely. `videoUrl` validates
through `isAcceptableVideoUrl` from `shared/media-source` via a thin
`IsRoomVideoUrl` decorator (the shared module stays dependency-free — the
frontend bundles the same file, so class-validator can't live there). `''`
stays admitted as the no-video sentinel: the settings form round-trips
`room.videoUrl || ''`, so refusing it would 400 every settings save on a
room that has no video yet.

**`UpdateRoomDto` deliberately omits `userId`.** The PATCH body flows
verbatim into Prisma `room.update`, and the previous inline type carried
`userId?` straight through — `whitelist: true` now strips it before it can
reach the update as a creator reassignment. The spec's stripping test is
the guard: its absence fails the build, not a code review.

**One pipe config, shared with the spec.** `validation.ts` exports the
options object `main.ts` hands to `useGlobalPipes`; the DTO spec builds its
pipe from the *same object*, so the semantics the tests pin (whitelist
stripping, trim-before-validate via `transform`) are the semantics
production runs — the config cannot drift from its test. The trim test only
passes if `@Transform` runs before validation, which is what pins
`transform: true`; the `userId`-stripping test pins `whitelist: true`.

Blast radius checked: auth's inline-typed bodies keep metatype `Object` and
are skipped by the pipe, unchanged; every harness room payload (YouTube
watch URLs, `/media/clicktrack.mp4`) passes the new admission, so the
measurement matrix keeps running. 18 new DTO tests; backend suite at 128,
lint and `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validated room creation and update requests.
  * Added support for trimming inputs, validating shared video URLs, and clearing video links.
  * Added validation for room names, descriptions, tags, visibility, and guest controls.
  * Unknown or unauthorized fields are now removed automatically.

* **Bug Fixes**
  * Improved rejection of malformed, hostile, or incomplete room data.
  * Ensured validation behavior is consistent across production and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->