### PR TITLE
fix: both fixture generators resolve paths from their own location

### DIFF
--- a/docs/measurements/sources/README.md
+++ b/docs/measurements/sources/README.md
@@ -15,8 +15,10 @@ the main matrix; `meta.json` in each run stamps the URL measured
 | `S2-overhauled-msjpaix6` | hls | S2 | 7 / 18 / 25ms | 2,273 |
 | `S0-overhauled-msjpgb9o` | vimeo (`vimeo.com/1084537`) | S0 | 8 / 38 / 125ms | 2,280 |
 
-Fixtures are generated, not committed (`public/media/` is gitignored):
-`sync-harness/scripts/make-clicktrack.sh` then `make-hls-fixture.sh`. The
+Fixtures are generated, not committed (`public/media/` is gitignored) -
+both scripts resolve their paths from their own location, so from the
+repository root:
+`sync-harness/scripts/make-clicktrack.sh && sync-harness/scripts/make-hls-fixture.sh`. The
 Vimeo arm plays Blender's official Big Buck Bunny upload — the same
 content as the YouTube arm, so the comparison compares players, not
 videos. The Vimeo player's own CDN traffic goes direct and unimpaired,

--- a/sync-harness/scripts/make-clicktrack.sh
+++ b/sync-harness/scripts/make-clicktrack.sh
@@ -4,7 +4,10 @@
 # which is what lets the page tap its own audio graph (a cross-origin
 # YouTube iframe cannot be tapped, and that is the whole reason this exists).
 set -e
-OUT="${1:-../video-sync-frontend/public/media/clicktrack.mp4}"
+# default output resolved from the script's own location - runnable from
+# any CWD, same contract as make-hls-fixture.sh
+HERE="$(cd "$(dirname "$0")" && pwd)"
+OUT="${1:-$HERE/../../video-sync-frontend/public/media/clicktrack.mp4}"
 mkdir -p "$(dirname "$OUT")"
 ffmpeg -y -loglevel error \
   -f lavfi -i "color=c=black:s=640x360:r=30:d=300" \


### PR DESCRIPTION
Closes the remaining CodeRabbit finding from #40 (the one without an
addressed-marker). `make-hls-fixture.sh` got the CWD-independence fix in
ab3c654, but its sibling `make-clicktrack.sh` kept a CWD-relative default
output — run from anywhere but `sync-harness/`, `mkdir -p` would write a
stray `video-sync-frontend/` tree wherever you happened to stand. Both
generators now resolve their defaults from their own location (verified
from the repo root and from `/tmp`), and the sources README gives exact
repo-relative invocations instead of bare script names.