### PR TITLE
feat: set-video synced control with cross-video command fencing, spec-first

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,8 +44,8 @@ jobs:
           java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config SyncExactlyOnce.cfg SyncExactlyOnce.tla
           java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config SyncExactlyOnce_live.cfg SyncExactlyOnce.tla
           expect_violation() {
-            local cfg="$1" prop="$2" out
-            if out=$(java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config "$cfg" SyncExactlyOnce.tla 2>&1); then
+            local cfg="$1" prop="$2" spec="$3" out
+            if out=$(java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config "$cfg" "$spec" 2>&1); then
               echo "$cfg unexpectedly passed - the spec lost its teeth"; return 1
             fi
             if ! grep -q "Invariant $prop is violated" <<<"$out"; then
@@ -53,9 +53,15 @@ jobs:
             fi
             echo "$cfg: $prop violated as designed"
           }
-          expect_violation SyncExactlyOnce_nodedup.cfg AtMostOnce
-          expect_violation SyncExactlyOnce_earlyevict.cfg AtMostOnce
-          expect_violation SyncExactlyOnce_nosnaplog.cfg ReplayReconstructs
+          expect_violation SyncExactlyOnce_nodedup.cfg AtMostOnce SyncExactlyOnce.tla
+          expect_violation SyncExactlyOnce_earlyevict.cfg AtMostOnce SyncExactlyOnce.tla
+          expect_violation SyncExactlyOnce_nosnaplog.cfg ReplayReconstructs SyncExactlyOnce.tla
+          # set-video fencing: cross-video command application and the
+          # dedup-vs-fence ordering inside the atomic apply
+          java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config SyncSetVideo.cfg SyncSetVideo.tla
+          java -cp tools/tla2tools.jar tlc2.TLC -workers 4 -config SyncSetVideo_live.cfg SyncSetVideo.tla
+          expect_violation SyncSetVideo_nofence.cfg NoCrossVideoApply SyncSetVideo.tla
+          expect_violation SyncSetVideo_earlyrecord.cfg DupAnswerImpliesApplied SyncSetVideo.tla
 
   lab-50:
     runs-on: ubuntu-latest

--- a/docs/FORMAL.md
+++ b/docs/FORMAL.md
@@ -284,3 +284,55 @@ real implementation obligation this spec makes visible rather than proves:
 command applied by the old owner can be re-applied by the new one. That
 lives with the fencing machinery, and is called out in COORDINATION.md
 rather than silently assumed here.
+
+# set-video: cross-video command fencing
+
+`formal/SyncSetVideo.tla` — the fourth spec, again written **before** the
+implementation it constrains. Changing the room's video is a synced control
+(`set-video`), which creates a hazard none of the other specs cover: a
+position command (play/pause/seek) is minted against *a particular video*,
+and if the room switches while it is in flight, a well-formed, authorized,
+exactly-once-delivered command is still **wrong** — a seek to minute 37 of
+video A yanks everyone to minute 37 of video B.
+
+## What is modeled
+
+Position commands carry the videoId their minter last observed
+(`forVideoId`); set-video commands carry a target video. The channel
+retries and reorders as in the exactly-once spec. The store's apply is one
+atomic step whose INTERNAL ORDER is the design decision under test:
+
+1. dedup lookup — an already-applied id answers "duplicate"
+2. video fence (position commands only) — a stale observed video answers
+   "stale-video"
+3. commit + dedup record
+
+set-video itself is deliberately **unfenced**: it carries no position, and
+a "stale" switch is still exactly what its sender meant — last-writer-wins
+is the right semantic for changing videos.
+
+## Properties and teeth
+
+| config | switch | result |
+|---|---|---|
+| `SyncSetVideo.cfg` (safety) | fenced, correct order | **green**: `TypeOK`, `NoCrossVideoApply`, `AtMostOnce`, `DupAnswerImpliesApplied` — 26,180 states, 7,185 distinct |
+| `SyncSetVideo_live.cfg` (liveness) | fenced | **green**: `EventuallyAnswered` — fencing rejects, never strands |
+| `SyncSetVideo_nofence.cfg` | `FencingOn = FALSE` | **must fail** `NoCrossVideoApply`: the in-flight seek applies to the switched video |
+| `SyncSetVideo_earlyrecord.cfg` | `EarlyRecord = TRUE` | **must fail** `DupAnswerImpliesApplied`: recording the id before the fence check burns the id of a never-applied command; after a switch back, its retry is answered "duplicate" — a claimed apply that never happened |
+
+The earlyrecord config is the reason `apply_control.lua` and
+`actor_commit.lua` split their former `SET NX` into GET → fence → SET
+(race-free because the whole script is one atomic step). A property that is
+deliberately ABSENT: "a fenced command never applies later" is *not* an
+invariant of the design — a retry already in flight when the stale-video
+answer lands may legally apply after a switch back to its observed video;
+the fence matches again, so it is not a cross-video apply.
+
+## Composition with the other specs
+
+Dedup TTL and eviction are not remodeled here — `SyncExactlyOnce.tla` owns
+the `Ttl`-vs-`RetryWindow` relation, and fencing leaves it intact precisely
+because a fenced command records nothing. Instance fencing stays with
+`SyncActor.tla`; the video fence composes with it inside `actor_commit.lua`,
+checked against the STORED timeline rather than the owner's in-memory copy,
+which may trail a handoff.

--- a/formal/SyncSetVideo.cfg
+++ b/formal/SyncSetVideo.cfg
@@ -1,0 +1,20 @@
+\* Safety at the design point: position commands fenced by observed video,
+\* dedup lookup ordered BEFORE the fence check inside the atomic apply.
+SPECIFICATION Spec
+CONSTANTS
+  SeekCmds = {s1}
+  SetVideoCmds = {sv1, sv2}
+  Videos = {v1, v2}
+  InitVideo = v1
+  MaxSends = 2
+  FencingOn = TRUE
+  EarlyRecord = FALSE
+  NoVideo = NoVideo
+INVARIANTS
+  TypeOK
+  NoCrossVideoApply
+  AtMostOnce
+  DupAnswerImpliesApplied
+
+\* bounded model: exhausted counters produce terminal states by design
+CHECK_DEADLOCK FALSE

--- a/formal/SyncSetVideo.tla
+++ b/formal/SyncSetVideo.tla
@@ -1,0 +1,229 @@
+---------------------------- MODULE SyncSetVideo ----------------------------
+(***************************************************************************)
+(* set-video as a synced control: switching the room's video must not let  *)
+(* position-carrying commands (play/pause/seek) minted against the OLD     *)
+(* video mutate the NEW one.                                               *)
+(*                                                                         *)
+(* The failure this models is concrete: a controller drags the scrubber    *)
+(* to minute 37 of video A; while that seek is in flight another           *)
+(* controller switches the room to video B; the seek arrives and yanks     *)
+(* everyone to minute 37 of a video they just started. The command was     *)
+(* well-formed, authorized, delivered exactly once - and still wrong,      *)
+(* because its PRECONDITION (which video it was about) silently changed.   *)
+(*                                                                         *)
+(* The mechanism: every position command carries the videoId its minter    *)
+(* last observed (forVideoId); the store's apply script rejects a command  *)
+(* whose observed video is not the current one, atomically with the        *)
+(* commit. set-video itself is NOT fenced - it carries no position, and a  *)
+(* "stale" switch is still exactly what its sender meant (last-writer-     *)
+(* wins is the right semantic for changing videos).                        *)
+(*                                                                         *)
+(* Two switches keep the spec's teeth - each OFF position is a committed   *)
+(* config whose named failure pins a real design constraint:               *)
+(*                                                                         *)
+(*   FencingOn = FALSE  ->  NoCrossVideoApply fails: the in-flight seek    *)
+(*                          applies to the switched video.                 *)
+(*                          (SyncSetVideo_nofence.cfg)                     *)
+(*   EarlyRecord = TRUE ->  DupAnswerImpliesApplied fails: recording the   *)
+(*                          idempotency id BEFORE the fence check burns    *)
+(*                          the id of a command that was never applied;    *)
+(*                          when the room switches back and the client     *)
+(*                          retries, the store answers "duplicate" -       *)
+(*                          claiming an apply that never happened. The     *)
+(*                          apply script must order: dedup lookup, THEN    *)
+(*                          fence check, THEN commit+record - all still    *)
+(*                          inside one atomic script.                      *)
+(*                          (SyncSetVideo_earlyrecord.cfg)                 *)
+(*                                                                         *)
+(* Abstractions: media position is dropped entirely - the property is      *)
+(* about WHICH video a command mutates, not where it lands. Dedup TTL and  *)
+(* eviction are NOT modeled: SyncExactlyOnce.tla owns the TTL-vs-retry     *)
+(* relation, and it is unchanged by fencing because a fenced command       *)
+(* records nothing. Store epochs / instance fencing live in SyncActor.    *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+  SeekCmds,      \* position-carrying command identities, e.g. {s1}
+  SetVideoCmds,  \* set-video command identities, e.g. {sv1, sv2}
+  Videos,        \* video identities, e.g. {v1, v2}
+  InitVideo,     \* the room's video at Init
+  MaxSends,      \* per-command bound on channel insertions (issue+retry)
+  FencingOn,     \* the store rejects a position command whose observed
+                 \* video is not the current one
+  EarlyRecord,   \* WRONG ordering under test: record the dedup id before
+                 \* the fence check instead of after it
+  NoVideo        \* model value: "not yet issued" marker, outside Videos
+
+ASSUME NoVideo \notin Videos
+
+Cmds == SeekCmds \cup SetVideoCmds
+
+VARIABLES
+  roomVideo,     \* the room's current video
+  seq,           \* commit counter (every apply bumps it)
+  fenceOf,       \* [SeekCmds -> Videos \cup {NoVideo}]: the video the
+                 \* command's minter observed, fixed at issue
+  targetOf,      \* [SetVideoCmds -> Videos \cup {NoVideo}]: the commanded
+                 \* new video, fixed at issue
+  sends,         \* [Cmds -> Nat]: channel insertions so far
+  chan,          \* [Cmds -> Nat]: copies in flight (a bag: delivery picks
+                 \* any pending command, so reordering is inherent)
+  dedup,         \* ids the store remembers (SET NX record)
+  applyCount,    \* [Cmds -> Nat]: ground truth applications
+  dupAnswered,   \* commands the store has answered "duplicate" to
+  fencedAnswered,\* commands the store has answered "stale-video" to
+  misapplied,    \* seeks that applied while the room showed a different
+                 \* video than their minter observed - THE bad event
+  acked          \* commands whose definitive answer the client observed
+
+vars == <<roomVideo, seq, fenceOf, targetOf, sends, chan, dedup, applyCount,
+          dupAnswered, fencedAnswered, misapplied, acked>>
+
+Init ==
+  /\ roomVideo = InitVideo
+  /\ seq = 0
+  /\ fenceOf = [c \in SeekCmds |-> NoVideo]
+  /\ targetOf = [c \in SetVideoCmds |-> NoVideo]
+  /\ sends = [c \in Cmds |-> 0]
+  /\ chan = [c \in Cmds |-> 0]
+  /\ dedup = {}
+  /\ applyCount = [c \in Cmds |-> 0]
+  /\ dupAnswered = {}
+  /\ fencedAnswered = {}
+  /\ misapplied = {}
+  /\ acked = {}
+
+Issued(c) ==
+  IF c \in SeekCmds THEN fenceOf[c] # NoVideo ELSE targetOf[c] # NoVideo
+
+(* Mint a position command: it carries the video its minter observes NOW.
+   Staleness needs no separate observe action - it arises whenever a
+   set-video applies between this mint and this command's delivery. *)
+IssueSeek(c) ==
+  /\ c \in SeekCmds
+  /\ ~Issued(c)
+  /\ sends[c] < MaxSends
+  /\ fenceOf' = [fenceOf EXCEPT ![c] = roomVideo]
+  /\ sends' = [sends EXCEPT ![c] = @ + 1]
+  /\ chan' = [chan EXCEPT ![c] = @ + 1]
+  /\ UNCHANGED <<roomVideo, seq, targetOf, dedup, applyCount, dupAnswered,
+                 fencedAnswered, misapplied, acked>>
+
+(* Mint a set-video: any target, including the current video - a redundant
+   switch is still a legal user intent. *)
+IssueSetVideo(c) ==
+  /\ c \in SetVideoCmds
+  /\ ~Issued(c)
+  /\ sends[c] < MaxSends
+  /\ \E v \in Videos :
+       targetOf' = [targetOf EXCEPT ![c] = v]
+  /\ sends' = [sends EXCEPT ![c] = @ + 1]
+  /\ chan' = [chan EXCEPT ![c] = @ + 1]
+  /\ UNCHANGED <<roomVideo, seq, fenceOf, dedup, applyCount, dupAnswered,
+                 fencedAnswered, misapplied, acked>>
+
+(* Unanswered command, client sends the same id again (reconnect flush or
+   deliberate retry - at-least-once delivery, the origin of duplicates). *)
+Retry(c) ==
+  /\ Issued(c)
+  /\ c \notin acked
+  /\ sends[c] < MaxSends
+  /\ sends' = [sends EXCEPT ![c] = @ + 1]
+  /\ chan' = [chan EXCEPT ![c] = @ + 1]
+  /\ UNCHANGED <<roomVideo, seq, fenceOf, targetOf, dedup, applyCount,
+                 dupAnswered, fencedAnswered, misapplied, acked>>
+
+(* The store's apply script - ONE atomic step, mirroring apply_control.lua.
+   The ORDER inside the step is the design decision under test:
+     1. dedup lookup: an already-applied id is answered "duplicate"
+     2. fence check (position commands only): a stale observed video is
+        answered "stale-video"; with EarlyRecord the id is (wrongly)
+        recorded on this path
+     3. commit + record
+   set-video always passes 2: it has no position to misapply and switching
+   is last-writer-wins by design. *)
+Deliver(c) ==
+  /\ chan[c] >= 1
+  /\ chan' = [chan EXCEPT ![c] = @ - 1]
+  /\ IF c \in dedup
+     THEN /\ dupAnswered' = dupAnswered \cup {c}
+          /\ UNCHANGED <<roomVideo, seq, fenceOf, targetOf, dedup,
+                         applyCount, fencedAnswered, misapplied>>
+     ELSE IF c \in SeekCmds /\ FencingOn /\ fenceOf[c] # roomVideo
+     THEN /\ fencedAnswered' = fencedAnswered \cup {c}
+          /\ dedup' = IF EarlyRecord THEN dedup \cup {c} ELSE dedup
+          /\ UNCHANGED <<roomVideo, seq, fenceOf, targetOf, applyCount,
+                         dupAnswered, misapplied>>
+     ELSE /\ roomVideo' = IF c \in SetVideoCmds THEN targetOf[c]
+                          ELSE roomVideo
+          /\ seq' = seq + 1
+          /\ applyCount' = [applyCount EXCEPT ![c] = @ + 1]
+          /\ dedup' = dedup \cup {c}
+          /\ misapplied' = IF c \in SeekCmds /\ fenceOf[c] # roomVideo
+                           THEN misapplied \cup {c}
+                           ELSE misapplied
+          /\ UNCHANGED <<fenceOf, targetOf, dupAnswered, fencedAnswered>>
+  /\ UNCHANGED <<sends, acked>>
+
+(* The client observes a definitive answer - the committed broadcast, the
+   duplicate re-anchor, or the stale-video re-anchor - and stops retrying. *)
+Ack(c) ==
+  /\ c \notin acked
+  /\ applyCount[c] >= 1 \/ c \in dupAnswered \/ c \in fencedAnswered
+  /\ acked' = acked \cup {c}
+  /\ UNCHANGED <<roomVideo, seq, fenceOf, targetOf, sends, chan, dedup,
+                 applyCount, dupAnswered, fencedAnswered, misapplied>>
+
+Next ==
+  \E c \in Cmds :
+    IssueSeek(c) \/ IssueSetVideo(c) \/ Retry(c) \/ Deliver(c) \/ Ack(c)
+
+Spec == Init /\ [][Next]_vars
+             /\ \A c \in Cmds : WF_vars(Deliver(c)) /\ WF_vars(Ack(c))
+
+(***************************************************************************)
+(* Invariants                                                              *)
+(***************************************************************************)
+
+TypeOK ==
+  /\ roomVideo \in Videos
+  /\ seq \in Nat
+  /\ fenceOf \in [SeekCmds -> Videos \cup {NoVideo}]
+  /\ targetOf \in [SetVideoCmds -> Videos \cup {NoVideo}]
+  /\ sends \in [Cmds -> 0..MaxSends]
+  /\ chan \in [Cmds -> 0..MaxSends]
+  /\ dedup \subseteq Cmds
+  /\ applyCount \in [Cmds -> 0..MaxSends]
+  /\ dupAnswered \subseteq Cmds
+  /\ fencedAnswered \subseteq Cmds
+  /\ misapplied \subseteq SeekCmds
+  /\ acked \subseteq Cmds
+
+(* THE property: no position command ever mutates a video its minter was
+   not looking at. *)
+NoCrossVideoApply == misapplied = {}
+
+(* Idempotency stays exactly-once with fencing composed in. *)
+AtMostOnce == \A c \in Cmds : applyCount[c] <= 1
+
+(* A "duplicate" answer is a claim that the command was applied; it must
+   never be a lie. The earlyrecord config is the counterexample: a fenced
+   command's burned id turns its retry into a false duplicate.
+   (Note the property that is deliberately ABSENT here: "a fenced command
+   never applies later" is NOT an invariant of the design - a retry already
+   in flight when the stale-video answer lands may legally apply after a
+   switch back to the observed video. The fence matches again, so it is
+   not a cross-video apply, and NoCrossVideoApply is the property that
+   matters.) *)
+DupAnswerImpliesApplied == \A c \in dupAnswered : applyCount[c] >= 1
+
+(***************************************************************************)
+(* Liveness: every issued command eventually gets a definitive answer -    *)
+(* applied, duplicate, or stale-video - and the client stops retrying.     *)
+(* Fencing must reject, never strand.                                      *)
+(***************************************************************************)
+EventuallyAnswered ==
+  \A c \in Cmds : Issued(c) ~> (c \in acked)
+
+===============================================================================

--- a/formal/SyncSetVideo_earlyrecord.cfg
+++ b/formal/SyncSetVideo_earlyrecord.cfg
@@ -1,0 +1,21 @@
+\* Wrong ordering inside the atomic apply: the dedup id recorded BEFORE the
+\* fence check. A fenced (never-applied) command burns its id; after a
+\* switch back, its retry is answered "duplicate" - a claimed apply that
+\* never happened. The nightly asserts this config FAILS on
+\* DupAnswerImpliesApplied; the fix is the GET-then-fence-then-SET order
+\* in apply_control.lua (atomicity makes the split lookup/record safe).
+SPECIFICATION Spec
+CONSTANTS
+  SeekCmds = {s1}
+  SetVideoCmds = {sv1, sv2}
+  Videos = {v1, v2}
+  InitVideo = v1
+  MaxSends = 2
+  FencingOn = TRUE
+  EarlyRecord = TRUE
+  NoVideo = NoVideo
+INVARIANTS
+  TypeOK
+  DupAnswerImpliesApplied
+
+CHECK_DEADLOCK FALSE

--- a/formal/SyncSetVideo_live.cfg
+++ b/formal/SyncSetVideo_live.cfg
@@ -1,0 +1,16 @@
+\* Liveness at the design point: fencing must reject, never strand - every
+\* issued command eventually gets a definitive answer and retry stops.
+SPECIFICATION Spec
+CONSTANTS
+  SeekCmds = {s1}
+  SetVideoCmds = {sv1, sv2}
+  Videos = {v1, v2}
+  InitVideo = v1
+  MaxSends = 2
+  FencingOn = TRUE
+  EarlyRecord = FALSE
+  NoVideo = NoVideo
+PROPERTIES
+  EventuallyAnswered
+
+CHECK_DEADLOCK FALSE

--- a/formal/SyncSetVideo_nofence.cfg
+++ b/formal/SyncSetVideo_nofence.cfg
@@ -1,0 +1,18 @@
+\* No fencing: an in-flight seek minted against video A MUST be shown to
+\* apply after the room switched to B. The nightly asserts this config
+\* FAILS on NoCrossVideoApply - the spec keeping its teeth.
+SPECIFICATION Spec
+CONSTANTS
+  SeekCmds = {s1}
+  SetVideoCmds = {sv1, sv2}
+  Videos = {v1, v2}
+  InitVideo = v1
+  MaxSends = 2
+  FencingOn = FALSE
+  EarlyRecord = FALSE
+  NoVideo = NoVideo
+INVARIANTS
+  TypeOK
+  NoCrossVideoApply
+
+CHECK_DEADLOCK FALSE

--- a/shared/sync-core/replay.ts
+++ b/shared/sync-core/replay.ts
@@ -57,6 +57,17 @@ export function checkTransition(prev: LogEntry, next: LogEntry): string | null {
   if (next.stampedAt < prev.stampedAt) {
     return `stampedAt regressed ${prev.stampedAt} -> ${next.stampedAt}`;
   }
+  if (next.reason === 'set-video') {
+    // the ONE transition allowed to change videoId - and it must land in
+    // the canonical fresh state: paused at 0 (a new video never autoplays)
+    if (next.isPlaying) {
+      return 'set-video committed a playing state';
+    }
+    if (differs(next.mediaTime, 0)) {
+      return `set-video committed mediaTime ${next.mediaTime}, not 0`;
+    }
+    return null;
+  }
   if (next.videoId !== prev.videoId) {
     return `videoId changed mid-epoch (${prev.videoId} -> ${next.videoId})`;
   }

--- a/shared/sync-core/timeline.ts
+++ b/shared/sync-core/timeline.ts
@@ -36,6 +36,9 @@ export function isNewer(incoming: Timeline, applied: Timeline | null): boolean {
  *   NOT the projected position — projecting forward would pause at a frame
  *   the presser never saw (P4)
  * - seek: jump to the commanded position, playing state unchanged
+ * - set-video: switch to `videoId`, always paused at 0 — a new video never
+ *   autoplays (P5's spirit: entering fresh state playing surprises every
+ *   participant whose player is still mounting)
  */
 export function applyControl(
   prev: Timeline,
@@ -43,6 +46,8 @@ export function applyControl(
   mediaTime: number,
   serverNow: number,
   by: string,
+  /** set-video only: the room's next videoId (null clears it) */
+  videoId?: string | null,
 ): Omit<Timeline, 'seq'> {
   const base = {
     v: 1 as const,
@@ -63,6 +68,14 @@ export function applyControl(
         isPlaying: prev.isPlaying,
         mediaTime,
         reason: 'seek',
+      };
+    case 'set-video':
+      return {
+        ...base,
+        videoId: videoId ?? null,
+        isPlaying: false,
+        mediaTime: 0,
+        reason: 'set-video',
       };
   }
 }

--- a/shared/sync-protocol.ts
+++ b/shared/sync-protocol.ts
@@ -29,7 +29,14 @@ export interface Timeline {
   stampedAt: number;
   /** fixed at 1 in v1; field reserved so the protocol never changes shape */
   rate: 1;
-  reason: 'play' | 'pause' | 'seek' | 'join' | 'snapshot' | 'succession';
+  reason:
+    | 'play'
+    | 'pause'
+    | 'seek'
+    | 'set-video'
+    | 'join'
+    | 'snapshot'
+    | 'succession';
   /** userId of the commander, when reason is a control intent */
   by?: string;
 }
@@ -46,11 +53,12 @@ export interface ClockPong {
   t2: number;
 }
 
-export type ControlIntent = 'play' | 'pause' | 'seek';
+export type ControlIntent = 'play' | 'pause' | 'seek' | 'set-video';
 
 /**
  * C→S control. mediaTime is the position the commander intends:
  * play = start here, pause = freeze at the frame I saw (P4), seek = go here.
+ * set-video ignores mediaTime (the new video always starts paused at 0).
  */
 export interface SyncControl {
   v: 1;
@@ -65,6 +73,21 @@ export interface SyncControl {
    * behavior. Deduped atomically inside the same Lua script as the commit.
    */
   cmdId?: string;
+  /**
+   * set-video payload: the room's next videoUrl ('' clears it). Validated
+   * at the gateway with the same shared admission rule as the REST DTOs.
+   */
+  videoUrl?: string;
+  /**
+   * Fence for position commands (play/pause/seek): the Timeline.videoId
+   * the commander had applied when it minted this command. The store
+   * refuses the command if the room's video has changed since - a seek
+   * aimed at video A must never yank video B (formal/SyncSetVideo.tla,
+   * the nofence config is the counterexample). Optional for wire compat:
+   * a command without it is unfenced, exactly the old behavior. Not sent
+   * on set-video - switching is last-writer-wins by design.
+   */
+  forVideoId?: string | null;
 }
 
 /** S→C error for rejected controls (permission, rate limit, no room). */
@@ -72,7 +95,18 @@ export interface SyncControlRejected {
   v: 1;
   roomCode: string;
   intent: ControlIntent;
-  reason: 'not-controller' | 'rate-limited' | 'room-not-found';
+  /**
+   * stale-video: the command's forVideoId no longer matches the room -
+   * refused, and a targeted sync:timeline re-anchor accompanies this
+   * event, so clients treat it silently (the re-anchor IS the remedy).
+   * invalid-video-url: a set-video whose URL failed the admission rule.
+   */
+  reason:
+    | 'not-controller'
+    | 'rate-limited'
+    | 'room-not-found'
+    | 'stale-video'
+    | 'invalid-video-url';
 }
 
 /** S→room when the active controller changes (P3 succession). */

--- a/video-sync-backend/src/shared/sync-core/replay.ts
+++ b/video-sync-backend/src/shared/sync-core/replay.ts
@@ -59,6 +59,17 @@ export function checkTransition(prev: LogEntry, next: LogEntry): string | null {
   if (next.stampedAt < prev.stampedAt) {
     return `stampedAt regressed ${prev.stampedAt} -> ${next.stampedAt}`;
   }
+  if (next.reason === 'set-video') {
+    // the ONE transition allowed to change videoId - and it must land in
+    // the canonical fresh state: paused at 0 (a new video never autoplays)
+    if (next.isPlaying) {
+      return 'set-video committed a playing state';
+    }
+    if (differs(next.mediaTime, 0)) {
+      return `set-video committed mediaTime ${next.mediaTime}, not 0`;
+    }
+    return null;
+  }
   if (next.videoId !== prev.videoId) {
     return `videoId changed mid-epoch (${prev.videoId} -> ${next.videoId})`;
   }

--- a/video-sync-backend/src/shared/sync-core/timeline.ts
+++ b/video-sync-backend/src/shared/sync-core/timeline.ts
@@ -38,6 +38,9 @@ export function isNewer(incoming: Timeline, applied: Timeline | null): boolean {
  *   NOT the projected position — projecting forward would pause at a frame
  *   the presser never saw (P4)
  * - seek: jump to the commanded position, playing state unchanged
+ * - set-video: switch to `videoId`, always paused at 0 — a new video never
+ *   autoplays (P5's spirit: entering fresh state playing surprises every
+ *   participant whose player is still mounting)
  */
 export function applyControl(
   prev: Timeline,
@@ -45,6 +48,8 @@ export function applyControl(
   mediaTime: number,
   serverNow: number,
   by: string,
+  /** set-video only: the room's next videoId (null clears it) */
+  videoId?: string | null,
 ): Omit<Timeline, 'seq'> {
   const base = {
     v: 1 as const,
@@ -65,6 +70,14 @@ export function applyControl(
         isPlaying: prev.isPlaying,
         mediaTime,
         reason: 'seek',
+      };
+    case 'set-video':
+      return {
+        ...base,
+        videoId: videoId ?? null,
+        isPlaying: false,
+        mediaTime: 0,
+        reason: 'set-video',
       };
   }
 }

--- a/video-sync-backend/src/shared/sync-protocol.ts
+++ b/video-sync-backend/src/shared/sync-protocol.ts
@@ -31,7 +31,14 @@ export interface Timeline {
   stampedAt: number;
   /** fixed at 1 in v1; field reserved so the protocol never changes shape */
   rate: 1;
-  reason: 'play' | 'pause' | 'seek' | 'join' | 'snapshot' | 'succession';
+  reason:
+    | 'play'
+    | 'pause'
+    | 'seek'
+    | 'set-video'
+    | 'join'
+    | 'snapshot'
+    | 'succession';
   /** userId of the commander, when reason is a control intent */
   by?: string;
 }
@@ -48,11 +55,12 @@ export interface ClockPong {
   t2: number;
 }
 
-export type ControlIntent = 'play' | 'pause' | 'seek';
+export type ControlIntent = 'play' | 'pause' | 'seek' | 'set-video';
 
 /**
  * C→S control. mediaTime is the position the commander intends:
  * play = start here, pause = freeze at the frame I saw (P4), seek = go here.
+ * set-video ignores mediaTime (the new video always starts paused at 0).
  */
 export interface SyncControl {
   v: 1;
@@ -67,6 +75,21 @@ export interface SyncControl {
    * behavior. Deduped atomically inside the same Lua script as the commit.
    */
   cmdId?: string;
+  /**
+   * set-video payload: the room's next videoUrl ('' clears it). Validated
+   * at the gateway with the same shared admission rule as the REST DTOs.
+   */
+  videoUrl?: string;
+  /**
+   * Fence for position commands (play/pause/seek): the Timeline.videoId
+   * the commander had applied when it minted this command. The store
+   * refuses the command if the room's video has changed since - a seek
+   * aimed at video A must never yank video B (formal/SyncSetVideo.tla,
+   * the nofence config is the counterexample). Optional for wire compat:
+   * a command without it is unfenced, exactly the old behavior. Not sent
+   * on set-video - switching is last-writer-wins by design.
+   */
+  forVideoId?: string | null;
 }
 
 /** S→C error for rejected controls (permission, rate limit, no room). */
@@ -74,7 +97,18 @@ export interface SyncControlRejected {
   v: 1;
   roomCode: string;
   intent: ControlIntent;
-  reason: 'not-controller' | 'rate-limited' | 'room-not-found';
+  /**
+   * stale-video: the command's forVideoId no longer matches the room -
+   * refused, and a targeted sync:timeline re-anchor accompanies this
+   * event, so clients treat it silently (the re-anchor IS the remedy).
+   * invalid-video-url: a set-video whose URL failed the admission rule.
+   */
+  reason:
+    | 'not-controller'
+    | 'rate-limited'
+    | 'room-not-found'
+    | 'stale-video'
+    | 'invalid-video-url';
 }
 
 /** S→room when the active controller changes (P3 succession). */

--- a/video-sync-backend/src/sync/actor-room-state.store.ts
+++ b/video-sync-backend/src/sync/actor-room-state.store.ts
@@ -82,6 +82,8 @@ interface RedisWithActor extends Redis {
     ttlMs: string,
     cmdId: string,
     dedupTtlMs: string,
+    videoFenced: string,
+    forVideoId: string,
   ): Promise<string | null>;
 }
 
@@ -97,6 +99,10 @@ export interface ForwardedControl {
    *  be answered to that socket alone (socket-id rooms span instances via
    *  the adapter) instead of broadcast to the room */
   originSocketId?: string;
+  /** set-video payload: the room's next videoId (null clears it) */
+  videoId?: string | null;
+  /** video fence for position commands; undefined = unfenced */
+  forVideoId?: string | null;
 }
 
 @Injectable()
@@ -267,7 +273,8 @@ export class ActorRoomStateStore
     fence: string,
     next: Omit<Timeline, 'seq'>,
     cmdId?: string,
-  ): Promise<{ timeline: Timeline; dup: boolean } | null> {
+    forVideoId?: string | null,
+  ): Promise<{ timeline: Timeline; dup: boolean; fenced: boolean } | null> {
     const raw = await this.kv.actorCommit(
       this.leaseKey(roomCode),
       this.timelineKey(roomCode),
@@ -287,6 +294,9 @@ export class ActorRoomStateStore
       String(KEY_TTL_MS),
       cmdId ?? '',
       String(CMD_DEDUP_TTL_MS),
+      // '' is the null-videoId encoding, so presence needs its own flag
+      forVideoId !== undefined ? '1' : '0',
+      forVideoId ?? '',
     );
     if (!raw) {
       // fenced out: this instance is a zombie for this room
@@ -296,14 +306,17 @@ export class ActorRoomStateStore
     }
     const parsed = JSON.parse(raw) as Timeline & {
       dup?: true;
+      fenced?: true;
       videoId?: string;
     };
     const committed: Timeline = { ...parsed, videoId: parsed.videoId ?? null };
     const dup = parsed.dup === true;
+    const fenced = parsed.fenced === true;
     delete (committed as Timeline & { dup?: true }).dup;
+    delete (committed as Timeline & { fenced?: true }).fenced;
     const entry = this.owned.get(roomCode);
     if (entry) entry.timeline = committed;
-    return { timeline: committed, dup };
+    return { timeline: committed, dup, fenced };
   }
 
   /**
@@ -333,7 +346,12 @@ export class ActorRoomStateStore
     mediaTime: number,
     serverNow: number,
     by: string,
-    opts?: { cmdId?: string; originSocketId?: string },
+    opts?: {
+      cmdId?: string;
+      originSocketId?: string;
+      videoId?: string | null;
+      forVideoId?: string | null;
+    },
   ): Promise<ApplyOutcome> {
     return this.enqueue(roomCode, () =>
       this.applyControlSerial(roomCode, intent, mediaTime, serverNow, by, opts),
@@ -346,7 +364,12 @@ export class ActorRoomStateStore
     mediaTime: number,
     serverNow: number,
     by: string,
-    opts?: { cmdId?: string; originSocketId?: string },
+    opts?: {
+      cmdId?: string;
+      originSocketId?: string;
+      videoId?: string | null;
+      forVideoId?: string | null;
+    },
   ): Promise<ApplyOutcome> {
     const cmdId = opts?.cmdId;
     const originSocketId = opts?.originSocketId;
@@ -364,6 +387,8 @@ export class ActorRoomStateStore
             by,
             cmdId,
             originSocketId,
+            videoId: opts?.videoId,
+            forVideoId: opts?.forVideoId,
           }),
         );
         if (delivered > 0) return { kind: 'forwarded' };
@@ -395,6 +420,8 @@ export class ActorRoomStateStore
               by,
               cmdId,
               originSocketId,
+              videoId: opts?.videoId,
+              forVideoId: opts?.forVideoId,
             }),
           );
           return second > 0 ? { kind: 'forwarded' } : { kind: 'missing' };
@@ -413,13 +440,30 @@ export class ActorRoomStateStore
     }
 
     // serialize locally against the in-memory timeline, then commit fenced
-    const next = applyControl(entry.timeline, intent, mediaTime, serverNow, by);
-    const committed = await this.commit(roomCode, entry.fence, next, cmdId);
+    const next = applyControl(
+      entry.timeline,
+      intent,
+      mediaTime,
+      serverNow,
+      by,
+      opts?.videoId,
+    );
+    const committed = await this.commit(
+      roomCode,
+      entry.fence,
+      next,
+      cmdId,
+      opts?.forVideoId,
+    );
     if (committed?.dup) {
       // cmdId already applied (possibly by the PREVIOUS owner before a
       // handoff - the record lives in Redis, not owner memory, precisely so
       // it survives that): answer with current state, commit nothing
       return { kind: 'duplicate', timeline: committed.timeline };
+    }
+    if (committed?.fenced) {
+      // observed video no longer current: refused, nothing recorded
+      return { kind: 'fenced', timeline: committed.timeline };
     }
     if (committed) return { kind: 'committed', timeline: committed.timeline };
     // Fenced out: another instance took ownership while we held stale
@@ -433,10 +477,12 @@ export class ActorRoomStateStore
       const retry = await this.commit(
         roomCode,
         nowLease.epoch,
-        applyControl(fresh, intent, mediaTime, serverNow, by),
+        applyControl(fresh, intent, mediaTime, serverNow, by, opts?.videoId),
         cmdId,
+        opts?.forVideoId,
       );
       if (retry?.dup) return { kind: 'duplicate', timeline: retry.timeline };
+      if (retry?.fenced) return { kind: 'fenced', timeline: retry.timeline };
       return retry
         ? { kind: 'committed', timeline: retry.timeline }
         : { kind: 'missing' };
@@ -450,6 +496,8 @@ export class ActorRoomStateStore
         by,
         cmdId,
         originSocketId,
+        videoId: opts?.videoId,
+        forVideoId: opts?.forVideoId,
       }),
     );
     return delivered > 0 ? { kind: 'forwarded' } : { kind: 'missing' };

--- a/video-sync-backend/src/sync/lua/actor_commit.lua
+++ b/video-sync-backend/src/sync/lua/actor_commit.lua
@@ -1,7 +1,9 @@
 -- Fenced commit. KEYS[1]=lease, KEYS[2]=timeline, KEYS[3]=cmd dedup record,
 -- KEYS[4]=append-only command log
 -- ARGV: instanceId, fence, isPlaying, mediaTime, reason, by, videoId,
---       ttlMs, cmdId, dedupTtlMs
+--       ttlMs, cmdId, dedupTtlMs,
+--       videoFenced ('1' makes ARGV[12] meaningful; absent = unfenced),
+--       forVideoId (the video the commander observed, ''-encoded null)
 -- A commit is accepted ONLY if the caller still holds the lease at the fence
 -- it believes it owns. This is the guard a revived zombie fails - the case
 -- the TLA+ spec exists to check (NoStaleFenceWrite).
@@ -13,6 +15,11 @@
 -- one instead of being applied again. The forward publish that delivers
 -- commands to owners can itself be redelivered, which is exactly the
 -- double-apply this closes.
+--
+-- Video fence ordering mirrors apply_control.lua (formal/SyncSetVideo.tla):
+-- dup LOOKUP, then video fence against the STORED timeline (the caller's
+-- in-memory copy may trail a handoff), then commit + dedup RECORD - a
+-- fenced command was never applied and must not burn its id.
 local lease = redis.call('HGETALL', KEYS[1])
 if #lease == 0 then return false end
 local m = {}
@@ -29,21 +36,33 @@ if #cur > 0 then
   -- seq restarts when the fence advances: (epoch, seq) stays ordered
   if c.storeEpoch == ARGV[2] then seq = tonumber(c.seq) + 1 end
 end
+local function answer_current(marker)
+  -- reply with the CURRENT committed state, commit nothing. false is
+  -- reserved for fenced-out-by-lease (the caller drops ownership on it),
+  -- so dup/fenced markers ride the encoded state instead.
+  local out = {
+    v = 1, seq = tonumber(c.seq), storeEpoch = c.storeEpoch,
+    videoId = c.videoId ~= '' and c.videoId or nil,
+    isPlaying = c.isPlaying == '1',
+    mediaTime = tonumber(c.mediaTime), stampedAt = tonumber(c.stampedAt),
+    rate = 1, reason = c.reason, by = c.by ~= '' and c.by or nil,
+  }
+  out[marker] = true
+  return cjson.encode(out)
+end
 if ARGV[9] ~= '' and #cur > 0 then
-  if redis.call('SET', KEYS[3], tostring(seq), 'NX', 'PX', ARGV[10])
-     == false then
-    -- duplicate: answer with the CURRENT committed state, commit nothing.
-    -- false is reserved for fenced-out (the caller drops ownership on it),
-    -- so the dup marker rides the encoded state instead.
-    return cjson.encode({
-      v = 1, seq = tonumber(c.seq), storeEpoch = c.storeEpoch,
-      videoId = c.videoId ~= '' and c.videoId or nil,
-      isPlaying = c.isPlaying == '1',
-      mediaTime = tonumber(c.mediaTime), stampedAt = tonumber(c.stampedAt),
-      rate = 1, reason = c.reason, by = c.by ~= '' and c.by or nil,
-      dup = true,
-    })
+  if redis.call('GET', KEYS[3]) then
+    return answer_current('dup')
   end
+end
+if ARGV[11] == '1' and #cur > 0 then
+  -- position command minted against a video the room no longer shows
+  if (c.videoId or '') ~= ARGV[12] then
+    return answer_current('fenced')
+  end
+end
+if ARGV[9] ~= '' and #cur > 0 then
+  redis.call('SET', KEYS[3], tostring(seq), 'PX', ARGV[10])
 end
 redis.call('HSET', KEYS[2],
   'seq', seq, 'storeEpoch', ARGV[2], 'videoId', ARGV[7],

--- a/video-sync-backend/src/sync/lua/apply_control.lua
+++ b/video-sync-backend/src/sync/lua/apply_control.lua
@@ -1,6 +1,10 @@
 -- KEYS[1]=room:X:tl  KEYS[2]=room:X:cmd:<cmdId> (dedup record; unused when
 -- ARGV[4] is empty)  KEYS[3]=room:X:log (append-only command log)
--- ARGV: intent, mediaTime, by, cmdId, dedupTtlMs
+-- ARGV: intent, mediaTime, by, cmdId, dedupTtlMs,
+--       videoId (set-video's next video, ''-encoded null),
+--       fenced flag ('1' makes ARGV[8] meaningful; nil/absent = unfenced,
+--       which keeps the relay's five-ARGV calls compatible),
+--       forVideoId (the video the commander observed, ''-encoded null)
 --
 -- The idempotency check lives HERE, inside the same atomic script as the
 -- commit, because a check-then-apply split across two round trips is the
@@ -9,31 +13,54 @@
 -- resends an EVAL whose reply was lost on a dropped connection
 -- (autoResendUnfulfilledCommands), and the actor plane's forward publish
 -- can be redelivered - both executed this script twice before this guard.
+--
+-- The ORDER inside the script is load-bearing (formal/SyncSetVideo.tla):
+-- dup LOOKUP, then fence check, then commit + dedup RECORD. Recording
+-- before the fence check burns the id of a command that never applied,
+-- turning its retry into a false "duplicate" (the earlyrecord config's
+-- counterexample). Splitting SET NX into GET + SET is race-free here
+-- because the whole script is one atomic step.
 local tl = load_tl(KEYS[1])
 if tl == nil then return false end
-if ARGV[4] ~= '' then
-  -- SET NX PX: check and record in one step. nil reply = already applied.
-  if redis.call('SET', KEYS[2], tostring(tonumber(tl.seq) + 1),
-                'NX', 'PX', ARGV[5]) == false then
-    -- duplicate: answer with current state, commit nothing. false (not
-    -- nil/false-return) is reserved for "room missing", so the dup marker
-    -- rides the encoded state instead.
-    return encode(tl, true)
+local intent = ARGV[1]
+if ARGV[4] ~= '' and redis.call('GET', KEYS[2]) then
+  -- duplicate: answer with current state, commit nothing. false (not
+  -- nil/false-return) is reserved for "room missing", so the dup marker
+  -- rides the encoded state instead.
+  return encode(tl, 'dup')
+end
+if ARGV[7] == '1' and intent ~= 'set-video' then
+  -- position command minted against a video the room no longer shows: a
+  -- seek aimed at video A must never move video B. set-video itself is
+  -- exempt - it carries no position and switching is last-writer-wins.
+  if (tl.videoId or '') ~= ARGV[8] then
+    return encode(tl, 'fenced')
   end
 end
+if ARGV[4] ~= '' then
+  redis.call('SET', KEYS[2], tostring(tonumber(tl.seq) + 1), 'PX', ARGV[5])
+end
 local now = now_ms()
-local intent = ARGV[1]
 tl.seq = tonumber(tl.seq) + 1
 tl.stampedAt = now
-tl.mediaTime = ARGV[2]
 tl.by = ARGV[3]
 tl.reason = intent
 if intent == 'play' then
   tl.isPlaying = '1'
+  tl.mediaTime = ARGV[2]
 elseif intent == 'pause' then
   tl.isPlaying = '0'
+  tl.mediaTime = ARGV[2]
+elseif intent == 'set-video' then
+  -- always paused at 0: a new video never autoplays (replay.ts holds this
+  -- transition to the same contract)
+  tl.videoId = ARGV[6]
+  tl.isPlaying = '0'
+  tl.mediaTime = '0'
+else
+  -- seek keeps isPlaying as-is
+  tl.mediaTime = ARGV[2]
 end
--- seek keeps isPlaying as-is
 save_tl(KEYS[1], tl, 86400000)
 log_tl(KEYS[3], tl, ARGV[4])
 return encode(tl)

--- a/video-sync-backend/src/sync/lua/common.lua
+++ b/video-sync-backend/src/sync/lua/common.lua
@@ -38,10 +38,13 @@ local function log_tl(logKey, tl, cmdId)
     'cmdId', cmdId or '')
   redis.call('PEXPIRE', logKey, 86400000)
 end
--- dup: set when answering a deduplicated command - the caller replies to
--- the sender with current state but must NOT broadcast (the original
--- commit already did). Stripped before the timeline reaches any client.
-local function encode(tl, dup)
+-- marker: 'dup' when answering a deduplicated command, 'fenced' when a
+-- position command's observed video no longer matches the room's. Both
+-- mean the same to the caller - reply to the sender with current state,
+-- commit nothing, do NOT broadcast - but they are distinct claims: dup
+-- says "this command applied", fenced says "this command never will".
+-- Stripped before the timeline reaches any client.
+local function encode(tl, marker)
   return cjson.encode({
     v = 1, seq = tonumber(tl.seq), storeEpoch = tl.storeEpoch,
     videoId = tl.videoId ~= '' and tl.videoId or nil,
@@ -49,6 +52,7 @@ local function encode(tl, dup)
     mediaTime = tonumber(tl.mediaTime),
     stampedAt = tonumber(tl.stampedAt),
     rate = 1, reason = tl.reason, by = tl.by ~= '' and tl.by or nil,
-    dup = dup or nil,
+    dup = marker == 'dup' or nil,
+    fenced = marker == 'fenced' or nil,
   })
 end

--- a/video-sync-backend/src/sync/redis-room-state.store.spec.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.spec.ts
@@ -243,6 +243,80 @@ describe('RedisRoomStateStore — repair sweep dedup', () => {
     expect(replay.kind).toBe('committed'); // which is why TTL >> redelivery window
   });
 
+  it('set-video commits the new video paused at 0; a stale-fence seek is refused', async () => {
+    if (!available) return;
+    // formal/SyncSetVideo.tla against the real Lua: the seek was minted
+    // while its sender still saw the old video
+    const a = make();
+    const r = `${room}-setvideo`;
+    await playingRoom(a, r);
+
+    const switched = await a.applyControl(r, 'set-video', 0, Date.now(), 'u1', {
+      videoId: 'vid-B',
+    });
+    expect(switched.kind).toBe('committed');
+    const tl = (switched as { timeline: Timeline }).timeline;
+    expect(tl.videoId).toBe('vid-B');
+    expect(tl.isPlaying).toBe(false);
+    expect(tl.mediaTime).toBe(0);
+    expect(tl.reason).toBe('set-video');
+
+    const stale = await a.applyControl(r, 'seek', 2220, Date.now(), 'u2', {
+      cmdId: 'stale-seek',
+      forVideoId: 'vid',
+    });
+    expect(stale.kind).toBe('fenced');
+    // nothing committed; the answer re-anchors with current state
+    expect((stale as { timeline: Timeline }).timeline.seq).toBe(tl.seq);
+    // a matching fence passes
+    const fresh = await a.applyControl(r, 'seek', 1, Date.now(), 'u2', {
+      cmdId: 'fresh-seek',
+      forVideoId: 'vid-B',
+    });
+    expect(fresh.kind).toBe('committed');
+  });
+
+  it('dup lookup precedes the fence; a fenced command never burns its id', async () => {
+    if (!available) return;
+    // both ordering decisions from formal/SyncSetVideo.tla in one trace
+    const a = make();
+    const r = `${room}-fence-order`;
+    await playingRoom(a, r);
+
+    // applied under vid, then the room switches
+    const first = await a.applyControl(r, 'seek', 40, Date.now(), 'u1', {
+      cmdId: 'seek-x',
+      forVideoId: 'vid',
+    });
+    expect(first.kind).toBe('committed');
+    await a.applyControl(r, 'set-video', 0, Date.now(), 'u1', {
+      videoId: 'vid-B',
+    });
+    // retry of an APPLIED command answers duplicate even though its fence
+    // is stale now - dup lookup runs first
+    const retry = await a.applyControl(r, 'seek', 40, Date.now(), 'u1', {
+      cmdId: 'seek-x',
+      forVideoId: 'vid',
+    });
+    expect(retry.kind).toBe('duplicate');
+
+    // a NEVER-applied command is fenced, id not recorded (earlyrecord's
+    // counterexample): after switching back, its retry must apply
+    const fenced = await a.applyControl(r, 'seek', 41, Date.now(), 'u2', {
+      cmdId: 'seek-y',
+      forVideoId: 'vid',
+    });
+    expect(fenced.kind).toBe('fenced');
+    await a.applyControl(r, 'set-video', 0, Date.now(), 'u1', {
+      videoId: 'vid',
+    });
+    const retryY = await a.applyControl(r, 'seek', 41, Date.now(), 'u2', {
+      cmdId: 'seek-y',
+      forVideoId: 'vid',
+    });
+    expect(retryY.kind).toBe('committed');
+  });
+
   it('every commit lands in the append-only log; duplicates never do', async () => {
     if (!available) return;
     const a = make();

--- a/video-sync-backend/src/sync/redis-room-state.store.ts
+++ b/video-sync-backend/src/sync/redis-room-state.store.ts
@@ -43,6 +43,9 @@ interface RedisWithCommands extends Redis {
     by: string,
     cmdId: string,
     dedupTtlMs: string,
+    videoId: string,
+    fenced: string,
+    forVideoId: string,
   ): Promise<string | null>;
   mustardApplySnapshot(
     key: string,
@@ -111,7 +114,12 @@ export class RedisRoomStateStore implements RoomStateStore {
     mediaTime: number,
     _serverNow: number, // stamping happens inside Lua from redis TIME (D6)
     by: string,
-    opts?: { cmdId?: string; originSocketId?: string },
+    opts?: {
+      cmdId?: string;
+      originSocketId?: string;
+      videoId?: string | null;
+      forVideoId?: string | null;
+    },
   ): Promise<ApplyOutcome> {
     const cmdId = opts?.cmdId;
     const result = await this.redis.mustardApplyControl(
@@ -124,19 +132,29 @@ export class RedisRoomStateStore implements RoomStateStore {
       by,
       cmdId ?? '',
       String(CMD_DEDUP_TTL_MS),
+      opts?.videoId ?? '',
+      // '' is the null-videoId encoding, so presence needs its own flag
+      opts?.forVideoId !== undefined ? '1' : '0',
+      opts?.forVideoId ?? '',
     );
     if (result === null) return { kind: 'missing' };
     const raw = JSON.parse(result) as Timeline & {
       dup?: true;
+      fenced?: true;
       videoId?: string;
     };
     // same normalization as parse(): Lua omits empty videoId entirely
     const timeline: Timeline = { ...raw, videoId: raw.videoId ?? null };
+    // dup/fenced markers are script-internal - strip before escape
+    delete (timeline as Timeline & { dup?: true }).dup;
+    delete (timeline as Timeline & { fenced?: true }).fenced;
     if (raw.dup) {
-      // already applied: hand back current state, commit nothing. The dup
-      // marker is script-internal - strip it before the timeline escapes.
-      delete (timeline as Timeline & { dup?: true }).dup;
+      // already applied: hand back current state, commit nothing
       return { kind: 'duplicate', timeline };
+    }
+    if (raw.fenced) {
+      // refused - observed video no longer current; nothing recorded
+      return { kind: 'fenced', timeline };
     }
     return { kind: 'committed', timeline };
   }

--- a/video-sync-backend/src/sync/replay.spec.ts
+++ b/video-sync-backend/src/sync/replay.spec.ts
@@ -41,6 +41,67 @@ describe('append-only log replay contract', () => {
     expect(store.getLog(r)).toHaveLength(2); // init + ONE commit
   });
 
+  it('set-video is the one legal videoId change, held to its own contract', async () => {
+    const store = new InMemoryRoomStateStore();
+    const r = 'replay-setvideo';
+    await store.init(r, 'vid', 0, 1_000);
+    await store.applyControl(r, 'play', 0, 2_000, 'u1', { cmdId: 'c1' });
+    await store.applyControl(r, 'set-video', 0, 3_000, 'u1', {
+      cmdId: 'c2',
+      videoId: 'vid-B',
+    });
+    await store.applyControl(r, 'play', 0, 4_000, 'u1', { cmdId: 'c3' });
+
+    const log = store.getLog(r);
+    const chain = checkChain(log);
+    expect(chain.violations).toEqual([]);
+
+    const base = {
+      storeEpoch: '1000',
+      videoId: 'vid',
+      isPlaying: true,
+      mediaTime: 100,
+      stampedAt: 5_000,
+      by: 'u1',
+    };
+    const prev = { ...base, seq: 3, reason: 'play' };
+    // a set-video that commits playing state, or a nonzero position, breaks
+    // the canonical-fresh-state contract
+    expect(
+      checkTransition(prev, {
+        ...base,
+        seq: 4,
+        reason: 'set-video',
+        videoId: 'vid-B',
+        isPlaying: true,
+        mediaTime: 0,
+        stampedAt: 6_000,
+      }),
+    ).toMatch(/playing state/);
+    expect(
+      checkTransition(prev, {
+        ...base,
+        seq: 4,
+        reason: 'set-video',
+        videoId: 'vid-B',
+        isPlaying: false,
+        mediaTime: 37,
+        stampedAt: 6_000,
+      }),
+    ).toMatch(/not 0/);
+    // any OTHER reason changing videoId is still illegal
+    expect(
+      checkTransition(prev, {
+        ...base,
+        seq: 4,
+        reason: 'seek',
+        videoId: 'vid-B',
+        mediaTime: 200,
+        stampedAt: 6_000,
+      }),
+    ).toMatch(/videoId changed mid-epoch/);
+  });
+
   it('the contract catches what it exists to catch', () => {
     const base = {
       storeEpoch: '1000',

--- a/video-sync-backend/src/sync/room-state.store.spec.ts
+++ b/video-sync-backend/src/sync/room-state.store.spec.ts
@@ -1,0 +1,142 @@
+import { InMemoryRoomStateStore } from './room-state.store';
+import type { Timeline } from '../shared/sync-protocol';
+import { checkChain } from '../shared/sync-core/replay';
+
+/**
+ * Video fencing + set-video on the in-memory store: the same contract the
+ * Lua scripts implement, so CI without Redis exercises the ordering
+ * decisions formal/SyncSetVideo.tla pinned. Each test here is a transcribed
+ * spec trace; the redis spec re-runs the same traces against the real Lua.
+ */
+describe('InMemoryRoomStateStore — set-video and the video fence', () => {
+  const now = 1_700_000_000_000;
+
+  const playingRoom = async (
+    store: InMemoryRoomStateStore,
+    room: string,
+    videoId = 'video-A',
+  ): Promise<Timeline> => {
+    await store.init(room, videoId, 0, now);
+    const played = await store.applyControl(room, 'play', 0, now + 1, 'host');
+    return (played as { timeline: Timeline }).timeline;
+  };
+
+  it('set-video commits the new video in the canonical fresh state: paused at 0', async () => {
+    const store = new InMemoryRoomStateStore();
+    const before = await playingRoom(store, 'r1');
+
+    const out = await store.applyControl(
+      'r1',
+      'set-video',
+      0,
+      now + 2,
+      'host',
+      { videoId: 'video-B' },
+    );
+    expect(out.kind).toBe('committed');
+    const tl = (out as { timeline: Timeline }).timeline;
+    expect(tl.videoId).toBe('video-B');
+    expect(tl.isPlaying).toBe(false);
+    expect(tl.mediaTime).toBe(0);
+    expect(tl.reason).toBe('set-video');
+    expect(tl.seq).toBe(before.seq + 1);
+    // the transition is legal under the replay checker's contract
+    expect(checkChain(store.getLog('r1')).violations).toEqual([]);
+  });
+
+  it('a position command minted against the old video is fenced, not applied', async () => {
+    const store = new InMemoryRoomStateStore();
+    await playingRoom(store, 'r2');
+    await store.applyControl('r2', 'set-video', 0, now + 2, 'host', {
+      videoId: 'video-B',
+    });
+    const current = (await store.get('r2'))!;
+
+    // the seek was minted while its sender still saw video-A
+    const out = await store.applyControl('r2', 'seek', 2220, now + 3, 'u2', {
+      cmdId: 'stale-seek',
+      forVideoId: 'video-A',
+    });
+    expect(out.kind).toBe('fenced');
+    // nothing committed: the answer is the CURRENT state for a re-anchor
+    expect((out as { timeline: Timeline }).timeline.seq).toBe(current.seq);
+    expect((await store.get('r2'))!.seq).toBe(current.seq);
+  });
+
+  it('dup lookup runs BEFORE the fence: an applied command retried after a switch answers duplicate', async () => {
+    const store = new InMemoryRoomStateStore();
+    await playingRoom(store, 'r3');
+
+    const first = await store.applyControl('r3', 'seek', 40, now + 2, 'u1', {
+      cmdId: 'seek-1',
+      forVideoId: 'video-A',
+    });
+    expect(first.kind).toBe('committed');
+
+    await store.applyControl('r3', 'set-video', 0, now + 3, 'host', {
+      videoId: 'video-B',
+    });
+
+    // the retry's fence is stale now - but the command DID apply, and the
+    // truthful answer is duplicate, not stale-video
+    const retry = await store.applyControl('r3', 'seek', 40, now + 4, 'u1', {
+      cmdId: 'seek-1',
+      forVideoId: 'video-A',
+    });
+    expect(retry.kind).toBe('duplicate');
+  });
+
+  it('a fenced command does not burn its id (formal/SyncSetVideo.tla, earlyrecord)', async () => {
+    const store = new InMemoryRoomStateStore();
+    await playingRoom(store, 'r4');
+    await store.applyControl('r4', 'set-video', 0, now + 2, 'host', {
+      videoId: 'video-B',
+    });
+
+    // fenced: minted against video-A, room shows video-B
+    const fenced = await store.applyControl('r4', 'seek', 40, now + 3, 'u1', {
+      cmdId: 'seek-2',
+      forVideoId: 'video-A',
+    });
+    expect(fenced.kind).toBe('fenced');
+
+    // the room switches BACK; the retry of the same id must now APPLY -
+    // an early-recorded id would answer "duplicate" for a command that
+    // never ran
+    await store.applyControl('r4', 'set-video', 0, now + 4, 'host', {
+      videoId: 'video-A',
+    });
+    const retry = await store.applyControl('r4', 'seek', 40, now + 5, 'u1', {
+      cmdId: 'seek-2',
+      forVideoId: 'video-A',
+    });
+    expect(retry.kind).toBe('committed');
+  });
+
+  it('an unfenced command keeps legacy semantics across a switch', async () => {
+    const store = new InMemoryRoomStateStore();
+    await playingRoom(store, 'r5');
+    await store.applyControl('r5', 'set-video', 0, now + 2, 'host', {
+      videoId: 'video-B',
+    });
+    // no forVideoId: wire compat - old clients are never fenced
+    const out = await store.applyControl('r5', 'seek', 40, now + 3, 'u1');
+    expect(out.kind).toBe('committed');
+  });
+
+  it('set-video itself is never fenced: switching is last-writer-wins', async () => {
+    const store = new InMemoryRoomStateStore();
+    await playingRoom(store, 'r6');
+    await store.applyControl('r6', 'set-video', 0, now + 2, 'host', {
+      videoId: 'video-B',
+    });
+    // a second switcher who still saw video-A is not refused - a "stale"
+    // switch is still exactly what its sender meant
+    const out = await store.applyControl('r6', 'set-video', 0, now + 3, 'u2', {
+      videoId: 'video-C',
+      forVideoId: 'video-A',
+    });
+    expect(out.kind).toBe('committed');
+    expect((out as { timeline: Timeline }).timeline.videoId).toBe('video-C');
+  });
+});

--- a/video-sync-backend/src/sync/room-state.store.ts
+++ b/video-sync-backend/src/sync/room-state.store.ts
@@ -33,6 +33,14 @@ export type ApplyOutcome =
    * original commit already did.
    */
   | { kind: 'duplicate'; timeline: Timeline }
+  /**
+   * The command's forVideoId no longer matches the room's video: refused,
+   * nothing committed, cmdId NOT recorded (a fenced command was never
+   * applied, so its retry must not be answered "duplicate" -
+   * formal/SyncSetVideo.tla, the earlyrecord config). `timeline` is the
+   * current state for a targeted re-anchor; do not broadcast.
+   */
+  | { kind: 'fenced'; timeline: Timeline }
   | { kind: 'forwarded' }
   | { kind: 'missing' };
 
@@ -66,7 +74,19 @@ export interface RoomStateStore {
     mediaTime: number,
     serverNow: number,
     by: string,
-    opts?: { cmdId?: string; originSocketId?: string },
+    opts?: {
+      cmdId?: string;
+      originSocketId?: string;
+      /** set-video only: the room's next videoId (null clears it) */
+      videoId?: string | null;
+      /**
+       * Fence for position commands: the videoId the commander observed.
+       * `undefined` = unfenced (wire compat); `null` = observed no video.
+       * Checked AFTER the dup lookup and BEFORE the dedup record, all
+       * atomic with the commit (formal/SyncSetVideo.tla).
+       */
+      forVideoId?: string | null;
+    },
   ): Promise<ApplyOutcome>;
   /** Re-anchor the projection (periodic sweep); returns the committed state. */
   applySnapshot(roomCode: string, serverNow: number): Promise<Timeline | null>;
@@ -130,13 +150,20 @@ export class InMemoryRoomStateStore implements RoomStateStore {
     mediaTime: number,
     serverNow: number,
     by: string,
-    opts?: { cmdId?: string; originSocketId?: string },
+    opts?: {
+      cmdId?: string;
+      originSocketId?: string;
+      videoId?: string | null;
+      forVideoId?: string | null;
+    },
   ): Promise<ApplyOutcome> {
     const cmdId = opts?.cmdId;
     const prev = this.rooms.get(roomCode);
     if (!prev) return Promise.resolve({ kind: 'missing' });
+    const seen = this.cmdSeen.get(roomCode) ?? new Map<string, number>();
     if (cmdId) {
-      const seen = this.cmdSeen.get(roomCode) ?? new Map<string, number>();
+      // dup LOOKUP first: a command that DID apply must answer duplicate
+      // on retry even if the room's video changed since
       // lazy expiry, same effect as PX: an expired record is no record
       for (const [id, expiresAt] of seen) {
         if (expiresAt <= serverNow) seen.delete(id);
@@ -145,11 +172,22 @@ export class InMemoryRoomStateStore implements RoomStateStore {
         this.cmdSeen.set(roomCode, seen);
         return Promise.resolve({ kind: 'duplicate', timeline: prev });
       }
+    }
+    // fence BEFORE the dedup record: a fenced command was never applied
+    // and must not burn its id (formal/SyncSetVideo.tla, earlyrecord)
+    if (
+      opts?.forVideoId !== undefined &&
+      intent !== 'set-video' &&
+      prev.videoId !== opts.forVideoId
+    ) {
+      return Promise.resolve({ kind: 'fenced', timeline: prev });
+    }
+    if (cmdId) {
       seen.set(cmdId, serverNow + CMD_DEDUP_TTL_MS);
       this.cmdSeen.set(roomCode, seen);
     }
     const next: Timeline = {
-      ...applyControl(prev, intent, mediaTime, serverNow, by),
+      ...applyControl(prev, intent, mediaTime, serverNow, by, opts?.videoId),
       seq: prev.seq + 1,
     };
     this.rooms.set(roomCode, next);

--- a/video-sync-backend/src/sync/sync.gateway.ts
+++ b/video-sync-backend/src/sync/sync.gateway.ts
@@ -20,6 +20,10 @@ import {
   SyncControl,
 } from '../shared/sync-protocol';
 import { ClockDomainService } from '../redis/clock-domain.service';
+import {
+  VIDEO_URL_MAX_LEN,
+  isAcceptableVideoUrl,
+} from '../shared/media-source';
 import { MetricsService } from '../metrics/metrics.service';
 import { TimelineService } from './timeline.service';
 import { ActorRoomStateStore } from './actor-room-state.store';
@@ -34,6 +38,7 @@ const CONTROL_INTENTS: ReadonlyArray<SyncControl['intent']> = [
   'play',
   'pause',
   'seek',
+  'set-video',
 ];
 
 interface RoomData {
@@ -85,15 +90,21 @@ export class SyncGateway
           this.clock.now(),
           c.cmdId,
           c.originSocketId,
+          c.videoId,
+          c.forVideoId,
         );
         if (!result.ok || !result.timeline) return;
-        if ('duplicate' in result) {
-          // the forward was redelivered (or the command retried): the
-          // original commit already broadcast. Answer ONLY the originating
-          // socket - socket-id rooms span instances via the adapter, so
-          // this reaches it wherever it is connected. Broadcasting here
-          // would turn retry traffic into room-wide updates.
-          this.metrics.controlDedupHits.inc({ type: c.intent });
+        if ('duplicate' in result || 'fenced' in result) {
+          // duplicate: the forward was redelivered (or the command
+          // retried) and the original commit already broadcast. fenced:
+          // the observed video is stale and nothing committed. Either way
+          // the answer is a re-anchor to ONLY the originating socket -
+          // socket-id rooms span instances via the adapter, so this
+          // reaches it wherever it is connected. Broadcasting here would
+          // turn retry/refusal traffic into room-wide updates.
+          if ('duplicate' in result) {
+            this.metrics.controlDedupHits.inc({ type: c.intent });
+          }
           if (c.originSocketId) {
             this.server
               .to(c.originSocketId)
@@ -359,7 +370,13 @@ export class SyncGateway
         (typeof data.cmdId !== 'string' ||
           data.cmdId.length === 0 ||
           data.cmdId.length > 64 ||
-          !/^[A-Za-z0-9_-]+$/.test(data.cmdId)))
+          !/^[A-Za-z0-9_-]+$/.test(data.cmdId))) ||
+      // the fence is compared against the stored videoId, never stored
+      // itself, but an unbounded string is still not allowed on the wire
+      (data.forVideoId !== undefined &&
+        data.forVideoId !== null &&
+        (typeof data.forVideoId !== 'string' ||
+          data.forVideoId.length > VIDEO_URL_MAX_LEN))
     ) {
       client.emit(SYNC_EVENTS.controlRejected, {
         v: 1,
@@ -369,6 +386,30 @@ export class SyncGateway
       });
       stop();
       return;
+    }
+    // set-video carries the room's next videoUrl; it must pass the SAME
+    // admission rule as the REST DTOs (shared/media-source.ts) - the
+    // timeline rides every broadcast, so this bounds store and wire.
+    // '' stays admitted as "clear the video".
+    let nextVideoId: string | null | undefined;
+    if (data.intent === 'set-video') {
+      const url =
+        typeof data.videoUrl === 'string' ? data.videoUrl.trim() : null;
+      if (url === null || (url !== '' && !isAcceptableVideoUrl(url))) {
+        this.metrics.controlEvents.inc({
+          type: data.intent,
+          result: 'rejected_invalid_video_url',
+        });
+        client.emit(SYNC_EVENTS.controlRejected, {
+          v: 1,
+          roomCode: data.roomCode,
+          intent: data.intent,
+          reason: 'invalid-video-url',
+        });
+        stop();
+        return;
+      }
+      nextVideoId = url === '' ? null : url;
     }
     const userId = (client.data as AuthedSocketData).userId;
     // membership, not just authentication: without this any authenticated
@@ -396,6 +437,8 @@ export class SyncGateway
       this.clock.now(),
       data.cmdId,
       client.id,
+      nextVideoId,
+      data.forVideoId,
     );
     if (!result.ok) {
       this.metrics.controlEvents.inc({
@@ -430,6 +473,25 @@ export class SyncGateway
         result: 'duplicate',
       });
       client.emit(SYNC_EVENTS.timeline, result.timeline);
+      stop();
+      return;
+    }
+    if ('fenced' in result) {
+      // the command's observed video is no longer the room's: refused,
+      // nothing committed (formal/SyncSetVideo.tla). The re-anchor is the
+      // remedy - it carries the set-video the sender missed; the rejection
+      // event is informational and clients keep it silent.
+      this.metrics.controlEvents.inc({
+        type: data.intent,
+        result: 'fenced_stale_video',
+      });
+      client.emit(SYNC_EVENTS.timeline, result.timeline);
+      client.emit(SYNC_EVENTS.controlRejected, {
+        v: 1,
+        roomCode: data.roomCode,
+        intent: data.intent,
+        reason: 'stale-video',
+      });
       stop();
       return;
     }

--- a/video-sync-backend/src/sync/timeline.service.ts
+++ b/video-sync-backend/src/sync/timeline.service.ts
@@ -12,6 +12,12 @@ export type ControlResult =
    * to the sender - the original commit already broadcast to the room.
    */
   | { ok: true; timeline: Timeline; duplicate: true }
+  /**
+   * refused: the command's forVideoId no longer matches the room's video
+   * (formal/SyncSetVideo.tla). `timeline` is current state for a TARGETED
+   * re-anchor to the sender; nothing was committed, nothing broadcasts.
+   */
+  | { ok: true; timeline: Timeline; fenced: true }
   /** the actor plane forwarded this intent; the room's owner broadcasts it */
   | { ok: true; timeline: null; forwarded: true }
   | { ok: false; reason: 'not-controller' | 'rate-limited' | 'room-not-found' };
@@ -146,6 +152,10 @@ export class TimelineService {
     /** the true originating socket; differs from socketId on the owner's
      *  side of a forward, where socketId is synthetic */
     originSocketId?: string,
+    /** set-video only: the room's next videoId (null clears it) */
+    videoId?: string | null,
+    /** video fence for position commands; undefined = unfenced */
+    forVideoId?: string | null,
   ): Promise<ControlResult> {
     const meta = this.meta.get(roomCode);
     if (!meta) return { ok: false, reason: 'room-not-found' };
@@ -161,7 +171,7 @@ export class TimelineService {
       mediaTime,
       now,
       userId,
-      { cmdId, originSocketId },
+      { cmdId, originSocketId, videoId, forVideoId },
     );
     if (outcome.kind === 'missing')
       return { ok: false, reason: 'room-not-found' };
@@ -171,6 +181,10 @@ export class TimelineService {
     if (outcome.kind === 'duplicate') {
       // nothing new was committed, so nothing to persist or broadcast
       return { ok: true, timeline: outcome.timeline, duplicate: true };
+    }
+    if (outcome.kind === 'fenced') {
+      // refused, nothing committed: targeted re-anchor only
+      return { ok: true, timeline: outcome.timeline, fenced: true };
     }
     this.schedulePersist(roomCode);
     return { ok: true, timeline: outcome.timeline };
@@ -297,6 +311,10 @@ export class TimelineService {
         data: {
           currentTime: projectMediaTime(tl, now),
           isPlaying: tl.isPlaying,
+          // the timeline is the authority for the room's video once
+          // set-video exists; persisting it keeps rehydration and the REST
+          // reads converging on what the room actually shows
+          videoUrl: tl.videoId,
           lastSyncAt: new Date(now),
         },
       });

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.test.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.test.tsx
@@ -1,11 +1,33 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { EnhancedVideoPlayer } from './EnhancedVideoPlayer';
 
-// The shell only needs the socket surface; a null socket keeps the sync
-// engine dormant so these tests exercise mount selection, not sync.
+// A null socket keeps the sync engine dormant, so most tests exercise mount
+// selection alone; the set-video test installs a socket and drives the
+// mocked engine's status stream instead.
+let mockSocket: unknown = null;
 jest.mock('../contexts/SocketContext', () => ({
-  useSocket: () => ({ socket: null, connected: false }),
+  useSocket: () => ({ socket: mockSocket, connected: false }),
+}));
+
+// captures the shell's onStatus listener so tests can push engine status
+const mockEngineState: { push: ((s: unknown) => void) | null } = {
+  push: null,
+};
+jest.mock('../sync/SyncEngine', () => ({
+  SyncEngine: class {
+    start() {}
+    dispose() {}
+    attachAdapter() {}
+    setEnabled() {}
+    sendIntent() {}
+    resumeFromGesture() {}
+    onStatus(cb: (s: unknown) => void) {
+      mockEngineState.push = cb;
+      return () => {};
+    }
+  },
+  sendSetVideo: jest.fn(),
 }));
 
 // jsdom has no AudioContext; the probe's own behavior is measured by the
@@ -37,6 +59,11 @@ jest.mock('@vimeo/player', () => ({
 
 const renderPlayer = (videoUrl: string) =>
   render(<EnhancedVideoPlayer videoUrl={videoUrl} roomCode="TEST01" isHost />);
+
+afterEach(() => {
+  mockSocket = null;
+  mockEngineState.push = null;
+});
 
 test('empty videoUrl shows the no-video card, no controls', () => {
   renderPlayer('');
@@ -82,6 +109,48 @@ test('a Vimeo URL mounts the Vimeo player with controls', () => {
   renderPlayer('https://vimeo.com/76979871');
   expect(screen.getByTestId('vimeo-mount')).toBeInTheDocument();
   expect(screen.getByTestId('play-button')).toBeInTheDocument();
+});
+
+test('a set-video timeline overrides the room prop: this client switches too', () => {
+  // socket present -> the (mocked) engine runs and its status drives the shell
+  mockSocket = { on: jest.fn(), off: jest.fn(), emit: jest.fn(), connected: true };
+  renderPlayer('https://www.youtube.com/watch?v=aqz-KE-bpKQ');
+  expect(document.getElementById('youtube-player')).toBeInTheDocument();
+
+  // the sync:timeline broadcast lands with a different video: the timeline
+  // is the authority, the stale room-row prop no longer decides the mount
+  act(() => {
+    mockEngineState.push!({
+      timeline: {
+        v: 1,
+        seq: 5,
+        storeEpoch: '1000',
+        videoId: 'https://cdn.example.com/movie.mp4',
+        isPlaying: false,
+        mediaTime: 0,
+        stampedAt: 1000,
+        rate: 1,
+        reason: 'set-video',
+      },
+      roomPlaying: false,
+      projectedS: 0,
+      durationS: 0,
+      driftMs: 0,
+      offsetMs: 0,
+      uncertaintyMs: Infinity,
+      rttMs: NaN,
+      ctrlState: 'LOCKED',
+      seq: 5,
+      fractionalRateOK: false,
+      needsGesture: false,
+      seeksIssued: 0,
+    });
+  });
+  expect(screen.getByTestId('html5-video')).toHaveAttribute(
+    'src',
+    'https://cdn.example.com/movie.mp4',
+  );
+  expect(document.getElementById('youtube-player')).toBeNull();
 });
 
 test('a hostile scheme never reaches a media element', () => {

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -302,10 +302,20 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
   const adapterRef = useRef<EngineAdapter | null>(null);
   const canControl = isHost || allowGuestControl;
 
-  const source = useMemo(() => classifyMediaSource(videoUrl), [videoUrl]);
+  // Which video the room is showing: the TIMELINE is the authority once one
+  // exists - set-video switches every participant through sync:timeline -
+  // and the room row's URL only covers the gap before the first timeline
+  // arrives. Both originate from the same store, so the handover is a
+  // no-op unless a switch actually happened.
+  const activeVideoUrl =
+    status.timeline !== null ? status.timeline.videoId ?? '' : videoUrl;
+  const source = useMemo(
+    () => classifyMediaSource(activeVideoUrl),
+    [activeVideoUrl],
+  );
 
   // a failure belongs to one attempted source; the next video starts clean
-  useEffect(() => setFailure(null), [videoUrl]);
+  useEffect(() => setFailure(null), [activeVideoUrl]);
 
   // Engine lifecycle: starts with the socket (before the player is ready, so
   // no room-joined timeline is ever missed) and adopts the adapter later.
@@ -327,7 +337,13 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
           icon: '👑',
           duration: 2000,
         });
+      } else if (r.reason === 'invalid-video-url') {
+        toast.error('That video URL was refused by the server', {
+          duration: 3000,
+        });
       }
+      // 'stale-video' stays silent by design: the targeted re-anchor that
+      // accompanies it already switches this client to the video it missed
     };
     socket.on(SYNC_EVENTS.controlRejected, onRejected);
 
@@ -419,7 +435,7 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
       <FailureCard
         title="Couldn't play this video"
         detail={failure}
-        url={videoUrl}
+        url={activeVideoUrl}
       />
     );
   } else {
@@ -469,7 +485,7 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
             <FailureCard
               title="This video URL can't be played"
               detail="It isn't an http(s) video link a player could fetch."
-              url={videoUrl}
+              url={activeVideoUrl}
             />
           );
         break;

--- a/video-sync-frontend/src/components/RoomSettings.tsx
+++ b/video-sync-frontend/src/components/RoomSettings.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import styled from '@emotion/styled';
-import { apiService } from '../services/api';
 import { toast } from 'react-hot-toast';
+import { useSocket } from '../contexts/SocketContext';
+import { isAcceptableVideoUrl } from '../shared/media-source';
+import { sendSetVideo } from '../sync/SyncEngine';
 
 const SettingsContainer = styled.div`
   background: #f5f5f5;
@@ -127,20 +129,31 @@ export const RoomSettings: React.FC<RoomSettingsProps> = ({ room, onClose, onUpd
   const [maxUsers, setMaxUsers] = useState(room.maxUsers || 20);
   const [videoUrl, setVideoUrl] = useState(room.videoUrl || '');
   const [loading, setLoading] = useState(false);
+  const { socket } = useSocket();
 
-  const handleUpdateSettings = async () => {
-    setLoading(true);
-    try {
-      await apiService.updateRoom(room.code, {
-        videoUrl,
-      });
-      toast.success('Room settings updated!');
-      if (onUpdate) onUpdate();
-    } catch (error) {
-      toast.error('Failed to update settings');
-    } finally {
-      setLoading(false);
+  const handleUpdateSettings = () => {
+    // Changing the video is a SYNCED CONTROL, not a REST write: everyone in
+    // the room switches together through the sync:timeline broadcast, with
+    // the same exactly-once machinery as play/pause/seek. The server
+    // persists the room row from the committed timeline.
+    const url = videoUrl.trim();
+    if (url !== '' && !isAcceptableVideoUrl(url)) {
+      // the same shared rule the gateway enforces - refused here it is
+      // instant feedback instead of a rejected control
+      toast.error("That URL can't be played - use a video link or YouTube id");
+      return;
     }
+    setLoading(true);
+    if (socket !== null && sendSetVideo(socket, room.code, url)) {
+      // wait-for-broadcast: the player switches when sync:timeline arrives
+      toast.success('Video changed for everyone in the room');
+      if (onUpdate) onUpdate();
+    } else {
+      // dropped, never buffered: a stale reconnect flush must not change
+      // the room's video minutes later
+      toast.error('Not connected - try again in a moment');
+    }
+    setLoading(false);
   };
 
   const handleEndRoom = async () => {

--- a/video-sync-frontend/src/pages/CreateRoomPage.tsx
+++ b/video-sync-frontend/src/pages/CreateRoomPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { apiService } from '../services/api';
 import { toast } from 'react-hot-toast';
 import styled from '@emotion/styled';
+import { isAcceptableVideoUrl } from '../shared/media-source';
 
 const Container = styled.div`
   max-width: 700px;
@@ -304,11 +305,19 @@ export const CreateRoomPage: React.FC = () => {
       return;
     }
 
+    // the same shared admission rule the backend DTO enforces - refused
+    // here it is instant feedback instead of a 400
+    const videoUrl = formData.videoUrl.trim();
+    if (videoUrl && !isAcceptableVideoUrl(videoUrl)) {
+      toast.error("That URL can't be played - use a video link or YouTube id");
+      return;
+    }
+
     setLoading(true);
     try {
       const response = await apiService.createRoom({
         name: formData.name,
-        videoUrl: formData.videoUrl || undefined,
+        videoUrl: videoUrl || undefined,
         userId: user.id,
         isPublic: formData.isPublic,
         description: formData.isPublic ? formData.description : undefined,

--- a/video-sync-frontend/src/shared/sync-core/replay.ts
+++ b/video-sync-frontend/src/shared/sync-core/replay.ts
@@ -59,6 +59,17 @@ export function checkTransition(prev: LogEntry, next: LogEntry): string | null {
   if (next.stampedAt < prev.stampedAt) {
     return `stampedAt regressed ${prev.stampedAt} -> ${next.stampedAt}`;
   }
+  if (next.reason === 'set-video') {
+    // the ONE transition allowed to change videoId - and it must land in
+    // the canonical fresh state: paused at 0 (a new video never autoplays)
+    if (next.isPlaying) {
+      return 'set-video committed a playing state';
+    }
+    if (differs(next.mediaTime, 0)) {
+      return `set-video committed mediaTime ${next.mediaTime}, not 0`;
+    }
+    return null;
+  }
   if (next.videoId !== prev.videoId) {
     return `videoId changed mid-epoch (${prev.videoId} -> ${next.videoId})`;
   }

--- a/video-sync-frontend/src/shared/sync-core/timeline.ts
+++ b/video-sync-frontend/src/shared/sync-core/timeline.ts
@@ -38,6 +38,9 @@ export function isNewer(incoming: Timeline, applied: Timeline | null): boolean {
  *   NOT the projected position — projecting forward would pause at a frame
  *   the presser never saw (P4)
  * - seek: jump to the commanded position, playing state unchanged
+ * - set-video: switch to `videoId`, always paused at 0 — a new video never
+ *   autoplays (P5's spirit: entering fresh state playing surprises every
+ *   participant whose player is still mounting)
  */
 export function applyControl(
   prev: Timeline,
@@ -45,6 +48,8 @@ export function applyControl(
   mediaTime: number,
   serverNow: number,
   by: string,
+  /** set-video only: the room's next videoId (null clears it) */
+  videoId?: string | null,
 ): Omit<Timeline, 'seq'> {
   const base = {
     v: 1 as const,
@@ -65,6 +70,14 @@ export function applyControl(
         isPlaying: prev.isPlaying,
         mediaTime,
         reason: 'seek',
+      };
+    case 'set-video':
+      return {
+        ...base,
+        videoId: videoId ?? null,
+        isPlaying: false,
+        mediaTime: 0,
+        reason: 'set-video',
       };
   }
 }

--- a/video-sync-frontend/src/shared/sync-protocol.ts
+++ b/video-sync-frontend/src/shared/sync-protocol.ts
@@ -31,7 +31,14 @@ export interface Timeline {
   stampedAt: number;
   /** fixed at 1 in v1; field reserved so the protocol never changes shape */
   rate: 1;
-  reason: 'play' | 'pause' | 'seek' | 'join' | 'snapshot' | 'succession';
+  reason:
+    | 'play'
+    | 'pause'
+    | 'seek'
+    | 'set-video'
+    | 'join'
+    | 'snapshot'
+    | 'succession';
   /** userId of the commander, when reason is a control intent */
   by?: string;
 }
@@ -48,11 +55,12 @@ export interface ClockPong {
   t2: number;
 }
 
-export type ControlIntent = 'play' | 'pause' | 'seek';
+export type ControlIntent = 'play' | 'pause' | 'seek' | 'set-video';
 
 /**
  * C→S control. mediaTime is the position the commander intends:
  * play = start here, pause = freeze at the frame I saw (P4), seek = go here.
+ * set-video ignores mediaTime (the new video always starts paused at 0).
  */
 export interface SyncControl {
   v: 1;
@@ -67,6 +75,21 @@ export interface SyncControl {
    * behavior. Deduped atomically inside the same Lua script as the commit.
    */
   cmdId?: string;
+  /**
+   * set-video payload: the room's next videoUrl ('' clears it). Validated
+   * at the gateway with the same shared admission rule as the REST DTOs.
+   */
+  videoUrl?: string;
+  /**
+   * Fence for position commands (play/pause/seek): the Timeline.videoId
+   * the commander had applied when it minted this command. The store
+   * refuses the command if the room's video has changed since - a seek
+   * aimed at video A must never yank video B (formal/SyncSetVideo.tla,
+   * the nofence config is the counterexample). Optional for wire compat:
+   * a command without it is unfenced, exactly the old behavior. Not sent
+   * on set-video - switching is last-writer-wins by design.
+   */
+  forVideoId?: string | null;
 }
 
 /** S→C error for rejected controls (permission, rate limit, no room). */
@@ -74,7 +97,18 @@ export interface SyncControlRejected {
   v: 1;
   roomCode: string;
   intent: ControlIntent;
-  reason: 'not-controller' | 'rate-limited' | 'room-not-found';
+  /**
+   * stale-video: the command's forVideoId no longer matches the room -
+   * refused, and a targeted sync:timeline re-anchor accompanies this
+   * event, so clients treat it silently (the re-anchor IS the remedy).
+   * invalid-video-url: a set-video whose URL failed the admission rule.
+   */
+  reason:
+    | 'not-controller'
+    | 'rate-limited'
+    | 'room-not-found'
+    | 'stale-video'
+    | 'invalid-video-url';
 }
 
 /** S→room when the active controller changes (P3 succession). */

--- a/video-sync-frontend/src/sync/SyncEngine.fence.test.ts
+++ b/video-sync-frontend/src/sync/SyncEngine.fence.test.ts
@@ -1,0 +1,108 @@
+import { SyncEngine, sendSetVideo } from './SyncEngine';
+import { SYNC_EVENTS, Timeline } from '../shared/sync-protocol';
+
+/**
+ * The client half of the video fence (formal/SyncSetVideo.tla): every
+ * position command carries the videoId this client had APPLIED when the
+ * gesture happened, so a command aimed at the old video dies at the store
+ * instead of moving the new one.
+ */
+
+let uuidCounter = 0;
+beforeAll(() => {
+  // jsdom ships no crypto global at all
+  const g = globalThis as { crypto?: { randomUUID?: () => string } };
+  if (!g.crypto) g.crypto = {};
+  if (!g.crypto.randomUUID) {
+    g.crypto.randomUUID = () => `test-uuid-${uuidCounter++}`;
+  }
+});
+
+interface FakeSocket {
+  connected: boolean;
+  emit: jest.Mock;
+  on: jest.Mock;
+  off: jest.Mock;
+}
+
+const makeSocket = (): { socket: FakeSocket; handlers: Map<string, Function> } => {
+  const handlers = new Map<string, Function>();
+  const socket: FakeSocket = {
+    connected: true,
+    emit: jest.fn(),
+    on: jest.fn((event: string, cb: Function) => handlers.set(event, cb)),
+    off: jest.fn(),
+  };
+  return { socket, handlers };
+};
+
+const timeline = (videoId: string | null, seq: number): Timeline => ({
+  v: 1,
+  seq,
+  storeEpoch: '1000',
+  videoId,
+  isPlaying: false,
+  mediaTime: 0,
+  stampedAt: 1000,
+  rate: 1,
+  reason: 'join',
+});
+
+const controlsSent = (socket: FakeSocket): Array<Record<string, unknown>> =>
+  socket.emit.mock.calls
+    .filter(([event]) => event === SYNC_EVENTS.control)
+    .map(([, payload]) => payload as Record<string, unknown>);
+
+describe('SyncEngine video fence', () => {
+  let engine: SyncEngine | null = null;
+  afterEach(() => {
+    engine?.dispose();
+    engine = null;
+  });
+
+  it('a command before the first timeline is unfenced (wire compat)', () => {
+    const { socket } = makeSocket();
+    engine = new SyncEngine(socket as never, 'ROOM01');
+    engine.start();
+    engine.sendIntent('play', 5);
+    const [cmd] = controlsSent(socket);
+    expect(cmd.intent).toBe('play');
+    expect('forVideoId' in cmd).toBe(false);
+  });
+
+  it('a command after a timeline carries the applied videoId as its fence', () => {
+    const { socket, handlers } = makeSocket();
+    engine = new SyncEngine(socket as never, 'ROOM01');
+    engine.start();
+    handlers.get(SYNC_EVENTS.timeline)!(timeline('vid-A', 1));
+    engine.sendIntent('seek', 37);
+    const [cmd] = controlsSent(socket);
+    expect(cmd.forVideoId).toBe('vid-A');
+
+    // a set-video broadcast moves the fence with it
+    handlers.get(SYNC_EVENTS.timeline)!({
+      ...timeline('vid-B', 2),
+      reason: 'set-video',
+    });
+    engine.sendIntent('pause', 0);
+    expect(controlsSent(socket)[1].forVideoId).toBe('vid-B');
+  });
+
+  it('sendSetVideo emits the switch and never buffers while disconnected', () => {
+    const { socket } = makeSocket();
+    expect(
+      sendSetVideo(socket as never, 'ROOM01', 'https://vimeo.com/76979871'),
+    ).toBe(true);
+    const [cmd] = controlsSent(socket);
+    expect(cmd.intent).toBe('set-video');
+    expect(cmd.videoUrl).toBe('https://vimeo.com/76979871');
+    expect(cmd.mediaTime).toBe(0);
+    expect(typeof cmd.cmdId).toBe('string');
+    // set-video is deliberately unfenced: switching is last-writer-wins
+    expect('forVideoId' in cmd).toBe(false);
+
+    socket.connected = false;
+    expect(sendSetVideo(socket as never, 'ROOM01', 'x')).toBe(false);
+    expect(controlsSent(socket)).toHaveLength(1);
+  });
+});

--- a/video-sync-frontend/src/sync/SyncEngine.ts
+++ b/video-sync-frontend/src/sync/SyncEngine.ts
@@ -148,6 +148,13 @@ export class SyncEngine {
       // idempotency key: the store applies each id at most once, so a
       // redelivered copy re-anchors the sender instead of re-committing
       cmdId: crypto.randomUUID(),
+      // video fence: the videoId this client had applied when the gesture
+      // happened. If a set-video lands first, the store refuses this
+      // command instead of letting it move the new video, and answers
+      // with the timeline the sender is missing
+      // (formal/SyncSetVideo.tla). Absent before the first timeline:
+      // unfenced, the legacy semantics.
+      ...(this.timeline !== null ? { forVideoId: this.timeline.videoId } : {}),
     });
   }
 
@@ -348,4 +355,32 @@ export class SyncEngine {
     this.telemetry.uninstall();
     this.listeners.clear();
   }
+}
+
+/**
+ * Change the room's video for everyone. A standalone function rather than
+ * an engine method because its caller is the settings form, which lives
+ * outside the player that owns the engine - but the protocol assembly and
+ * the no-buffering rule stay in THIS file, next to sendIntent's.
+ *
+ * Wait-for-broadcast like every control: the local player switches when
+ * sync:timeline says so. NOT fenced - switching is last-writer-wins by
+ * design (formal/SyncSetVideo.tla). Returns false when disconnected: the
+ * command is dropped, never buffered, and the caller should say so.
+ */
+export function sendSetVideo(
+  socket: Socket,
+  roomCode: string,
+  videoUrl: string,
+): boolean {
+  if (!socket.connected) return false;
+  socket.emit(SYNC_EVENTS.control, {
+    v: 1,
+    roomCode,
+    intent: 'set-video',
+    mediaTime: 0,
+    videoUrl,
+    cmdId: crypto.randomUUID(),
+  });
+  return true;
 }


### PR DESCRIPTION
Step 6 of the multi-source player program, stacked on #35 — and the one the
whole stack was building toward: changing the room's video is now a synced
control. Same exactly-once machinery as play/pause/seek, committed by the
store, broadcast on `sync:timeline`; every participant switches together
into the canonical fresh state (paused at 0 — a new video never autoplays).

## The spec came first: `formal/SyncSetVideo.tla`

The hazard none of the existing specs covered: a position command is minted
against a *particular* video. If the room switches while it is in flight, a
well-formed, authorized, exactly-once-delivered seek still yanks everyone
to minute 37 of a video they just started. The command's *precondition*
silently changed — delivery guarantees can't see that.

**Mechanism:** every position command carries the videoId its minter had
applied (`forVideoId`); the store refuses a stale fence atomically with the
commit and answers with the current timeline — the re-anchor IS the remedy,
so the client handles `stale-video` silently. set-video itself is
deliberately unfenced: it carries no position, and a "stale" switch is
still exactly what its sender meant.

**The ordering inside the atomic script is the load-bearing decision:**
dup LOOKUP, then fence check, then commit + dedup RECORD.

| config | result |
|---|---|
| `SyncSetVideo.cfg` | green: `NoCrossVideoApply`, `AtMostOnce`, `DupAnswerImpliesApplied` (7,185 distinct states) |
| `SyncSetVideo_live.cfg` | green: `EventuallyAnswered` — fencing rejects, never strands |
| `SyncSetVideo_nofence.cfg` | fails `NoCrossVideoApply` as designed: the in-flight seek moves the switched video |
| `SyncSetVideo_earlyrecord.cfg` | fails `DupAnswerImpliesApplied` as designed: recording the id before the fence burns a never-applied command's id; after a switch back, its retry answers "duplicate" — a claimed apply that never happened |

The earlyrecord counterexample is why `apply_control.lua` and
`actor_commit.lua` split their former `SET NX` into GET → fence → SET
(race-free: the whole script is one atomic step). All four configs run in
the nightly with the exact-named-property assertion pattern. FORMAL.md
documents the spec, including the property that is deliberately absent
("a fenced command never applies later" is NOT an invariant — a retry
in flight when the answer lands may legally apply after a switch back).

## Implementation, store to screen

- **Protocol:** `set-video` intent with a `videoUrl` payload validated by
  the same shared admission rule as the REST DTOs (the gateway is the
  classifier's third consumer); `forVideoId` fence, optional for wire
  compat — old clients stay unfenced, the cmdId pattern again.
- **Transition contract:** `set-video` is the ONE legal mid-epoch videoId
  change, and the replay checker holds it to paused-at-0. The command log
  reconciliation from #28 covers switches with no changes.
- **All three stores** (in-memory, Redis Lua, actor plane) implement the
  fence with the spec's ordering. On the actor plane the fence checks the
  STORED timeline, not the owner's in-memory copy, which may trail a
  handoff; forwards carry the new fields.
- **Persistence:** the room row's `videoUrl` now converges from the
  committed timeline, so rehydration and REST reads agree with what the
  room actually shows.
- **Client:** the engine stamps every position command with its applied
  videoId; the shell mounts whatever the TIMELINE says once one exists
  (the room-row prop only covers the pre-join gap); the settings form
  sends the control — validated locally for instant feedback, dropped
  (never buffered) when disconnected, matching the no-buffering rule the
  dedup TTL's soundness rests on.
- **relay-go: zero changes.** Its five-ARGV calls leave the fence flag
  absent, which Lua reads as unfenced legacy semantics — and the
  `videoId or ''` hardening from #31 covers the nil that a relay commit
  would otherwise hit.

Tests transcribe the spec traces against both the in-memory store and the
real Lua: fenced refusal, dup-lookup-before-fence (an applied command
retried after a switch answers duplicate), fence-never-burns-id (the
earlyrecord trace), unfenced legacy compat, set-video exemption. Backend
121 green (Redis suite included), frontend 26 green, `tsc`/lint/CI build
clean on both packages.