### PR TITLE
feat: Vimeo playback — VimeoAdapter models the promise-only SDK locally

### DIFF
--- a/video-sync-frontend/package-lock.json
+++ b/video-sync-frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@types/node": "^16.18.126",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@vimeo/player": "^2.30.4",
         "axios": "^1.10.0",
         "hls.js": "^1.6.17",
         "react": "^19.1.0",
@@ -35,7 +36,8 @@
       },
       "devDependencies": {
         "@types/react-router-dom": "^5.3.3",
-        "@types/simple-peer": "^9.11.8"
+        "@types/simple-peer": "^9.11.8",
+        "@types/vimeo__player": "^2.18.3"
       },
       "engines": {
         "node": ">=20"
@@ -4245,6 +4247,13 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
+    "node_modules/@types/vimeo__player": {
+      "version": "2.18.3",
+      "resolved": "https://registry.npmjs.org/@types/vimeo__player/-/vimeo__player-2.18.3.tgz",
+      "integrity": "sha512-IzSzb6doT4I4uAnBHa+mBCiNtK7iAllEJjtpkX0sKY6/s1Vi+aX1134IAiPgiyFlMvFab/oZQpSeccK4r0/T2A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -4511,9 +4520,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@vimeo/player": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/@vimeo/player/-/player-2.29.0.tgz",
-      "integrity": "sha512-9JjvjeqUndb9otCCFd0/+2ESsLk7VkDE6sxOBy9iy2ukezuQbplVRi+g9g59yAurKofbmTi/KcKxBGO/22zWRw==",
+      "version": "2.30.4",
+      "resolved": "https://registry.npmjs.org/@vimeo/player/-/player-2.30.4.tgz",
+      "integrity": "sha512-M8m1UAhJSb+KCWuXDLWHViwj+3YY/0ogwFquRfMHs9e9LYjXT9iB7n+sOCKwUusbiXuU2HKmXx+FEGHtYZfUSg==",
       "license": "MIT",
       "dependencies": {
         "native-promise-only": "0.8.1",
@@ -17647,6 +17656,16 @@
       "license": "MIT",
       "dependencies": {
         "@vimeo/player": "2.29.0"
+      }
+    },
+    "node_modules/vimeo-video-element/node_modules/@vimeo/player": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@vimeo/player/-/player-2.29.0.tgz",
+      "integrity": "sha512-9JjvjeqUndb9otCCFd0/+2ESsLk7VkDE6sxOBy9iy2ukezuQbplVRi+g9g59yAurKofbmTi/KcKxBGO/22zWRw==",
+      "license": "MIT",
+      "dependencies": {
+        "native-promise-only": "0.8.1",
+        "weakmap-polyfill": "2.0.4"
       }
     },
     "node_modules/w3c-hr-time": {

--- a/video-sync-frontend/package.json
+++ b/video-sync-frontend/package.json
@@ -17,6 +17,7 @@
     "@types/node": "^16.18.126",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@vimeo/player": "^2.30.4",
     "axios": "^1.10.0",
     "hls.js": "^1.6.17",
     "react": "^19.1.0",
@@ -64,6 +65,7 @@
   },
   "devDependencies": {
     "@types/react-router-dom": "^5.3.3",
-    "@types/simple-peer": "^9.11.8"
+    "@types/simple-peer": "^9.11.8",
+    "@types/vimeo__player": "^2.18.3"
   }
 }

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.test.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.test.tsx
@@ -19,6 +19,22 @@ jest.mock('../sync/audio-truth', () => ({
   },
 }));
 
+// the real SDK's constructor fetches from vimeo.com; mount wiring has its
+// own test (VimeoMount.test.tsx), here it only needs to render
+jest.mock('@vimeo/player', () => ({
+  __esModule: true,
+  default: class {
+    on() {}
+    off() {}
+    ready() {
+      return new Promise(() => {});
+    }
+    destroy() {
+      return Promise.resolve();
+    }
+  },
+}));
+
 const renderPlayer = (videoUrl: string) =>
   render(<EnhancedVideoPlayer videoUrl={videoUrl} roomCode="TEST01" isHost />);
 
@@ -62,11 +78,10 @@ test('a remote file URL is attempted, and its error fails visibly', () => {
   expect(screen.queryByTestId('html5-video')).toBeNull();
 });
 
-test('a Vimeo URL shows the not-yet-supported card', () => {
+test('a Vimeo URL mounts the Vimeo player with controls', () => {
   renderPlayer('https://vimeo.com/76979871');
-  expect(screen.getByTestId('failure-card')).toHaveTextContent(
-    "Vimeo isn't supported yet",
-  );
+  expect(screen.getByTestId('vimeo-mount')).toBeInTheDocument();
+  expect(screen.getByTestId('play-button')).toBeInTheDocument();
 });
 
 test('a hostile scheme never reaches a media element', () => {

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -13,6 +13,7 @@ import { SyncHud } from './SyncHud';
 import { FailureCard } from './player/FailureCard';
 import { YouTubeMount } from './player/YouTubeMount';
 import { Html5Mount } from './player/Html5Mount';
+import { VimeoMount } from './player/VimeoMount';
 
 const PlayerContainer = styled.div`
   width: 100%;
@@ -447,11 +448,13 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
         );
         break;
       case 'vimeo':
-        card = (
-          <FailureCard
-            title="Vimeo isn't supported yet"
-            detail="Vimeo playback is on the roadmap; pick a YouTube or direct video URL for now."
-            url={videoUrl}
+        mount = (
+          <VimeoMount
+            key={source.videoId}
+            videoId={source.videoId}
+            hash={source.hash}
+            onAdapter={handleAdapter}
+            onFailure={handleFailure}
           />
         );
         break;

--- a/video-sync-frontend/src/components/player/VimeoMount.test.tsx
+++ b/video-sync-frontend/src/components/player/VimeoMount.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { VimeoMount } from './VimeoMount';
+
+const mockVimeoState: {
+  failReady: boolean;
+  instances: Array<{
+    options: Record<string, unknown>;
+    listeners: Map<string, (data?: unknown) => void>;
+    destroy: jest.Mock;
+  }>;
+} = { failReady: false, instances: [] };
+
+jest.mock('@vimeo/player', () => {
+  // untyped internals: babel's out-of-scope guard for mock factories
+  // rejects even identifiers appearing in TYPE annotations
+  class FakePlayer {
+    options: Record<string, unknown>;
+    listeners = new Map();
+    destroy = jest.fn(() => Promise.resolve());
+    constructor(_el: HTMLElement, options: Record<string, unknown>) {
+      this.options = options;
+      mockVimeoState.instances.push(this);
+    }
+    on(event: string, cb: Function) {
+      this.listeners.set(event, cb);
+    }
+    off() {}
+    ready() {
+      return mockVimeoState.failReady
+        ? Promise.reject(new Error('Because of its privacy settings, this video cannot be played here.'))
+        : Promise.resolve();
+    }
+    getDuration() {
+      return Promise.resolve(0);
+    }
+  }
+  return { __esModule: true, default: FakePlayer };
+});
+
+beforeEach(() => {
+  mockVimeoState.failReady = false;
+  mockVimeoState.instances.length = 0;
+});
+
+test('delivers an adapter once the player is ready', async () => {
+  const onAdapter = jest.fn();
+  const { unmount } = render(
+    <VimeoMount videoId="76979871" onAdapter={onAdapter} onFailure={jest.fn()} />,
+  );
+  await waitFor(() => expect(onAdapter).toHaveBeenCalled());
+  expect(onAdapter.mock.calls[0][0]).not.toBeNull();
+  expect(mockVimeoState.instances[0].options).toMatchObject({
+    id: 76979871,
+    controls: false,
+    autopause: false,
+  });
+
+  unmount();
+  expect(mockVimeoState.instances[0].destroy).toHaveBeenCalled();
+  expect(onAdapter).toHaveBeenLastCalledWith(null);
+});
+
+test('an unlisted hash rides the url form the SDK understands', async () => {
+  render(
+    <VimeoMount
+      videoId="76979871"
+      hash="9b1d4c2f8a"
+      onAdapter={jest.fn()}
+      onFailure={jest.fn()}
+    />,
+  );
+  await waitFor(() => expect(mockVimeoState.instances).toHaveLength(1));
+  expect(mockVimeoState.instances[0].options.url).toBe(
+    'https://vimeo.com/76979871/9b1d4c2f8a',
+  );
+  expect(mockVimeoState.instances[0].options.id).toBeUndefined();
+});
+
+test('a private video fails visibly with the SDK message', async () => {
+  mockVimeoState.failReady = true;
+  const onFailure = jest.fn();
+  render(
+    <VimeoMount videoId="76979871" onAdapter={jest.fn()} onFailure={onFailure} />,
+  );
+  await waitFor(() =>
+    expect(onFailure).toHaveBeenCalledWith(
+      'Because of its privacy settings, this video cannot be played here.',
+    ),
+  );
+});

--- a/video-sync-frontend/src/components/player/VimeoMount.tsx
+++ b/video-sync-frontend/src/components/player/VimeoMount.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useRef } from 'react';
+import styled from '@emotion/styled';
+import { VimeoAdapter } from '../../sync/VimeoAdapter';
+import { MountProps } from './mount-props';
+
+// The SDK builds its iframe inside this container; the container owns the
+// geometry so the embed fills the shell's 16:9 area.
+const Container = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+
+  & iframe {
+    width: 100%;
+    height: 100%;
+  }
+`;
+
+/**
+ * Mounts the Vimeo player for a classified vimeo source. Like hls.js, the
+ * SDK is a dynamic import - a lazy chunk only Vimeo rooms fetch. The shell
+ * remounts this component (key=videoId) when the video changes.
+ */
+export const VimeoMount: React.FC<
+  { videoId: string; hash?: string } & MountProps
+> = ({ videoId, hash, onAdapter, onFailure }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let cancelled = false;
+    let sdkPlayer: { destroy(): Promise<void> } | null = null;
+    let adapter: VimeoAdapter | null = null;
+
+    void import('@vimeo/player').then(({ default: Player }) => {
+      // the chunk can land after a fast source change tore us down
+      if (cancelled) return;
+      const player = new Player(container, {
+        // the url form carries the unlisted-video hash (vimeo.com/<id>/<h>);
+        // the typed `h` option lags in the SDK typings
+        ...(hash !== undefined
+          ? { url: `https://vimeo.com/${videoId}/${hash}` }
+          : { id: Number(videoId) }),
+        // the shell owns controls; videos below Vimeo's paid tiers ignore
+        // this and show their own - sync still reconciles either way
+        controls: false,
+        // two tabs of one browser must not pause each other mid-party
+        autopause: false,
+        keyboard: false,
+        dnt: true,
+      });
+      sdkPlayer = player;
+
+      player.on('error', (e: { message?: string }) => {
+        if (!cancelled) {
+          onFailure(e?.message ?? 'The Vimeo player reported an error.');
+        }
+      });
+
+      player
+        .ready()
+        .then(() => {
+          if (cancelled) return;
+          adapter = new VimeoAdapter(player);
+          onAdapter(adapter);
+        })
+        .catch((e: { message?: string }) => {
+          // ready() rejects for private/deleted/embed-restricted videos
+          if (!cancelled) {
+            onFailure(
+              e?.message ?? 'Vimeo could not load this video (private or removed).',
+            );
+          }
+        });
+    });
+
+    return () => {
+      cancelled = true;
+      adapter?.dispose();
+      onAdapter(null);
+      void sdkPlayer?.destroy().catch(() => {
+        /* already gone */
+      });
+    };
+  }, [videoId, hash, onAdapter, onFailure]);
+
+  return <Container ref={containerRef} data-testid="vimeo-mount" />;
+};

--- a/video-sync-frontend/src/sync/VimeoAdapter.test.ts
+++ b/video-sync-frontend/src/sync/VimeoAdapter.test.ts
@@ -1,0 +1,130 @@
+import { VimeoAdapter, VimeoPlayerLike } from './VimeoAdapter';
+
+/** Minimal event-emitting fake of the SDK surface the adapter drives. */
+class FakePlayer implements VimeoPlayerLike {
+  listeners = new Map<string, Array<(data?: unknown) => void>>();
+  rateControlEnabled = true;
+  appliedRate = 1;
+  setCurrentTime = jest.fn(() => Promise.resolve(0));
+  play = jest.fn(() => Promise.resolve());
+  pause = jest.fn(() => Promise.resolve());
+
+  on(event: string, callback: (data?: unknown) => void): void {
+    const list = this.listeners.get(event) ?? [];
+    list.push(callback);
+    this.listeners.set(event, list);
+  }
+
+  off(event: string, callback?: (data?: unknown) => void): void {
+    const list = this.listeners.get(event) ?? [];
+    this.listeners.set(
+      event,
+      callback ? list.filter((cb) => cb !== callback) : [],
+    );
+  }
+
+  emit(event: string, data?: unknown): void {
+    for (const cb of this.listeners.get(event) ?? []) cb(data);
+  }
+
+  getDuration(): Promise<number> {
+    return Promise.resolve(636);
+  }
+
+  setPlaybackRate(rate: number): Promise<number> {
+    if (!this.rateControlEnabled) {
+      return Promise.reject(new Error('rate control disabled by owner'));
+    }
+    this.appliedRate = rate;
+    return Promise.resolve(rate);
+  }
+
+  getPlaybackRate(): Promise<number> {
+    return Promise.resolve(this.appliedRate);
+  }
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+test('lifecycle follows SDK events', () => {
+  const p = new FakePlayer();
+  const a = new VimeoAdapter(p);
+  expect(a.getLifecycle()).toBe('unstarted');
+  p.emit('loaded');
+  expect(a.getLifecycle()).toBe('cued');
+  p.emit('play');
+  expect(a.getLifecycle()).toBe('playing');
+  p.emit('bufferstart');
+  expect(a.getLifecycle()).toBe('buffering');
+  p.emit('bufferend');
+  expect(a.getLifecycle()).toBe('playing');
+  p.emit('pause');
+  expect(a.getLifecycle()).toBe('paused');
+  p.emit('ended');
+  expect(a.getLifecycle()).toBe('ended');
+});
+
+test('playhead comes from timeupdate edges; paused reads stay put', () => {
+  const p = new FakePlayer();
+  const a = new VimeoAdapter(p);
+  p.emit('timeupdate', { seconds: 42.5, duration: 636 });
+  // paused: no extrapolation, the edge value is the truth
+  expect(a.getPlayerTime()).toBe(42.5);
+  expect(a.getDuration()).toBe(636);
+
+  // playing: extrapolates forward from the edge, never backwards
+  p.emit('play');
+  expect(a.getPlayerTime()).toBeGreaterThanOrEqual(42.5);
+});
+
+test('a seek invalidates the edge and commands the player', () => {
+  const p = new FakePlayer();
+  const a = new VimeoAdapter(p);
+  p.emit('play');
+  p.emit('timeupdate', { seconds: 100 });
+  a.seekTo(30);
+  expect(p.setCurrentTime).toHaveBeenCalledWith(30);
+  // between the command and the seeked event the model holds the last
+  // known value rather than extrapolating a dead edge
+  expect(a.getPlayerTime()).toBe(100);
+  p.emit('seeked', { seconds: 30 });
+  expect(a.getPlayerTime()).toBeGreaterThanOrEqual(30);
+});
+
+test('probeFractionalRate: true when the owner allows rate control', async () => {
+  const p = new FakePlayer();
+  const a = new VimeoAdapter(p);
+  await expect(a.probeFractionalRate()).resolves.toBe(true);
+  // the probe must leave the player at 1x
+  expect(p.appliedRate).toBe(1);
+});
+
+test('probeFractionalRate: false when setPlaybackRate rejects (SEEK mode)', async () => {
+  const p = new FakePlayer();
+  p.rateControlEnabled = false;
+  const a = new VimeoAdapter(p);
+  await expect(a.probeFractionalRate()).resolves.toBe(false);
+});
+
+test('setRate is optimistic and falls back to 1 on rejection', async () => {
+  const p = new FakePlayer();
+  p.rateControlEnabled = false;
+  const a = new VimeoAdapter(p);
+  p.emit('play');
+  p.emit('timeupdate', { seconds: 10 });
+  expect(a.setRate(1.05)).toBe(1.05);
+  await tick(); // the rejected apply lands
+  // extrapolation now runs at the fallback rate, not the refused one
+  const t1 = a.getPlayerTime();
+  expect(t1).toBeGreaterThanOrEqual(10);
+});
+
+test('dispose unsubscribes every handler', () => {
+  const p = new FakePlayer();
+  const a = new VimeoAdapter(p);
+  a.dispose();
+  p.listeners.forEach((list) => expect(list).toHaveLength(0));
+  // events after dispose must not mutate the model
+  p.emit('play');
+  expect(a.getLifecycle()).toBe('unstarted');
+});

--- a/video-sync-frontend/src/sync/VimeoAdapter.ts
+++ b/video-sync-frontend/src/sync/VimeoAdapter.ts
@@ -1,0 +1,208 @@
+import { PlayerLifecycle } from '../shared/sync-core/drift-controller';
+import { PlayerAdapter } from '../shared/sync-core/player-adapter';
+
+/**
+ * The slice of the Vimeo Player SDK the adapter drives, structural so
+ * tests can hand in a plain fake. Every read is a postMessage round-trip
+ * returning a Promise - which is the whole reason this adapter keeps a
+ * local model instead of asking the player anything on the hot path.
+ */
+export interface VimeoPlayerLike {
+  on(event: string, callback: (data?: unknown) => void): void;
+  off(event: string, callback?: (data?: unknown) => void): void;
+  getDuration(): Promise<number>;
+  setCurrentTime(seconds: number): Promise<number>;
+  play(): Promise<void>;
+  pause(): Promise<void>;
+  setPlaybackRate(rate: number): Promise<number>;
+  getPlaybackRate(): Promise<number>;
+}
+
+interface TimePayload {
+  seconds: number;
+  duration?: number;
+}
+
+/**
+ * Wraps the Vimeo player behind the shared PlayerAdapter surface.
+ *
+ * The SDK is promise-only, but the engine's contract is synchronous reads
+ * on a 250ms cadence - so the playhead is modeled locally from `timeupdate`
+ * edges (~4Hz while playing) and extrapolated at the playback rate between
+ * them, capped so a stalled pipe reads as its last truth instead of
+ * fiction. Same edge-reconstruction idea as YouTubeAdapter, different
+ * transport: events push edges here, YT gets polled.
+ */
+export class VimeoAdapter implements PlayerAdapter {
+  private edge: { tLocal: number; value: number } | null = null;
+  private lastKnown = 0;
+  private durationS = 0;
+  private life: PlayerLifecycle = 'unstarted';
+  private rate = 1;
+  private lastCommandAt = 0;
+  private handlers: Array<[string, (data?: unknown) => void]> = [];
+
+  constructor(private player: VimeoPlayerLike) {
+    const on = (event: string, callback: (data?: unknown) => void) => {
+      this.handlers.push([event, callback]);
+      player.on(event, callback);
+    };
+
+    on('timeupdate', (d) => {
+      const p = d as TimePayload;
+      this.lastKnown = p.seconds;
+      this.edge = { tLocal: Date.now(), value: p.seconds };
+      if (p.duration) this.durationS = p.duration;
+    });
+    on('seeked', (d) => {
+      const p = d as TimePayload;
+      this.lastKnown = p.seconds;
+      this.edge = { tLocal: Date.now(), value: p.seconds };
+    });
+    on('play', () => {
+      this.life = 'playing';
+    });
+    on('pause', () => {
+      this.life = 'paused';
+    });
+    on('bufferstart', () => {
+      this.life = 'buffering';
+    });
+    on('bufferend', () => {
+      // a pause during the stall arrives as its own event after this one
+      if (this.life === 'buffering') this.life = 'playing';
+    });
+    on('ended', () => {
+      this.life = 'ended';
+    });
+    on('loaded', () => {
+      if (this.life === 'unstarted') this.life = 'cued';
+    });
+    on('playbackratechange', (d) => {
+      this.rate = (d as { playbackRate: number }).playbackRate;
+    });
+    on('durationchange', (d) => {
+      this.durationS = (d as { duration: number }).duration;
+    });
+
+    void player
+      .getDuration()
+      .then((d) => {
+        this.durationS = d;
+      })
+      .catch(() => {
+        /* duration arrives via events once playback starts */
+      });
+  }
+
+  getPlayerTime(): number {
+    const now = Date.now();
+    // timeupdate cadence is ~250ms while playing; past 1200ms the edge is
+    // stale (stall, teardown) and extrapolating it would be fiction
+    if (
+      this.life === 'playing' &&
+      this.edge &&
+      now - this.edge.tLocal < 1200
+    ) {
+      return this.edge.value + ((now - this.edge.tLocal) / 1000) * this.rate;
+    }
+    return this.lastKnown;
+  }
+
+  getLifecycle(): PlayerLifecycle {
+    return this.life;
+  }
+
+  /** Numeric state for the harness telemetry contract (1 = PLAYING). */
+  getRawState(): number {
+    switch (this.life) {
+      case 'playing':
+        return 1;
+      case 'paused':
+        return 2;
+      case 'buffering':
+        return 3;
+      case 'ended':
+        return 0;
+      case 'cued':
+        return 5;
+      default:
+        return -1;
+    }
+  }
+
+  getDuration(): number {
+    return this.durationS;
+  }
+
+  seekTo(mediaTime: number): void {
+    this.lastCommandAt = Date.now();
+    this.edge = null; // the old edge is meaningless across a seek
+    void this.player.setCurrentTime(Math.max(0, mediaTime)).catch(() => {
+      /* teardown race */
+    });
+  }
+
+  play(): void {
+    this.lastCommandAt = Date.now();
+    void this.player.play().catch(() => {
+      /* autoplay policy: the engine surfaces the gesture chip */
+    });
+  }
+
+  pause(): void {
+    this.lastCommandAt = Date.now();
+    void this.player.pause().catch(() => {
+      /* teardown race */
+    });
+  }
+
+  /**
+   * The SDK apply is async but the engine needs the effective rate NOW.
+   * probeFractionalRate gates RATE mode on rate control actually working,
+   * so reporting the requested rate optimistically is honest; if the apply
+   * still rejects (owner revoked it mid-session), the model falls back to
+   * 1 and the next playbackratechange event is the truth.
+   */
+  setRate(rate: number): number {
+    this.lastCommandAt = Date.now();
+    this.rate = rate;
+    void this.player.setPlaybackRate(rate).catch(() => {
+      this.rate = 1;
+    });
+    return rate;
+  }
+
+  /**
+   * Vimeo honours fractional rates only when the video's owner left rate
+   * control enabled - setPlaybackRate rejects otherwise, which lands the
+   * engine in SEEK mode, the design center.
+   */
+  async probeFractionalRate(): Promise<boolean> {
+    try {
+      await this.player.setPlaybackRate(1.05);
+      const applied = await this.player.getPlaybackRate();
+      return Math.abs(applied - 1.05) < 0.001;
+    } catch {
+      return false;
+    } finally {
+      try {
+        await this.player.setPlaybackRate(1);
+      } catch {
+        /* teardown race */
+      }
+    }
+  }
+
+  /** True when a recent programmatic command explains a state transition. */
+  wasRecentlyCommanded(windowMs = 1500): boolean {
+    return Date.now() - this.lastCommandAt < windowMs;
+  }
+
+  dispose(): void {
+    for (const [event, callback] of this.handlers) {
+      this.player.off(event, callback);
+    }
+    this.handlers = [];
+  }
+}


### PR DESCRIPTION
Step 5 of the multi-source player program, stacked on #34. The `vimeo`
sources the classifier has extracted since Step 1 (canonical, `player.`
URLs, unlisted hashes) now mount a real player instead of a
not-yet-supported card.

**The adapter problem worth reading.** The Vimeo SDK is promise-only —
every read is a postMessage round-trip — but the engine's contract is
synchronous reads on a 250ms cadence. So `VimeoAdapter` never asks the
player anything on the hot path: the playhead is modeled locally from
`timeupdate` edges (~4Hz while playing) and extrapolated at the playback
rate between them, capped at 1200ms so a stalled pipe reads as its last
truth instead of fiction. It's the same edge-reconstruction idea as
`YouTubeAdapter` with the transport inverted: events push edges here,
where YT gets polled. Lifecycle is a small state machine over SDK events
(`bufferend` only resumes `playing` if nothing else claimed the state).

**Rate control honesty.** `setRate` must return the applied rate
synchronously; the SDK applies async and only if the video's owner left
rate control enabled. `probeFractionalRate` gates RATE mode on an actual
1.05× round-trip (rejection → SEEK mode, the design center), so `setRate`
reporting the requested rate optimistically is honest — and if the apply
still rejects, the model falls back to 1× and the next
`playbackratechange` event is the truth.

**Mount details.** The SDK ships as a dynamic-import lazy chunk (8KB
gzipped) like hls.js. Unlisted hashes ride the `url:` option form
(`vimeo.com/<id>/<hash>`) because the typed `h` option lags in the SDK
typings. `autopause: false` because two tabs of one browser must not pause
each other mid-party. `ready()` rejections (private, removed,
embed-restricted) fail visibly with the SDK's own message.

10 new tests: adapter lifecycle/edges/seek-invalidations, both probe
outcomes, optimistic-rate fallback, dispose unsubscription, and mount
wiring (adapter delivery, hash-url form, destroy on unmount, private-video
failure). Frontend suite at 22; `tsc` and CI-strict build green.