### PR TITLE
feat: HLS playback via dynamically imported hls.js

### DIFF
--- a/video-sync-frontend/package-lock.json
+++ b/video-sync-frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "axios": "^1.10.0",
+        "hls.js": "^1.6.17",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.60.0",
@@ -35,6 +36,9 @@
       "devDependencies": {
         "@types/react-router-dom": "^5.3.3",
         "@types/simple-peer": "^9.11.8"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -9471,9 +9475,9 @@
       }
     },
     "node_modules/hls.js": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.6.tgz",
-      "integrity": "sha512-S4uTCwTHOtImW+/jxMjzG7udbHy5z682YQRbm/4f7VXuVNEoGBRjPJnD3Fxrufomdhzdtv24KnxRhPMXSvL6Fw==",
+      "version": "1.6.17",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.17.tgz",
+      "integrity": "sha512-NUplVGVuc1hSPwdB/9/cbRkUmLrYi75/hqiXKdA+l300pJNxDu96R7jRb2imDzWJqIUF4I5ThmAdp9GvOCXsuQ==",
       "license": "Apache-2.0"
     },
     "node_modules/hoist-non-react-statics": {

--- a/video-sync-frontend/package.json
+++ b/video-sync-frontend/package.json
@@ -18,6 +18,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "axios": "^1.10.0",
+    "hls.js": "^1.6.17",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.60.0",

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -434,12 +434,13 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
           />
         );
         break;
-      case 'hls': // plain <video> until hls.js lands: Safari plays it
-      case 'file': // natively, everywhere else fails into the card
+      case 'hls':
+      case 'file':
         mount = (
           <Html5Mount
             key={source.url}
             url={source.url}
+            hls={source.kind === 'hls'}
             onAdapter={handleAdapter}
             onFailure={handleFailure}
           />

--- a/video-sync-frontend/src/components/player/Html5Mount.test.tsx
+++ b/video-sync-frontend/src/components/player/Html5Mount.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { Html5Mount } from './Html5Mount';
+
+jest.mock('../../sync/audio-truth', () => ({
+  AudioTruthProbe: class {
+    start() {
+      return Promise.resolve(false);
+    }
+    stop() {}
+  },
+}));
+
+// Captures every constructed instance so tests can assert attach/teardown.
+const mockHlsState: {
+  supported: boolean;
+  instances: Array<{
+    loadSource: jest.Mock;
+    attachMedia: jest.Mock;
+    destroy: jest.Mock;
+  }>;
+} = { supported: true, instances: [] };
+
+jest.mock('hls.js', () => {
+  class FakeHls {
+    static isSupported = () => mockHlsState.supported;
+    static Events = { ERROR: 'hlsError' };
+    static ErrorTypes = { NETWORK_ERROR: 'networkError', MEDIA_ERROR: 'mediaError' };
+    loadSource = jest.fn();
+    attachMedia = jest.fn();
+    on = jest.fn();
+    startLoad = jest.fn();
+    recoverMediaError = jest.fn();
+    destroy = jest.fn();
+    constructor() {
+      mockHlsState.instances.push(this);
+    }
+  }
+  return { __esModule: true, default: FakeHls };
+});
+
+const MANIFEST = 'https://cdn.example.com/vod/master.m3u8';
+
+beforeEach(() => {
+  mockHlsState.supported = true;
+  mockHlsState.instances.length = 0;
+  jest.restoreAllMocks();
+});
+
+test('a file source sets src directly and never touches hls.js', () => {
+  const { getByTestId } = render(
+    <Html5Mount
+      url="https://cdn.example.com/movie.mp4"
+      onAdapter={jest.fn()}
+      onFailure={jest.fn()}
+    />,
+  );
+  expect(getByTestId('html5-video')).toHaveAttribute(
+    'src',
+    'https://cdn.example.com/movie.mp4',
+  );
+  expect(mockHlsState.instances).toHaveLength(0);
+});
+
+test('an hls source drives Media Source Extensions via hls.js', async () => {
+  const { getByTestId, unmount } = render(
+    <Html5Mount url={MANIFEST} hls onAdapter={jest.fn()} onFailure={jest.fn()} />,
+  );
+  await waitFor(() => expect(mockHlsState.instances).toHaveLength(1));
+  const h = mockHlsState.instances[0];
+  expect(h.loadSource).toHaveBeenCalledWith(MANIFEST);
+  expect(h.attachMedia).toHaveBeenCalledWith(getByTestId('html5-video'));
+
+  // teardown must destroy the instance or its workers/buffers leak
+  unmount();
+  expect(h.destroy).toHaveBeenCalled();
+});
+
+test('native HLS (Safari) gets the manifest as a plain src', async () => {
+  jest
+    .spyOn(window.HTMLMediaElement.prototype, 'canPlayType')
+    .mockReturnValue('maybe');
+  const { getByTestId } = render(
+    <Html5Mount url={MANIFEST} hls onAdapter={jest.fn()} onFailure={jest.fn()} />,
+  );
+  expect(getByTestId('html5-video')).toHaveAttribute('src', MANIFEST);
+  // give the (never-taken) dynamic-import branch a tick to prove itself idle
+  await new Promise((r) => setTimeout(r, 0));
+  expect(mockHlsState.instances).toHaveLength(0);
+});
+
+test('no native HLS and no MSE fails visibly', async () => {
+  mockHlsState.supported = false;
+  const onFailure = jest.fn();
+  render(<Html5Mount url={MANIFEST} hls onAdapter={jest.fn()} onFailure={onFailure} />);
+  await waitFor(() =>
+    expect(onFailure).toHaveBeenCalledWith(
+      'This browser supports neither native HLS nor Media Source Extensions.',
+    ),
+  );
+  expect(mockHlsState.instances).toHaveLength(0);
+});

--- a/video-sync-frontend/src/components/player/Html5Mount.tsx
+++ b/video-sync-frontend/src/components/player/Html5Mount.tsx
@@ -35,17 +35,21 @@ function isSameOrigin(url: string): boolean {
 }
 
 /**
- * Mounts a plain HTMLMediaElement for classified file (and, until hls.js
- * lands, hls) sources. This is the attempt half of attempt-and-fail-visibly:
- * validation admitted the URL because it MIGHT be a video; the element's
- * error event is where "it wasn't" surfaces, routed to the shell's failure
- * card. The shell remounts this component (key=url) when the video changes.
+ * Mounts a plain HTMLMediaElement for classified file and hls sources.
+ * This is the attempt half of attempt-and-fail-visibly: validation
+ * admitted the URL because it MIGHT be a video; the element's error event
+ * is where "it wasn't" surfaces, routed to the shell's failure card. The
+ * shell remounts this component (key=url) when the video changes.
+ *
+ * HLS: Safari gets the manifest as a native src (canPlayType says so);
+ * everywhere else hls.js drives Media Source Extensions. hls.js is a
+ * dynamic import so the ~200KB library is a lazy chunk only HLS rooms
+ * fetch - sync itself never needs it, since the adapter only reads the
+ * media element and the element doesn't care who feeds it.
  */
-export const Html5Mount: React.FC<{ url: string } & MountProps> = ({
-  url,
-  onAdapter,
-  onFailure,
-}) => {
+export const Html5Mount: React.FC<
+  { url: string; hls?: boolean } & MountProps
+> = ({ url, hls = false, onAdapter, onFailure }) => {
   const mediaRef = useRef<HTMLVideoElement | null>(null);
 
   useEffect(() => {
@@ -74,13 +78,67 @@ export const Html5Mount: React.FC<{ url: string } & MountProps> = ({
     // read the already-latched error once or the card never appears.
     if (el.error !== null) onError();
 
+    let cancelled = false;
+    let hlsInstance: { destroy(): void } | null = null;
+    if (hls) {
+      if (el.canPlayType('application/vnd.apple.mpegurl') !== '') {
+        el.src = url; // Safari and iOS: the manifest IS a native source
+      } else {
+        void import('hls.js').then(({ default: Hls }) => {
+          // the chunk can land after a fast source change tore us down;
+          // attaching then would feed a dead element and leak the instance
+          if (cancelled) return;
+          if (!Hls.isSupported()) {
+            onFailure(
+              'This browser supports neither native HLS nor Media Source Extensions.',
+            );
+            return;
+          }
+          const h = new Hls();
+          hlsInstance = h;
+          // one recovery attempt per error type (the canonical hls.js
+          // pattern); a second fatal of the same type fails visibly
+          // instead of looping a broken stream forever
+          let retriedNetwork = false;
+          let retriedMedia = false;
+          h.on(Hls.Events.ERROR, (_event, data) => {
+            if (!data.fatal || cancelled) return;
+            if (data.type === Hls.ErrorTypes.NETWORK_ERROR && !retriedNetwork) {
+              retriedNetwork = true;
+              h.startLoad();
+              return;
+            }
+            if (data.type === Hls.ErrorTypes.MEDIA_ERROR && !retriedMedia) {
+              retriedMedia = true;
+              h.recoverMediaError();
+              return;
+            }
+            h.destroy();
+            hlsInstance = null;
+            onFailure(`HLS playback failed (${data.details}).`);
+          });
+          h.loadSource(url);
+          h.attachMedia(el);
+        });
+      }
+    }
+
     return () => {
+      cancelled = true;
       el.removeEventListener('error', onError);
+      hlsInstance?.destroy();
       probe?.stop();
       adapter.dispose();
       onAdapter(null);
     };
-  }, [url, onAdapter, onFailure]);
+  }, [url, hls, onAdapter, onFailure]);
 
-  return <Media ref={mediaRef} src={url} playsInline data-testid="html5-video" />;
+  return (
+    <Media
+      ref={mediaRef}
+      src={hls ? undefined : url}
+      playsInline
+      data-testid="html5-video"
+    />
+  );
 };


### PR DESCRIPTION
Step 4 of the multi-source player program, stacked on #33. `hls` sources
classified in Step 1 and routed to `Html5Mount` in Step 3 now actually play
everywhere, not just Safari.

**Path selection.** `canPlayType('application/vnd.apple.mpegurl')` decides:
Safari and iOS get the manifest as a plain native `src`; everywhere else
hls.js drives Media Source Extensions. Neither available → the failure card
says so explicitly.

**The library is a lazy chunk.** hls.js arrives via dynamic `import()`, so
CRA splits it into a 160KB-gzipped chunk that only HLS rooms ever fetch —
the main bundle grew 399 bytes. Sync itself needed zero changes: the
adapter reads the media element, and the element doesn't care whether a
file URL or a MediaSource feeds it. A `cancelled` guard covers the chunk
landing after a fast source change already tore the mount down.

**Bounded recovery, then visible failure.** Fatal HLS errors get the
canonical one-recovery-per-type attempt (`startLoad()` for network,
`recoverMediaError()` for media); a second fatal of the same type destroys
the instance and fails into the card with the error detail rather than
looping a broken stream forever.

4 new jsdom tests: file sources never touch hls.js, MSE attach + teardown
destroy, the native-Safari path, and the no-support failure. Frontend suite
at 12, `tsc` and CI-strict build green.