### PR TITLE
fix: stop serving password hashes to anyone who knows a room code

### DIFF
--- a/video-sync-backend/src/rooms/rooms.service.spec.ts
+++ b/video-sync-backend/src/rooms/rooms.service.spec.ts
@@ -1,0 +1,142 @@
+import { RoomsService } from './rooms.service';
+import { DatabaseService } from '../database/database.service';
+
+/**
+ * The rule this file exists to enforce: a query that reaches a client must
+ * never ask Prisma for a User relation WHOLESALE.
+ *
+ * Prisma returns every scalar of a relation pulled with
+ * `include: { creator: true }` - and User.password is a scalar. That is how
+ * GET /api/rooms/:code came to hand any caller holding a room code the
+ * creator's bcrypt hash and email, in production, unauthenticated. The bug
+ * is invisible at the call site: nothing in `include: { creator: true }`
+ * mentions a password.
+ *
+ * So the assertion is on the QUERY, not the response. Asserting on a
+ * response proves nothing here - the response is whatever the mock returns.
+ * Asserting on the arguments proves the service asked the database to
+ * narrow, which is the only thing that actually protects the field.
+ */
+
+/** Every User scalar that must never be requested for somebody else. */
+const FORBIDDEN_USER_FIELDS = ['password', 'email'];
+
+/**
+ * Walk a Prisma query argument tree and collect every violation: a user
+ * relation included wholesale (`true`), or narrowed by a select that still
+ * asks for a forbidden field.
+ */
+function violations(node: unknown, path: string[] = []): string[] {
+  if (node === null || typeof node !== 'object') return [];
+  const found: string[] = [];
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    const here = [...path, key];
+    const isUserRelation = key === 'creator' || key === 'user';
+
+    if (isUserRelation) {
+      if (value === true) {
+        found.push(
+          `${here.join('.')}: included wholesale (pulls every User scalar, password included)`,
+        );
+        continue;
+      }
+      if (value && typeof value === 'object') {
+        const select = (value as { select?: Record<string, unknown> }).select;
+        if (!select) {
+          found.push(`${here.join('.')}: no select (pulls every User scalar)`);
+        } else {
+          for (const field of FORBIDDEN_USER_FIELDS) {
+            if (select[field]) {
+              found.push(`${here.join('.')}.select.${field}: requested`);
+            }
+          }
+        }
+      }
+    }
+    found.push(...violations(value, here));
+  }
+  return found;
+}
+
+describe("RoomsService - no query hands a client another user's secrets", () => {
+  const room = {
+    id: 'room-1',
+    code: 'CODE1',
+    creatorId: 'user-1',
+    participants: [],
+  };
+
+  /** Records the argument every Prisma call receives so we can inspect it. */
+  const calls: Array<{ op: string; args: unknown }> = [];
+  const record = (op: string, result: unknown) => (args: unknown) => {
+    calls.push({ op, args });
+    return Promise.resolve(result);
+  };
+
+  const database = {
+    room: {
+      findUnique: jest.fn(record('room.findUnique', room)),
+      findMany: jest.fn(record('room.findMany', [room])),
+      create: jest.fn(record('room.create', room)),
+      update: jest.fn(record('room.update', room)),
+      delete: jest.fn(record('room.delete', room)),
+    },
+    participant: {
+      findMany: jest.fn(record('participant.findMany', [])),
+      updateMany: jest.fn(record('participant.updateMany', { count: 0 })),
+      deleteMany: jest.fn(record('participant.deleteMany', { count: 0 })),
+    },
+    chatMessage: {
+      findMany: jest.fn(record('chatMessage.findMany', [])),
+      deleteMany: jest.fn(record('chatMessage.deleteMany', { count: 0 })),
+    },
+    syncEvent: {
+      deleteMany: jest.fn(record('syncEvent.deleteMany', { count: 0 })),
+    },
+  } as unknown as DatabaseService;
+
+  const service = new RoomsService(database);
+
+  beforeEach(() => {
+    calls.length = 0;
+  });
+
+  const readPaths: Array<[string, () => Promise<unknown>]> = [
+    ['getRoomByCode', () => service.getRoomByCode('CODE1')],
+    ['getPublicRooms', () => service.getPublicRooms()],
+    ['getUserRooms', () => service.getUserRooms('user-1')],
+    [
+      'createRoom',
+      () => service.createRoom('user-1', 'a room', undefined, false),
+    ],
+  ];
+
+  it.each(readPaths)(
+    "%s never requests another user's password or email",
+    async (_name, run) => {
+      await run().catch(() => undefined); // shape of the call is the assertion
+      expect(calls.length).toBeGreaterThan(0);
+      const found = calls.flatMap((c) =>
+        violations(c.args).map((v) => `${c.op} -> ${v}`),
+      );
+      expect(found).toEqual([]);
+    },
+  );
+
+  it('the guard itself catches the bug that shipped', () => {
+    // the exact shape that leaked in production, so a future refactor that
+    // reintroduces it fails here rather than in the wild
+    expect(violations({ include: { creator: true } })).toEqual([
+      'include.creator: included wholesale (pulls every User scalar, password included)',
+    ]);
+    expect(
+      violations({ include: { user: { select: { id: true, email: true } } } }),
+    ).toEqual(['include.user.select.email: requested']);
+    // and does not fire on the narrowed form we want everywhere
+    expect(
+      violations({
+        include: { creator: { select: { id: true, username: true } } },
+      }),
+    ).toEqual([]);
+  });
+});

--- a/video-sync-backend/src/rooms/rooms.service.ts
+++ b/video-sync-backend/src/rooms/rooms.service.ts
@@ -37,8 +37,20 @@ export class RoomsService {
   async getRoomByCode(code: string) {
     const room = await this.database.room.findUnique({
       where: { code },
+      // Narrowed on purpose, and the narrowing is load-bearing. Prisma
+      // returns EVERY scalar of a relation pulled with `creator: true` -
+      // and User.password is a scalar, so that shape served the creator's
+      // bcrypt hash to any caller holding a room code, unauthenticated,
+      // in production. Participant emails went the same way. Nothing
+      // renders either field: the UI shows a host name and participant
+      // names. rooms.service.spec.ts fails if this ever widens again.
       include: {
-        creator: true,
+        creator: {
+          select: {
+            id: true,
+            username: true,
+          },
+        },
         participants: {
           where: { isActive: true },
           include: {
@@ -46,7 +58,6 @@ export class RoomsService {
               select: {
                 id: true,
                 username: true,
-                email: true,
               },
             },
           },


### PR DESCRIPTION
`GET /api/rooms/:code` loaded the room's creator with
`include: { creator: true }`. Prisma returns **every scalar** of a
relation pulled that way, and `User.password` is a scalar — so the
response body carried the creator's bcrypt hash and email. The same
query also asked for `email: true` on every active participant.

No guard sits in front of the route and no serializer sits behind it, so
the audience was **any unauthenticated caller holding a room code** — and
`GET /api/rooms/public` hands out codes, which makes the prerequisite
nothing at all for public rooms.

Verified against production before fixing (throwaway room, since deleted):

```
creator fields returned -> ['createdAt','email','id','password','updatedAt','username']
PASSWORD HASH EXPOSED: YES  ($2b$10$…)
```

## The fix, and why it ships with an unusual test

Both User relations in that query are narrowed to `{ id, username }` —
the shape `deleteRoom`, `getPublicRooms`, `getUserRooms`, and the sync
gateway already use. Nothing in the UI reads the removed fields (the
frontend renders a host name and participant names), so no consumer
changes.

The dangerous part of this bug is that **the call site gave no hint** —
nothing in `creator: true` mentions a password. So the regression test
asserts on **query shape, not response**: a mocked response proves
nothing, while the arguments prove the service asked the database to
narrow. It walks each client-reaching query and fails on a User relation
included wholesale or a `select` that still asks for `password`/`email`,
and it pins the exact shape that leaked. Reverting the fix turns it red:

```
room.findUnique -> include.creator: included wholesale (pulls every User scalar, password included)
room.findUnique -> include.participants.include.user.select.email: requested
```

## Scope

Audited every Prisma query in the backend (3 parallel auditors +
adversarial verification). This one query was the only leak:
the sync gateway already narrows to `{id, username}`, and
`auth.service`'s full-row loads never leave the service — they exist for
`bcrypt.compare` and an existence check.

## What this does not fix

The underlying reason this was reachable: **there are no auth guards on
the REST API at all**, and endpoints trust a client-supplied `userId`. A
token-less `DELETE /api/rooms/…` reaches the room lookup and returns 404,
not 401. That is the next piece of work, and it is bigger than this one.

## Operational note

These hashes and emails were served to unauthenticated callers and may
sit in logs, proxy caches, and browser caches. Treat affected users'
passwords as disclosed — for this app that is a small, mostly-throwaway
user set, but the call is yours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room data privacy by limiting creator information to IDs and usernames.
  * Removed participant email addresses from room responses.
  * Prevented sensitive account details, including password hashes and emails, from being retrieved or exposed.
* **Tests**
  * Added security coverage to verify room queries avoid loading sensitive user fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->