### PR TITLE
feat: player shell + mounts — classification decides what renders

### DIFF
--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.test.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EnhancedVideoPlayer } from './EnhancedVideoPlayer';
+
+// The shell only needs the socket surface; a null socket keeps the sync
+// engine dormant so these tests exercise mount selection, not sync.
+jest.mock('../contexts/SocketContext', () => ({
+  useSocket: () => ({ socket: null, connected: false }),
+}));
+
+// jsdom has no AudioContext; the probe's own behavior is measured by the
+// audio-truth harness, not here.
+jest.mock('../sync/audio-truth', () => ({
+  AudioTruthProbe: class {
+    start() {
+      return Promise.resolve(false);
+    }
+    stop() {}
+  },
+}));
+
+const renderPlayer = (videoUrl: string) =>
+  render(<EnhancedVideoPlayer videoUrl={videoUrl} roomCode="TEST01" isHost />);
+
+test('empty videoUrl shows the no-video card, no controls', () => {
+  renderPlayer('');
+  expect(screen.getByTestId('failure-card')).toHaveTextContent('No video yet');
+  expect(screen.queryByTestId('play-button')).toBeNull();
+});
+
+test('a YouTube watch URL mounts the YouTube player with controls', () => {
+  renderPlayer('https://www.youtube.com/watch?v=aqz-KE-bpKQ');
+  expect(document.getElementById('youtube-player')).toBeInTheDocument();
+  expect(screen.getByTestId('play-button')).toBeInTheDocument();
+  expect(screen.getByTestId('progress-bar')).toBeInTheDocument();
+});
+
+test('a legacy bare video id mounts the YouTube player', () => {
+  renderPlayer('aqz-KE-bpKQ');
+  expect(document.getElementById('youtube-player')).toBeInTheDocument();
+});
+
+test('a same-origin media path mounts an HTML5 video with its URL', () => {
+  renderPlayer('/media/clip.webm');
+  expect(screen.getByTestId('html5-video')).toHaveAttribute(
+    'src',
+    '/media/clip.webm',
+  );
+});
+
+test('a remote file URL is attempted, and its error fails visibly', () => {
+  const url = 'https://cdn.example.com/movie.mp4?sig=abc';
+  renderPlayer(url);
+  const video = screen.getByTestId('html5-video');
+  expect(video).toHaveAttribute('src', url);
+
+  // attempt-and-fail-visibly: the element's error swaps in the card
+  fireEvent(video, new Event('error'));
+  const card = screen.getByTestId('failure-card');
+  expect(card).toHaveTextContent("Couldn't play this video");
+  expect(card).toHaveTextContent(url);
+  expect(screen.queryByTestId('html5-video')).toBeNull();
+});
+
+test('a Vimeo URL shows the not-yet-supported card', () => {
+  renderPlayer('https://vimeo.com/76979871');
+  expect(screen.getByTestId('failure-card')).toHaveTextContent(
+    "Vimeo isn't supported yet",
+  );
+});
+
+test('a hostile scheme never reaches a media element', () => {
+  renderPlayer('javascript:alert(1)');
+  expect(screen.getByTestId('failure-card')).toHaveTextContent(
+    "can't be played",
+  );
+  expect(screen.queryByTestId('html5-video')).toBeNull();
+  expect(document.getElementById('youtube-player')).toBeNull();
+});

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useSocket } from '../contexts/SocketContext';
 import styled from '@emotion/styled';
 import { toast } from 'react-hot-toast';
@@ -7,11 +7,12 @@ import {
   type EngineAdapter,
   type EngineStatus,
 } from '../sync/SyncEngine';
-import { YouTubeAdapter } from '../sync/YouTubeAdapter';
-import { Html5Adapter } from '../sync/Html5Adapter';
-import { AudioTruthProbe } from '../sync/audio-truth';
+import { classifyMediaSource } from '../shared/media-source';
 import { SYNC_EVENTS } from '../shared/sync-protocol';
 import { SyncHud } from './SyncHud';
+import { FailureCard } from './player/FailureCard';
+import { YouTubeMount } from './player/YouTubeMount';
+import { Html5Mount } from './player/Html5Mount';
 
 const PlayerContainer = styled.div`
   width: 100%;
@@ -29,14 +30,6 @@ const VideoWrapper = styled.div`
   padding-bottom: 56.25%;
   background: #000;
   overflow: hidden;
-`;
-
-const PlayerDiv = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
 `;
 
 const GestureChip = styled.button`
@@ -280,6 +273,14 @@ const EMPTY_STATUS: EngineStatus = {
   seeksIssued: 0,
 };
 
+/**
+ * The player SHELL: engine lifecycle, controls, HUD, failure card. Which
+ * player actually renders is decided by classifyMediaSource - the same
+ * classification the backend validates against, so a URL the API admitted
+ * always lands on a mount (or the explicit not-yet-supported card), never
+ * on undefined behavior. Mounts report an EngineAdapter up when drivable;
+ * adapter presence is the shell's readiness.
+ */
 export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
   videoUrl,
   roomCode,
@@ -287,8 +288,8 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
   allowGuestControl = false
 }) => {
   const { socket, connected } = useSocket();
-  const [videoId, setVideoId] = useState<string | null>(null);
   const [isReady, setIsReady] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
   const [syncEnabled, setSyncEnabled] = useState(true);
   const syncEnabledRef = useRef(true);
   const [status, setStatus] = useState<EngineStatus>(EMPTY_STATUS);
@@ -296,33 +297,14 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
     () => new URLSearchParams(window.location.search).get('debug') === '1',
   );
 
-  const playerRef = useRef<YTPlayer | null>(null);
   const engineRef = useRef<SyncEngine | null>(null);
   const adapterRef = useRef<EngineAdapter | null>(null);
-  const mediaRef = useRef<HTMLVideoElement | null>(null);
-  const probeRef = useRef<AudioTruthProbe | null>(null);
-  // a same-origin media file drives the HTML5 path: the sync core is
-  // player-agnostic, and only a same-origin element can be audio-tapped
-  const isDirectMedia = /^\/?media\/.+\.(mp4|webm|ogg)$/i.test(videoUrl ?? '');
   const canControl = isHost || allowGuestControl;
 
-  // Extract YouTube video ID
-  const getYouTubeId = useCallback((url: string): string | null => {
-    if (!url) return null;
+  const source = useMemo(() => classifyMediaSource(videoUrl), [videoUrl]);
 
-    const patterns = [
-      /(?:https?:\/\/)?(?:www\.)?youtube\.com\/watch\?v=([a-zA-Z0-9_-]{11})/,
-      /(?:https?:\/\/)?(?:www\.)?youtu\.be\/([a-zA-Z0-9_-]{11})/,
-      /(?:https?:\/\/)?(?:www\.)?youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/,
-      /^([a-zA-Z0-9_-]{11})$/
-    ];
-
-    for (const pattern of patterns) {
-      const match = url.match(pattern);
-      if (match?.[1]) return match[1];
-    }
-    return null;
-  }, []);
+  // a failure belongs to one attempted source; the next video starts clean
+  useEffect(() => setFailure(null), [videoUrl]);
 
   // Engine lifecycle: starts with the socket (before the player is ready, so
   // no room-joined timeline is ever missed) and adopts the adapter later.
@@ -353,8 +335,8 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
       unsubscribe();
       engine.dispose();
       engineRef.current = null;
-      // adapterRef is owned by the player effect below - clearing it here
-      // orphaned a live adapter (and its poll timer) on every reconnect
+      // adapterRef is owned by the active mount - clearing it here orphaned
+      // a live adapter (and its poll timer) on every reconnect
     };
   }, [socket, roomCode]);
 
@@ -367,90 +349,16 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
-  // HTML5 bootstrap (audio-truth + player-agnostic proof)
-  useEffect(() => {
-    if (!isDirectMedia) return;
-    const el = mediaRef.current;
-    if (!el) return;
-    const adapter = new Html5Adapter(el);
+  // Mount callbacks: stable so mounts don't remount on shell re-renders
+  const handleAdapter = useCallback((adapter: EngineAdapter | null) => {
     adapterRef.current = adapter;
-    engineRef.current?.attachAdapter(adapter);
-    setIsReady(true);
-    const probe = new AudioTruthProbe(el);
-    probeRef.current = probe;
-    void probe.start();
-    return () => {
-      probe.stop();
-      probeRef.current = null;
-      adapterRef.current = null;
-      setIsReady(false);
-    };
-  }, [isDirectMedia, videoUrl]);
+    if (adapter) engineRef.current?.attachAdapter(adapter);
+    setIsReady(adapter !== null);
+  }, []);
 
-  // Player bootstrap
-  useEffect(() => {
-    if (isDirectMedia) return;
-    const id = getYouTubeId(videoUrl);
-    setVideoId(id);
-    if (!id) return;
-
-    let cancelled = false;
-    const initializePlayer = (vid: string) => {
-      if (cancelled) return;
-      playerRef.current = new window.YT.Player('youtube-player', {
-        videoId: vid,
-        playerVars: {
-          autoplay: 0,
-          controls: 0,
-          disablekb: 1,
-          modestbranding: 1,
-          rel: 0,
-          iv_load_policy: 3,
-          enablejsapi: 1,
-          origin: window.location.origin,
-          playsinline: 1,
-        },
-        events: {
-          onReady: (event) => {
-            playerRef.current = event.target;
-            setIsReady(true);
-            const adapter = new YouTubeAdapter(event.target);
-            adapterRef.current = adapter;
-            engineRef.current?.attachAdapter(adapter);
-          },
-        },
-      });
-    };
-
-    const API_SRC = 'https://www.youtube.com/iframe_api';
-    const onApiReady = () => initializePlayer(id);
-    if (window.YT?.Player) {
-      initializePlayer(id);
-    } else {
-      // the API script is global: appending it twice re-runs it and races
-      if (!document.querySelector(`script[src="${API_SRC}"]`)) {
-        const tag = document.createElement('script');
-        tag.src = API_SRC;
-        document.head.appendChild(tag);
-      }
-      window.onYouTubeIframeAPIReady = onApiReady;
-    }
-
-    return () => {
-      // a late API load would otherwise build an orphan player (and an
-      // undisposed adapter poll timer) after this effect is gone
-      cancelled = true;
-      if (window.onYouTubeIframeAPIReady === onApiReady) {
-        window.onYouTubeIframeAPIReady = undefined;
-      }
-      adapterRef.current?.dispose();
-      adapterRef.current = null;
-      playerRef.current?.destroy?.();
-      setIsReady(false);
-    };
-    // intentional: the player re-initializes only when the video changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [videoUrl]);
+  const handleFailure = useCallback((reason: string) => {
+    setFailure(reason);
+  }, []);
 
   // ---- gesture-only intents (wait-for-broadcast: the player is never
   // touched here; everyone converges from the sync:timeline broadcast) ----
@@ -502,24 +410,85 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
     return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
 
-  if (isDirectMedia) {
-    return (
-      <PlayerContainer>
-        <VideoWrapper>
-          <video
-            ref={mediaRef}
-            src={videoUrl}
-            playsInline
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: '100%',
-              height: '100%',
-            }}
+  // What fills the 16:9 area. null mount = nothing playable = no controls.
+  let mount: React.ReactNode = null;
+  let card: React.ReactNode = null;
+  if (failure) {
+    card = (
+      <FailureCard
+        title="Couldn't play this video"
+        detail={failure}
+        url={videoUrl}
+      />
+    );
+  } else {
+    switch (source.kind) {
+      case 'youtube':
+        // key: a new video id must tear the old player down, not mutate it
+        mount = (
+          <YouTubeMount
+            key={source.videoId}
+            videoId={source.videoId}
+            onAdapter={handleAdapter}
+            onFailure={handleFailure}
           />
-          {showHud && <SyncHud status={status} />}
-        </VideoWrapper>
+        );
+        break;
+      case 'hls': // plain <video> until hls.js lands: Safari plays it
+      case 'file': // natively, everywhere else fails into the card
+        mount = (
+          <Html5Mount
+            key={source.url}
+            url={source.url}
+            onAdapter={handleAdapter}
+            onFailure={handleFailure}
+          />
+        );
+        break;
+      case 'vimeo':
+        card = (
+          <FailureCard
+            title="Vimeo isn't supported yet"
+            detail="Vimeo playback is on the roadmap; pick a YouTube or direct video URL for now."
+            url={videoUrl}
+          />
+        );
+        break;
+      case 'none':
+        card =
+          source.reason === 'empty' ? (
+            <FailureCard
+              title="No video yet"
+              detail="Add a video URL in the room settings to start watching together."
+            />
+          ) : (
+            <FailureCard
+              title="This video URL can't be played"
+              detail="It isn't an http(s) video link a player could fetch."
+              url={videoUrl}
+            />
+          );
+        break;
+    }
+  }
+
+  const shownTime = status.roomPlaying
+    ? status.projectedS
+    : status.timeline?.mediaTime ?? 0;
+
+  return (
+    <PlayerContainer>
+      <VideoWrapper>
+        {mount ?? card}
+        {mount && status.needsGesture && (
+          <GestureChip onClick={() => engineRef.current?.resumeFromGesture()}>
+            ▶ Click to join playback
+          </GestureChip>
+        )}
+        {showHud && <SyncHud status={status} />}
+      </VideoWrapper>
+
+      {mount && (
         <Controls>
           <ControlRow>
             <PlayButton
@@ -531,6 +500,7 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
               {status.roomPlaying ? '⏸' : '▶'}
               {status.roomPlaying ? 'Pause' : 'Play'}
             </PlayButton>
+
             <ProgressContainer>
               <ProgressBar
                 data-testid="progress-bar"
@@ -540,109 +510,41 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
                 <ProgressFill
                   progress={
                     status.durationS > 0
-                      ? Math.min(
-                          100,
-                          ((status.roomPlaying
-                            ? status.projectedS
-                            : (status.timeline?.mediaTime ?? 0)) /
-                            status.durationS) *
-                            100,
-                        )
+                      ? Math.min(100, (shownTime / status.durationS) * 100)
                       : 0
                   }
                 />
               </ProgressBar>
             </ProgressContainer>
+
+            <TimeDisplay>
+              {formatTime(shownTime)} / {formatTime(status.durationS)}
+            </TimeDisplay>
           </ControlRow>
+
+          <StatusRow>
+            <StatusGroup>
+              <StatusItem type={connected ? 'success' : 'error'}>
+                <StatusDot color={connected ? '#6366f1' : '#f87171'} />
+                {connected ? 'Connected' : 'Disconnected'}
+              </StatusItem>
+
+              <CollaborativeIndicator enabled={allowGuestControl}>
+                {allowGuestControl ? '👥 Collaborative' : '👑 Host Only'}
+              </CollaborativeIndicator>
+            </StatusGroup>
+
+            <StatusGroup>
+              <StatusItem type="info">
+                {Number.isFinite(status.rttMs) ? `${Math.round(status.rttMs)}ms` : '—'}
+              </StatusItem>
+              <ControlButton active={syncEnabled} onClick={handleSyncToggle}>
+                🔗 Sync {syncEnabled ? 'ON' : 'OFF'}
+              </ControlButton>
+            </StatusGroup>
+          </StatusRow>
         </Controls>
-      </PlayerContainer>
-    );
-  }
-
-  if (!videoId) {
-    return (
-      <PlayerContainer>
-        <div style={{ padding: '60px', textAlign: 'center', color: '#2d3748' }}>
-          <h3>No Video Selected</h3>
-          <p style={{ color: '#718096' }}>
-            Please provide a valid YouTube URL
-          </p>
-        </div>
-      </PlayerContainer>
-    );
-  }
-
-  const shownTime = status.roomPlaying
-    ? status.projectedS
-    : status.timeline?.mediaTime ?? 0;
-
-  return (
-    <PlayerContainer>
-      <VideoWrapper>
-        <PlayerDiv id="youtube-player" />
-        {status.needsGesture && (
-          <GestureChip onClick={() => engineRef.current?.resumeFromGesture()}>
-            ▶ Click to join playback
-          </GestureChip>
-        )}
-        {showHud && <SyncHud status={status} />}
-      </VideoWrapper>
-
-      <Controls>
-        <ControlRow>
-          <PlayButton
-            data-testid="play-button"
-            onClick={handlePlayPause}
-            canControl={canControl}
-            disabled={!isReady}
-          >
-            {status.roomPlaying ? '⏸' : '▶'}
-            {status.roomPlaying ? 'Pause' : 'Play'}
-          </PlayButton>
-
-          <ProgressContainer>
-            <ProgressBar
-              data-testid="progress-bar"
-              onClick={handleProgressClick}
-              canControl={canControl}
-            >
-              <ProgressFill
-                progress={
-                  status.durationS > 0
-                    ? Math.min(100, (shownTime / status.durationS) * 100)
-                    : 0
-                }
-              />
-            </ProgressBar>
-          </ProgressContainer>
-
-          <TimeDisplay>
-            {formatTime(shownTime)} / {formatTime(status.durationS)}
-          </TimeDisplay>
-        </ControlRow>
-
-        <StatusRow>
-          <StatusGroup>
-            <StatusItem type={connected ? 'success' : 'error'}>
-              <StatusDot color={connected ? '#6366f1' : '#f87171'} />
-              {connected ? 'Connected' : 'Disconnected'}
-            </StatusItem>
-
-            <CollaborativeIndicator enabled={allowGuestControl}>
-              {allowGuestControl ? '👥 Collaborative' : '👑 Host Only'}
-            </CollaborativeIndicator>
-          </StatusGroup>
-
-          <StatusGroup>
-            <StatusItem type="info">
-              {Number.isFinite(status.rttMs) ? `${Math.round(status.rttMs)}ms` : '—'}
-            </StatusItem>
-            <ControlButton active={syncEnabled} onClick={handleSyncToggle}>
-              🔗 Sync {syncEnabled ? 'ON' : 'OFF'}
-            </ControlButton>
-          </StatusGroup>
-        </StatusRow>
-      </Controls>
+      )}
     </PlayerContainer>
   );
 };

--- a/video-sync-frontend/src/components/player/FailureCard.tsx
+++ b/video-sync-frontend/src/components/player/FailureCard.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+const Card = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 24px;
+  text-align: center;
+  color: #e2e8f0;
+`;
+
+const Title = styled.h3`
+  margin: 0;
+  font-size: 18px;
+  color: #f8fafc;
+`;
+
+const Detail = styled.p`
+  margin: 0;
+  font-size: 14px;
+  color: #a0aec0;
+  max-width: 480px;
+`;
+
+const Url = styled.code`
+  margin-top: 8px;
+  font-size: 12px;
+  color: #718096;
+  word-break: break-all;
+  max-width: 90%;
+`;
+
+/**
+ * The visible end of attempt-and-fail-visibly: validation admits anything a
+ * player could conceivably fetch (see shared/media-source.ts), so when the
+ * attempt dies, THIS is what owns the outcome - the URL is shown so "why is
+ * my room black" is answerable from the screen.
+ */
+export const FailureCard: React.FC<{
+  title: string;
+  detail?: string;
+  url?: string;
+}> = ({ title, detail, url }) => (
+  <Card data-testid="failure-card">
+    <Title>{title}</Title>
+    {detail && <Detail>{detail}</Detail>}
+    {url && <Url>{url}</Url>}
+  </Card>
+);

--- a/video-sync-frontend/src/components/player/FailureCard.tsx
+++ b/video-sync-frontend/src/components/player/FailureCard.tsx
@@ -46,7 +46,9 @@ export const FailureCard: React.FC<{
   detail?: string;
   url?: string;
 }> = ({ title, detail, url }) => (
-  <Card data-testid="failure-card">
+  // role="alert": the card swaps in dynamically after a playback failure,
+  // and without a live region a screen reader never hears about it
+  <Card data-testid="failure-card" role="alert">
     <Title>{title}</Title>
     {detail && <Detail>{detail}</Detail>}
     {url && <Url>{url}</Url>}

--- a/video-sync-frontend/src/components/player/Html5Mount.tsx
+++ b/video-sync-frontend/src/components/player/Html5Mount.tsx
@@ -69,6 +69,10 @@ export const Html5Mount: React.FC<{ url: string } & MountProps> = ({
       );
     };
     el.addEventListener('error', onError);
+    // React assigns src during commit; this listener attaches in the
+    // passive effect. A failure in that gap fires no further event, so
+    // read the already-latched error once or the card never appears.
+    if (el.error !== null) onError();
 
     return () => {
       el.removeEventListener('error', onError);

--- a/video-sync-frontend/src/components/player/Html5Mount.tsx
+++ b/video-sync-frontend/src/components/player/Html5Mount.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useRef } from 'react';
+import styled from '@emotion/styled';
+import { Html5Adapter } from '../../sync/Html5Adapter';
+import { AudioTruthProbe } from '../../sync/audio-truth';
+import { MountProps } from './mount-props';
+
+const Media = styled.video`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+// https://developer.mozilla.org/docs/Web/API/MediaError/code
+const MEDIA_ERRORS: Record<number, string> = {
+  1: 'Loading was aborted.',
+  2: 'A network error interrupted the download.',
+  3: 'The video downloaded but could not be decoded.',
+  4: 'The URL could not be loaded - not a playable video, or unreachable.',
+};
+
+/**
+ * Only a same-origin element can be tapped by the Web Audio API - a
+ * cross-origin tap is CORS-tainted and reads silence, which would make the
+ * audio-truth ground truth quietly lie. So the probe runs exactly when the
+ * tap can be real.
+ */
+function isSameOrigin(url: string): boolean {
+  try {
+    return new URL(url, window.location.href).origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Mounts a plain HTMLMediaElement for classified file (and, until hls.js
+ * lands, hls) sources. This is the attempt half of attempt-and-fail-visibly:
+ * validation admitted the URL because it MIGHT be a video; the element's
+ * error event is where "it wasn't" surfaces, routed to the shell's failure
+ * card. The shell remounts this component (key=url) when the video changes.
+ */
+export const Html5Mount: React.FC<{ url: string } & MountProps> = ({
+  url,
+  onAdapter,
+  onFailure,
+}) => {
+  const mediaRef = useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() => {
+    const el = mediaRef.current;
+    if (!el) return;
+
+    const adapter = new Html5Adapter(el);
+    onAdapter(adapter);
+
+    let probe: AudioTruthProbe | null = null;
+    if (isSameOrigin(url)) {
+      probe = new AudioTruthProbe(el);
+      void probe.start();
+    }
+
+    const onError = () => {
+      const code = el.error?.code;
+      onFailure(
+        (code !== undefined && MEDIA_ERRORS[code]) ||
+          'The video element reported an unknown error.',
+      );
+    };
+    el.addEventListener('error', onError);
+
+    return () => {
+      el.removeEventListener('error', onError);
+      probe?.stop();
+      adapter.dispose();
+      onAdapter(null);
+    };
+  }, [url, onAdapter, onFailure]);
+
+  return <Media ref={mediaRef} src={url} playsInline data-testid="html5-video" />;
+};

--- a/video-sync-frontend/src/components/player/YouTubeMount.tsx
+++ b/video-sync-frontend/src/components/player/YouTubeMount.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect } from 'react';
+import styled from '@emotion/styled';
+import { YouTubeAdapter } from '../../sync/YouTubeAdapter';
+import type { EngineAdapter } from '../../sync/SyncEngine';
+import { MountProps } from './mount-props';
+
+const PlayerDiv = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+const API_SRC = 'https://www.youtube.com/iframe_api';
+
+// https://developers.google.com/youtube/iframe_api_reference#onError
+const YT_ERRORS: Record<number, string> = {
+  2: 'YouTube rejected the video id.',
+  5: "YouTube's HTML5 player failed.",
+  100: 'This video was not found (removed or private).',
+  101: 'The owner disabled embedded playback for this video.',
+  150: 'The owner disabled embedded playback for this video.',
+};
+
+/**
+ * Mounts the YouTube IFrame player for a classified youtube source. The
+ * shell remounts this component (key=videoId) when the video changes, so
+ * one effect owns the full create/destroy story.
+ */
+export const YouTubeMount: React.FC<{ videoId: string } & MountProps> = ({
+  videoId,
+  onAdapter,
+  onFailure,
+}) => {
+  useEffect(() => {
+    let cancelled = false;
+    let player: YTPlayer | null = null;
+    let adapter: EngineAdapter | null = null;
+
+    const initializePlayer = () => {
+      if (cancelled) return;
+      player = new window.YT.Player('youtube-player', {
+        videoId,
+        playerVars: {
+          autoplay: 0,
+          controls: 0,
+          disablekb: 1,
+          modestbranding: 1,
+          rel: 0,
+          iv_load_policy: 3,
+          enablejsapi: 1,
+          origin: window.location.origin,
+          playsinline: 1,
+        },
+        events: {
+          onReady: (event) => {
+            // onReady arrives async after destroy() on fast source
+            // changes; building the adapter then would leak its 20Hz
+            // poll timer with no dispose left to run
+            if (cancelled) return;
+            player = event.target;
+            adapter = new YouTubeAdapter(event.target);
+            onAdapter(adapter);
+          },
+          onError: (event) => {
+            if (cancelled) return;
+            onFailure(
+              YT_ERRORS[event.data] ??
+                `YouTube player error ${event.data}.`,
+            );
+          },
+        },
+      });
+    };
+
+    const onApiReady = () => initializePlayer();
+    if (window.YT?.Player) {
+      initializePlayer();
+    } else {
+      // the API script is global: appending it twice re-runs it and races
+      if (!document.querySelector(`script[src="${API_SRC}"]`)) {
+        const tag = document.createElement('script');
+        tag.src = API_SRC;
+        document.head.appendChild(tag);
+      }
+      window.onYouTubeIframeAPIReady = onApiReady;
+    }
+
+    return () => {
+      // a late API load would otherwise build an orphan player (and an
+      // undisposed adapter poll timer) after this effect is gone
+      cancelled = true;
+      if (window.onYouTubeIframeAPIReady === onApiReady) {
+        window.onYouTubeIframeAPIReady = undefined;
+      }
+      adapter?.dispose();
+      onAdapter(null);
+      player?.destroy?.();
+    };
+  }, [videoId, onAdapter, onFailure]);
+
+  return <PlayerDiv id="youtube-player" />;
+};

--- a/video-sync-frontend/src/components/player/mount-props.ts
+++ b/video-sync-frontend/src/components/player/mount-props.ts
@@ -1,0 +1,14 @@
+import type { EngineAdapter } from '../../sync/SyncEngine';
+
+/**
+ * The contract between the player shell and a mount. A mount owns one
+ * concrete player (YouTube iframe, HTMLMediaElement, ...) and reports two
+ * things up: the EngineAdapter when its player becomes drivable (null again
+ * on teardown - adapter presence IS readiness), and a human-readable reason
+ * when playback dies. The shell owns everything else: engine lifecycle,
+ * controls, HUD, and the failure card that a reported failure swaps in.
+ */
+export interface MountProps {
+  onAdapter: (adapter: EngineAdapter | null) => void;
+  onFailure: (reason: string) => void;
+}


### PR DESCRIPTION
Step 3 of the multi-source player program, stacked on #31 (parallel to #32 —
this one is frontend-only; the base retargets to `main` when #31 merges).
The player becomes the second consumer of the shared classifier.

**Shell + mounts.** `EnhancedVideoPlayer` is now a shell: engine lifecycle,
controls, HUD, and the failure card. Which player renders is decided by
`classifyMediaSource` — the same classification the backend admits against,
so a URL the API accepted always lands on a mount or an explicit card,
never on undefined behavior. `YouTubeMount` and `Html5Mount` each own one
player's full create/destroy story (keyed by video id/URL, so a source
change is a teardown, not a mutation) and report an `EngineAdapter` up when
drivable — adapter presence is the shell's readiness. The two duplicated
control panels collapse into one, and direct-media rooms gain the full
status row they were missing.

**What falls out of classification for free:**

- Remote `mp4`/`webm`/`ogg` URLs actually mount — the old player showed
  "No Video Selected" for anything non-YouTube, non-`/media/`.
- All YouTube URL shapes work (`shorts`, `live`, `music.`, `-nocookie`,
  playlist-bearing watch URLs), replacing three ad-hoc regexes.
- `hls` sources reach the plain `<video>`: Safari plays them natively
  today; everywhere else fails visibly into the card until Step 4's
  hls.js. Vimeo gets an honest not-yet-supported card until Step 5.

**Probe gating.** The audio-truth probe now gates on *same-origin* instead
of the `/media/` regex. A cross-origin Web Audio tap is CORS-tainted and
reads silence — the probe would quietly lie as ground truth — so it runs
exactly when the tap can be real. The `/media/clicktrack.mp4` audio-truth
runs are unaffected.

**Failure card owns attempt-and-fail-visibly.** Validation admits anything
a player could conceivably fetch; the card is where "it wasn't" surfaces.
Media element errors map their `MediaError` code to a human reason, and
YouTube `onError` — previously silently ignored, a black frame with no
explanation — maps embed-restriction/not-found codes. The failing URL is
shown on screen, so "why is my room black" is answerable without devtools.

Harness contract preserved: `play-button`, `progress-bar`, `sync-hud`
testids and `#youtube-player` unchanged. 8 jsdom tests cover mount
selection, the error→card swap, and that a hostile scheme never reaches a
media element. `tsc --noEmit` and the CI-strict CRA build both green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved video playback for YouTube and same-origin HTML5 media.
  * Added clearer playback error messages for unsupported, invalid, unavailable, or failed videos.
  * Added full-screen player presentation and more reliable cleanup when switching videos.

* **Bug Fixes**
  * Prevented stale player callbacks and controls from appearing after video changes or playback failures.
  * Improved handling of invalid URLs and hostile or unsupported media sources.

* **Tests**
  * Added coverage for YouTube URLs and IDs, HTML5 media, failures, empty URLs, and unsupported sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->