### PR TITLE
feat: harness source provenance — HARNESS_VIDEO_URL classifies-or-dies

### DIFF
--- a/docs/RELAY.md
+++ b/docs/RELAY.md
@@ -30,6 +30,16 @@ passes the key into the same `apply_control.lua`, so both planes dedup
 identically — verified by the `--dup-controls` conformance run (4 injected
 duplicates, 0 double-applies, on this plane's binary framing).
 
+The relay does NOT speak `set-video` or the video fence
+(`docs/SYNC_DESIGN.md` §2c): its binary control frame carries only
+play/pause/seek, and its five-ARGV `apply_control.lua` calls leave the
+fence flag absent — which the Lua reads as *unfenced*, the legacy
+semantics old Node clients get too. Deliberate: the shared Lua evolves,
+the relay's calls stay valid, and nothing on this plane changed when
+set-video landed. Relay clients in a room whose video switches keep
+following the timeline (the `videoId` field has always ridden every
+broadcast); they just cannot initiate a switch.
+
 *(10 bots × 120s each, re-measured after the simulated-player fix described
 in `docs/SYNC_DESIGN.md` §8. **[lab]** — these two fleet runs were not
 committed; the table is reproducible from the harness, not citable.)*

--- a/docs/SYNC_DESIGN.md
+++ b/docs/SYNC_DESIGN.md
@@ -152,6 +152,39 @@ truncation is legal, holes are not. Deduplicated deliveries never append:
 the log records **commits, not deliveries**. The nightly runs the
 reconciler over the 50-bot fleet's actual traffic, gated.
 
+## 2c. set-video, and fencing position commands by video
+
+Changing the room's video is a control (`set-video`), not a REST write:
+committed by the store with the §2a machinery, broadcast on
+`sync:timeline`, every participant switches together into the canonical
+fresh state — **paused at 0** (a new video never autoplays; the log
+contract of §2b holds `set-video` to exactly that, and it is the one
+transition allowed to change `videoId` mid-epoch). The room row's
+`videoUrl` is persisted *from* the committed timeline, so REST reads and
+rehydration converge on what the room actually shows.
+
+Exactly-once delivery is not enough here, because a position command's
+correctness depends on a **precondition**: which video it was about. A
+seek to minute 37 of video A, in flight while someone switches the room to
+video B, arrives well-formed, authorized, deduplicated — and yanks
+everyone to minute 37 of the wrong video. So every position command
+carries the `videoId` its sender had applied (`forVideoId`), and the store
+refuses a stale fence *atomically with the commit*, answering the sender
+with the current timeline — the re-anchor it was missing is the remedy, so
+the `stale-video` rejection stays silent on the client.
+
+Two ordering decisions inside the atomic script are model-checked
+(`formal/SyncSetVideo.tla`, FORMAL.md): the dup **lookup** precedes the
+fence (an applied command retried after a switch is truthfully a
+duplicate), and the dedup **record** follows it (a fenced command was
+never applied, and recording its id would turn a later retry into a
+claimed apply that never happened — the `earlyrecord` counterexample,
+which is why the Lua's former `SET NX` became GET → fence → SET).
+`set-video` itself is unfenced: it carries no position, and a "stale"
+switch is still exactly what its sender meant. Unfenced commands (older
+clients, the relay's binary frames) keep legacy semantics — the field is
+optional on the wire, the same compatibility pattern as `cmdId`.
+
 ## 3. Clock sync
 
 NTP-style over a Socket.IO ack: client stamps t0/t3, the server ack carries
@@ -246,11 +279,13 @@ threshold and then seeking.
 ## 6. Protocol
 
 Five events: `sync:clock` (ack: `{t0}`→`{t0,t1,t2}`), `sync:control`
-(`{roomCode, intent, mediaTime, cmdId?}` — the optional idempotency key of
-§2a; identity comes only from the JWT-verified socket), `sync:timeline`
-(the only state message), `sync:control-rejected`
-(`not-controller` / `rate-limited` / `room-not-found`), `room:controller`
-(succession/reclaim). A 10s server sweep re-anchors playing rooms as the
+(`{roomCode, intent, mediaTime, cmdId?, videoUrl?, forVideoId?}` —
+`cmdId` is §2a's optional idempotency key, `videoUrl` is `set-video`'s
+payload admitted by the same shared rule as the REST DTOs, `forVideoId`
+is §2c's optional video fence; identity comes only from the JWT-verified
+socket), `sync:timeline` (the only state message), `sync:control-rejected`
+(`not-controller` / `rate-limited` / `room-not-found` / `stale-video` /
+`invalid-video-url`), `room:controller` (succession/reclaim). A 10s server sweep re-anchors playing rooms as the
 repair channel for lost broadcasts; redundancy is harmless because clients
 order by `(storeEpoch, seq)`.
 

--- a/scripts/make-hls-fixture.sh
+++ b/scripts/make-hls-fixture.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Segment the clicktrack fixture (scripts/make-clicktrack.sh) into a
+# same-origin VOD HLS rendition for the source matrix's hls arm. Stream-
+# copied, so the rendition is byte-derived from its source; like the
+# clicktrack itself, it is generated rather than committed
+# (public/media/ is gitignored) and THIS script is the provenance.
+# Same-origin keeps the hls arm audio-truth eligible.
+set -e
+SRC="${1:-../video-sync-frontend/public/media/clicktrack.mp4}"
+OUT_DIR="$(dirname "$SRC")/hls"
+if [ ! -f "$SRC" ]; then
+  echo "missing $SRC - run scripts/make-clicktrack.sh first" >&2
+  exit 1
+fi
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+ffmpeg -y -loglevel error -i "$SRC" \
+  -c copy -hls_time 6 -hls_playlist_type vod \
+  -hls_segment_filename "$OUT_DIR/clicktrack%03d.ts" \
+  "$OUT_DIR/clicktrack.m3u8"
+echo "wrote $OUT_DIR ($(du -sh "$OUT_DIR" | cut -f1))"

--- a/sync-harness/src/report.ts
+++ b/sync-harness/src/report.ts
@@ -85,7 +85,7 @@ ${meta.scenario.title}
 
 - git SHA: \`${meta.gitSha}\`
 - started: ${meta.startedAt}
-- clients: ${meta.clients} · video: \`${meta.videoId}\` · ws: \`${meta.wsUrl}\`
+- clients: ${meta.clients} · video: \`${meta.videoId}\` (${meta.videoSource ?? 'youtube'}) · ws: \`${meta.wsUrl}\`
 - hardware: ${meta.hardware}
 
 ## Pairwise |drift| (steady-state windows)

--- a/sync-harness/src/run-scenario.ts
+++ b/sync-harness/src/run-scenario.ts
@@ -13,7 +13,13 @@ import {
   waitForShim,
   type HarnessClient,
 } from './browser.js';
-import { SCENARIOS, TEST_VIDEO_ID, TEST_VIDEO_URL, TIMELINE } from './scenarios.js';
+import {
+  SCENARIOS,
+  TEST_VIDEO_ID,
+  TEST_VIDEO_SOURCE,
+  TEST_VIDEO_URL,
+  TIMELINE,
+} from './scenarios.js';
 import { computeStats } from './stats.js';
 import { applyLatency, resetProxy, toxiproxyUp, TOXIPROXY_LISTEN_PORT } from './toxiproxy.js';
 import { writeRun } from './report.js';
@@ -169,6 +175,8 @@ async function runScenario(s: ScenarioSpec, attempt = 1): Promise<boolean> {
       startedAt: new Date(scenarioStart).toISOString(),
       clients: N_CLIENTS,
       videoId: TEST_VIDEO_ID,
+      videoUrl: TEST_VIDEO_URL,
+      videoSource: TEST_VIDEO_SOURCE.kind,
       wsUrl,
       hardware: `${hostname()} · ${process.arch} · node ${process.version}`,
       engine: ENGINE,

--- a/sync-harness/src/scenarios.ts
+++ b/sync-harness/src/scenarios.ts
@@ -1,4 +1,9 @@
 import type { ScenarioSpec } from './types.js';
+import {
+  classifyMediaSource,
+  isAcceptableVideoUrl,
+  type MediaSource,
+} from '../../shared/media-source';
 
 // Impairment values are ONE-WAY, PER-DIRECTION delays. A netem `delay X` on
 // the proxy container applies to both legs of every round trip, so it adds
@@ -104,5 +109,37 @@ export const TIMELINE = {
 
 // Big Buck Bunny, Blender Foundation's official upload: CC-BY, embeddable,
 // low-monetization, strong audio transients (also suits the M10 audio pass).
-export const TEST_VIDEO_ID = 'aqz-KE-bpKQ';
-export const TEST_VIDEO_URL = `https://www.youtube.com/watch?v=${TEST_VIDEO_ID}`;
+const DEFAULT_VIDEO_URL = 'https://www.youtube.com/watch?v=aqz-KE-bpKQ';
+
+/**
+ * The video a run measures. HARNESS_VIDEO_URL selects the source arm for
+ * the source matrix (file/hls/vimeo instead of the default YouTube), and
+ * it is classified HERE, once, with the same shared rule the app enforces:
+ * a URL the app would refuse dies at startup with the classification in
+ * the error - not forty minutes into a run as a black-frame measurement
+ * of nothing.
+ */
+export const TEST_VIDEO_URL =
+  process.env.HARNESS_VIDEO_URL ?? DEFAULT_VIDEO_URL;
+const classified = classifyMediaSource(TEST_VIDEO_URL);
+// the ADMISSION rule, not just classification: the player attempts
+// admissible-but-unknown URLs and fails visibly, which for a measurement
+// run means forty minutes of black frames - so the harness refuses at
+// startup everything the app would refuse at the door, plus nothing else
+if (!isAcceptableVideoUrl(TEST_VIDEO_URL) || classified.kind === 'none') {
+  throw new Error(
+    `HARNESS_VIDEO_URL fails the app's admission rule: "${TEST_VIDEO_URL}"`,
+  );
+}
+export const TEST_VIDEO_SOURCE: Exclude<MediaSource, { kind: 'none' }> =
+  classified;
+
+/**
+ * Provider id where one exists, the raw URL otherwise - what RunMeta
+ * stamps as videoId. Derived from the classification instead of hardcoded
+ * so the stamp can never disagree with what the run actually played.
+ */
+export const TEST_VIDEO_ID =
+  TEST_VIDEO_SOURCE.kind === 'youtube' || TEST_VIDEO_SOURCE.kind === 'vimeo'
+    ? TEST_VIDEO_SOURCE.videoId
+    : TEST_VIDEO_URL;

--- a/sync-harness/src/types.ts
+++ b/sync-harness/src/types.ts
@@ -55,7 +55,18 @@ export interface RunMeta {
   gitSha: string;
   startedAt: string;
   clients: number;
+  /** provider id where one exists, the raw URL otherwise; derived from
+   *  the classification, never hardcoded */
   videoId: string;
+  /** the exact URL the run measured (HARNESS_VIDEO_URL or the default).
+   *  Optional: runs committed before the source matrix lack it. */
+  videoUrl?: string;
+  /** classifier verdict for videoUrl - the source arm this run measured.
+   *  Optional for the same historical reason; absent means youtube.
+   *  ('none' cannot occur: the harness classifies-or-dies at startup.)
+   *  Inline union, not shared/media-source's MediaSource['kind']: this
+   *  file is deliberately dependency-free (see header). */
+  videoSource?: 'youtube' | 'vimeo' | 'hls' | 'file';
   wsUrl: string;
   hardware: string;
   engine: 'baseline' | 'overhauled';


### PR DESCRIPTION
Step 7's plumbing, stacked on #36. The measurement harness can now run the
matrix against any source arm the player supports.

- **`HARNESS_VIDEO_URL` classify-or-die.** The run's video is validated at
  startup with the *same shared admission rule the app enforces* — a URL
  the app would refuse dies immediately with the classification in the
  error, not forty minutes into a run as a black-frame measurement of
  nothing. Smoke-checked across the arms: bare id → youtube, `.m3u8` →
  hls, `vimeo.com/<id>` → vimeo, `/media/…` → file; garbage dies.
- **Provenance on `RunMeta`.** `videoUrl` (the exact URL measured) and
  `videoSource` (the classifier's verdict) are stamped on every run, and
  `videoId` is now *derived* from the classification instead of hardcoded —
  the stamp can never disagree with what the run actually played. Both new
  fields are optional in the type because committed historical runs lack
  them (absent = youtube); reports render the source with that default.
- **Docs (code-derived only).** SYNC_DESIGN gains §2c — set-video as a
  control, why exactly-once delivery is not enough when a command's
  *precondition* is which video it was about, and the two model-checked
  orderings inside the atomic apply — plus the updated protocol section.
  RELAY.md records that the relay plane deliberately stays fence-free:
  its five-ARGV Lua calls read as unfenced legacy semantics, so nothing
  changed cross-plane; relay clients follow a switch via the timeline but
  cannot initiate one.

**Deliberately absent:** the five source-matrix runs (file S0+S2, hls
S0+S2, vimeo S0) and the README support matrix. Runs get committed under
`docs/measurements/sources/` with provenance against *merged* SHAs — a
number stamped against a stack that review may still mutate would be
invalidated by any rebase — so they follow as the final PR once this stack
lands. `HARNESS_OUT=../docs/measurements/sources` already routes the output
with no further code.

Harness `tsc` clean; no app code touched.