### PR TITLE
feat: the REST API now has authorization, not just the socket plane

### DIFF
--- a/sync-harness/src/app-api.ts
+++ b/sync-harness/src/app-api.ts
@@ -9,14 +9,23 @@ export interface HarnessUser {
   id: string;
   username: string;
   email: string;
-  /** JWT for the socket handshake (issued at register/login) */
-  token?: string;
+  /**
+   * JWT proving this identity. One token, two planes: the socket handshake
+   * (sync/ws-auth.ts) and now every REST call too. The server derives the
+   * actor from this token — the harness no longer *tells* it who it is.
+   */
+  token: string;
 }
 
-async function post<T>(path: string, body: unknown): Promise<T> {
+/** Bearer header for the REST plane; omitted entirely when no token. */
+function authHeaders(token?: string): Record<string, string> {
+  return token ? { authorization: `Bearer ${token}` } : {};
+}
+
+export async function post<T>(path: string, body: unknown, token?: string): Promise<T> {
   const res = await fetch(`${apiBase()}${path}`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...authHeaders(token) },
     body: JSON.stringify(body),
   });
   if (!res.ok) {
@@ -25,14 +34,20 @@ async function post<T>(path: string, body: unknown): Promise<T> {
   return (await res.json()) as T;
 }
 
+
 export async function registerUser(runId: string, index: number): Promise<HarnessUser> {
   const username = `harness-${runId}-${index}`;
+  // register mints the token; it is the one endpoint that cannot require one
   const user = await post<HarnessUser>('/auth/register', {
     username,
     email: `${username}@harness.invalid`,
     password: `harness-${runId}`,
   });
   if (!user.id) throw new Error(`register returned no id: ${JSON.stringify(user)}`);
+  // Every downstream call — REST and socket — is authenticated with this
+  // token, so a tokenless registration has to fail HERE. Otherwise it
+  // surfaces later as an unexplained 401 from whatever ran next.
+  if (!user.token) throw new Error(`register returned no token: ${JSON.stringify(user)}`);
   return user;
 }
 
@@ -41,13 +56,21 @@ export async function createRoom(
   runId: string,
   videoUrl: string,
 ): Promise<{ code: string; id: string }> {
-  const room = await post<{ code: string; id: string }>('/rooms', {
-    name: `harness ${runId}`,
-    videoUrl,
-    userId: creator.id,
-    isPublic: false,
-    allowGuestControl: false,
-  });
+  if (!creator.token) {
+    throw new Error(`createRoom needs ${creator.username}'s token: POST /rooms is authenticated`);
+  }
+  // No userId in the body: ownership comes from the bearer token. Sending a
+  // creator id here would be exactly the forgeable claim the guard removes.
+  const room = await post<{ code: string; id: string }>(
+    '/rooms',
+    {
+      name: `harness ${runId}`,
+      videoUrl,
+      isPublic: false,
+      allowGuestControl: false,
+    },
+    creator.token,
+  );
   if (!room.code) throw new Error(`createRoom returned no code: ${JSON.stringify(room)}`);
   return room;
 }

--- a/sync-harness/src/bots/bench-planes.ts
+++ b/sync-harness/src/bots/bench-planes.ts
@@ -67,8 +67,8 @@ const sampleTimeline = {
 const sioBytes = Buffer.byteLength(`42${JSON.stringify(['sync:timeline', sampleTimeline])}`);
 console.log(`timeline broadcast wire size: socket.io/JSON=${sioBytes}B binary=31B (${(sioBytes / 31).toFixed(1)}x)`);
 
-await bench('node/socket.io', new SocketIOTransport('http://localhost:3000'), user.token ?? '');
-await bench('relay-go/binary', new RawWSBinaryTransport('http://localhost:3400'), user.token ?? '');
+await bench('node/socket.io', new SocketIOTransport('http://localhost:3000'), user.token);
+await bench('relay-go/binary', new RawWSBinaryTransport('http://localhost:3400'), user.token);
 if (anyInvalid) {
   // a plane that timed out is not comparable to one that did not; exiting
   // non-zero stops an invalid comparison being quoted as a result

--- a/sync-harness/src/bots/bot-client.ts
+++ b/sync-harness/src/bots/bot-client.ts
@@ -161,7 +161,7 @@ export class BotClient {
           this.rejoinFailures += 1;
         });
     });
-    await this.transport.connect(this.user.token ?? '');
+    await this.transport.connect(this.user.token);
   }
 
   async join(roomCode: string): Promise<void> {

--- a/sync-harness/src/browser.ts
+++ b/sync-harness/src/browser.ts
@@ -40,7 +40,11 @@ export async function openClient(
 ): Promise<HarnessClient> {
   const context = await browser.newContext({ viewport: { width: 500, height: 400 } });
   // AuthContext reads localStorage.user; seeding it skips the login UI so
-  // joins are deterministic and fast.
+  // joins are deterministic and fast. The seeded object MUST carry `token`:
+  // the app's axios interceptor reads it from exactly here to authenticate
+  // REST calls (room fetch, create, delete), so a token-less seed logs the
+  // client in visually and then 401s on the first request. registerUser
+  // guarantees the field is present.
   await context.addInitScript((u) => {
     window.localStorage.setItem('user', JSON.stringify(u));
   }, user);

--- a/sync-harness/src/verify-m3.ts
+++ b/sync-harness/src/verify-m3.ts
@@ -59,9 +59,9 @@ function once<T>(socket: Socket, event: string, timeoutMs = 4000): Promise<T> {
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 // ---------- fixtures ----------
-const creator: HarnessUser & { token?: string } = await registerUser(runId, 0);
-const guest: HarnessUser & { token?: string } = await registerUser(runId, 1);
-const late: HarnessUser & { token?: string } = await registerUser(runId, 2);
+const creator: HarnessUser = await registerUser(runId, 0);
+const guest: HarnessUser = await registerUser(runId, 1);
+const late: HarnessUser = await registerUser(runId, 2);
 const room = await createRoom(creator, runId, 'https://www.youtube.com/watch?v=aqz-KE-bpKQ');
 
 // 1. unauthenticated rejected

--- a/sync-harness/src/verify-m6.ts
+++ b/sync-harness/src/verify-m6.ts
@@ -22,10 +22,16 @@ function check(name: string, ok: boolean, detail = ''): void {
   if (!ok) failures += 1;
 }
 
-async function post<T>(base: string, path: string, body: unknown): Promise<T> {
+// Local driver (not app-api's) because the lab's REST plane is a fixed
+// nginx address, not the env-driven one. Same auth rule though: the REST
+// endpoints are bearer-authenticated, identity comes from the token.
+async function post<T>(base: string, path: string, body: unknown, token?: string): Promise<T> {
   const res = await fetch(`${base}/api${path}`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: {
+      'content-type': 'application/json',
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
     body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`POST ${path}: ${res.status} ${await res.text()}`);
@@ -92,11 +98,17 @@ const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms
 
 // ---- fixtures: users on distinct instances ----
 const users = await Promise.all([register(0), register(1), register(2)]);
-const room = await post<{ code: string }>(NGINX, '/rooms', {
-  name: `lab ${runId}`,
-  videoUrl: 'https://www.youtube.com/watch?v=aqz-KE-bpKQ',
-  userId: users[0].id,
-});
+// users[0] owns the room by virtue of the token the request carries — the
+// checks below rely on that ownership (only the creator may control).
+const room = await post<{ code: string }>(
+  NGINX,
+  '/rooms',
+  {
+    name: `lab ${runId}`,
+    videoUrl: 'https://www.youtube.com/watch?v=aqz-KE-bpKQ',
+  },
+  users[0].token,
+);
 
 const sockA = await connect(B[0], users[0]); // creator on instance 1
 const sockB = await connect(B[1], users[1]); // follower on instance 2

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,18 @@
+{
+  "services": {
+    "mustard-watch-party-backend": {
+      "root": "video-sync-backend",
+      "entrypoint": "src/main.ts",
+      "buildCommand": "npm ci --include=dev && npm run build"
+    }
+  },
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": {
+        "type": "service",
+        "service": "mustard-watch-party-backend"
+      }
+    }
+  ]
+}

--- a/video-sync-backend/src/auth/current-user.decorator.ts
+++ b/video-sync-backend/src/auth/current-user.decorator.ts
@@ -1,0 +1,37 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { AuthedRequest } from './jwt-auth.guard';
+import type { AuthedUser } from './token-payload';
+
+/**
+ * The verified caller, as derived by JwtAuthGuard.
+ *
+ *   @CurrentUser() user: AuthedUser      -> { userId, username }
+ *   @CurrentUser('userId') id: string    -> just the id
+ *
+ * Throws if no identity is on the request, which can only mean the route
+ * forgot @UseGuards(JwtAuthGuard). That is a wiring bug, and it fails loudly
+ * here rather than handing a handler `undefined` to write into creatorId.
+ */
+export const CurrentUser = createParamDecorator(currentUser);
+
+/**
+ * The decorator's body, exported so it can be tested directly -
+ * createParamDecorator hides the factory behind route metadata otherwise.
+ */
+export function currentUser(
+  field: keyof AuthedUser | undefined,
+  context: ExecutionContext,
+): AuthedUser | string {
+  const request = context.switchToHttp().getRequest<AuthedRequest>();
+  const user = request.user;
+  if (!user) {
+    throw new UnauthorizedException(
+      'No authenticated user on this request (route is missing JwtAuthGuard)',
+    );
+  }
+  return field ? user[field] : user;
+}

--- a/video-sync-backend/src/auth/jwt-auth.guard.spec.ts
+++ b/video-sync-backend/src/auth/jwt-auth.guard.spec.ts
@@ -1,0 +1,188 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { JwtService, JwtSignOptions } from '@nestjs/jwt';
+import type { Socket } from 'socket.io';
+import { AuthedRequest, JwtAuthGuard } from './jwt-auth.guard';
+import { currentUser } from './current-user.decorator';
+import type { TokenPayload } from './token-payload';
+import { wsAuthMiddleware, AuthedSocketData } from '../sync/ws-auth';
+
+/**
+ * The REST plane had ZERO guards: every endpoint took the caller's word for
+ * who they were (a userId in the body, or in the path). This guard is the
+ * fix, and these tests pin the two things that make it a fix rather than a
+ * formality:
+ *
+ *   1. every way of NOT presenting a valid token is a 401 - missing header,
+ *      malformed header, foreign signature, expired token, subject-less
+ *      payload. A guard that only rejects the empty case is a speed bump.
+ *   2. the identity it attaches is the token's, and it is the SAME identity
+ *      the WebSocket handshake derives from the same token (last test).
+ */
+
+const SECRET = 'test-secret-not-production';
+const OTHER_SECRET = 'a-different-secret';
+
+const jwt = new JwtService({ secret: SECRET });
+const guard = new JwtAuthGuard(jwt);
+
+/** A request carrying whatever Authorization header the test wants. */
+function contextFor(
+  authorization?: string,
+  extra: Record<string, unknown> = {},
+): { context: ExecutionContext; request: AuthedRequest } {
+  const request: AuthedRequest = {
+    headers: authorization === undefined ? {} : { authorization },
+    ...extra,
+  };
+  const context = {
+    switchToHttp: () => ({ getRequest: () => request }),
+  } as unknown as ExecutionContext;
+  return { context, request };
+}
+
+const sign = (payload: object, options?: JwtSignOptions) =>
+  jwt.sign(payload, options);
+
+describe('JwtAuthGuard', () => {
+  it('rejects a request with no Authorization header', () => {
+    const { context, request } = contextFor(undefined);
+    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+    expect(() => guard.canActivate(context)).toThrow(/Missing Authorization/i);
+    expect(request.user).toBeUndefined();
+  });
+
+  it('rejects a request whose headers object is absent entirely', () => {
+    const context = {
+      switchToHttp: () => ({ getRequest: () => ({}) }),
+    } as unknown as ExecutionContext;
+    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+  });
+
+  it.each([
+    ['no scheme (bare token)', () => sign({ sub: 'u1', name: 'ana' })],
+    ['wrong scheme', () => `Basic ${sign({ sub: 'u1', name: 'ana' })}`],
+    ['scheme with no token', () => 'Bearer'],
+    ['scheme with empty token', () => 'Bearer   '],
+    [
+      'extra junk after the token',
+      () => `Bearer ${sign({ sub: 'u1', name: 'ana' })} extra`,
+    ],
+    ['empty header', () => ' '],
+  ])('rejects a malformed Authorization header: %s', (_name, build) => {
+    const { context, request } = contextFor(build());
+    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+    expect(request.user).toBeUndefined();
+  });
+
+  it('rejects a token signed with a foreign secret', () => {
+    // the forged-token case: well-formed, right claims, wrong key
+    const forged = new JwtService({ secret: OTHER_SECRET }).sign({
+      sub: 'victim',
+      name: 'victim',
+    });
+    const { context, request } = contextFor(`Bearer ${forged}`);
+    expect(() => guard.canActivate(context)).toThrow(/Invalid token/);
+    expect(request.user).toBeUndefined();
+  });
+
+  it('rejects a tampered token (payload edited, signature stale)', () => {
+    const token = sign({ sub: 'user-1', name: 'ana' });
+    const [header, , signature] = token.split('.');
+    const swapped = Buffer.from(
+      JSON.stringify({ sub: 'someone-else', name: 'mallory' }),
+    ).toString('base64url');
+    const { context } = contextFor(`Bearer ${header}.${swapped}.${signature}`);
+    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+  });
+
+  it('rejects an expired token, and says so', () => {
+    // negative expiresIn (seconds): issued already stale
+    const expired = sign({ sub: 'user-1', name: 'ana' }, { expiresIn: -10 });
+    const { context, request } = contextFor(`Bearer ${expired}`);
+    expect(() => guard.canActivate(context)).toThrow(/expired/i);
+    expect(request.user).toBeUndefined();
+  });
+
+  it('rejects a validly signed token that carries no subject', () => {
+    // a signature proves provenance, not that there is anyone to authorize
+    const { context } = contextFor(`Bearer ${sign({ name: 'ana' })}`);
+    expect(() => guard.canActivate(context)).toThrow(/subject/i);
+  });
+
+  it('accepts a valid token and attaches the identity from its claims', () => {
+    const token = sign({ sub: 'user-1', name: 'ana' });
+    const { context, request } = contextFor(`Bearer ${token}`);
+
+    expect(guard.canActivate(context)).toBe(true);
+    expect(request.user).toEqual({ userId: 'user-1', username: 'ana' });
+  });
+
+  it('accepts a lower-case bearer scheme (RFC 7235 is case-insensitive)', () => {
+    const { context, request } = contextFor(
+      `bearer ${sign({ sub: 'user-1', name: 'ana' })}`,
+    );
+    expect(guard.canActivate(context)).toBe(true);
+    expect(request.user?.userId).toBe('user-1');
+  });
+
+  it('takes identity from the token even when the request says otherwise', () => {
+    // the whole point: the body/params are along for the ride now
+    const token = sign({ sub: 'real-user', name: 'ana' });
+    const { context, request } = contextFor(`Bearer ${token}`, {
+      body: { userId: 'attacker' },
+      params: { userId: 'attacker' },
+    });
+
+    guard.canActivate(context);
+    expect(request.user?.userId).toBe('real-user');
+  });
+
+  describe('@CurrentUser() reads what the guard attached', () => {
+    it('hands the handler the whole identity, or one field of it', () => {
+      const { context } = contextFor(
+        `Bearer ${sign({ sub: 'user-1', name: 'ana' })}`,
+      );
+      guard.canActivate(context);
+
+      expect(currentUser(undefined, context)).toEqual({
+        userId: 'user-1',
+        username: 'ana',
+      });
+      expect(currentUser('userId', context)).toBe('user-1');
+    });
+
+    it('throws rather than yielding undefined on an unguarded route', () => {
+      // if a route ever forgets @UseGuards, the failure must be loud - an
+      // undefined userId written into creatorId is the silent version
+      const { context } = contextFor('Bearer whatever');
+      expect(() => currentUser('userId', context)).toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  it('derives the SAME identity as the WebSocket handshake, from one token', () => {
+    // the anti-drift test. Both planes verify with this JwtService instance
+    // and read TokenPayload; if either changes which claim is the user id,
+    // this fails instead of the two planes silently disagreeing about who
+    // is in the room.
+    const payload: TokenPayload = { sub: 'user-1', name: 'ana' };
+    const token = sign(payload);
+
+    const { context, request } = contextFor(`Bearer ${token}`);
+    guard.canActivate(context);
+
+    const socket = { handshake: { auth: { token } }, data: {} };
+    let wsError: Error | undefined;
+    wsAuthMiddleware(jwt)(socket as unknown as Socket, (err) => {
+      wsError = err;
+    });
+    const socketData = socket.data as AuthedSocketData;
+
+    expect(wsError).toBeUndefined();
+    expect({
+      userId: socketData.userId,
+      username: socketData.username,
+    }).toEqual(request.user);
+  });
+});

--- a/video-sync-backend/src/auth/jwt-auth.guard.ts
+++ b/video-sync-backend/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,79 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { subjectOf, type AuthedUser, TokenPayload } from './token-payload';
+
+/**
+ * The request as this guard sees it: an Authorization header on the way in,
+ * a server-derived identity on the way out. Declared structurally so the
+ * guard, the @CurrentUser() decorator and the tests all agree on the one
+ * property that matters without dragging in Express's Request surface.
+ */
+export interface AuthedRequest {
+  headers?: { authorization?: string };
+  user?: AuthedUser;
+}
+
+/**
+ * REST counterpart to sync/ws-auth.ts: verify the bearer token, derive
+ * identity server-side, attach it to the request. Same tokens, same secret
+ * (JwtModule from AuthModule, keyed off config 'jwt.secret'), same claims
+ * (TokenPayload) - the two planes cannot disagree about who a caller is.
+ *
+ * After this guard runs, a client-supplied userId in a body, query or path
+ * is decoration. Handlers read @CurrentUser() and nothing else.
+ */
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  constructor(private readonly jwt: JwtService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<AuthedRequest>();
+    const header = request.headers?.authorization;
+
+    if (!header) {
+      throw new UnauthorizedException(
+        'Missing Authorization header (expected "Bearer <token>")',
+      );
+    }
+
+    const parts = header.trim().split(/\s+/);
+    const [scheme, token] = parts;
+    if (parts.length !== 2 || scheme.toLowerCase() !== 'bearer' || !token) {
+      throw new UnauthorizedException(
+        'Malformed Authorization header (expected "Bearer <token>")',
+      );
+    }
+
+    let payload: TokenPayload;
+    try {
+      payload = this.jwt.verify<TokenPayload>(token);
+    } catch (error) {
+      // jsonwebtoken names the expiry case; everything else (bad signature,
+      // wrong algorithm, garbage) is one indistinguishable "invalid" to the
+      // caller on purpose - a probing client learns nothing about the key.
+      const expired =
+        (error as Error | undefined)?.name === 'TokenExpiredError';
+      throw new UnauthorizedException(
+        expired ? 'Token expired - sign in again' : 'Invalid token',
+      );
+    }
+
+    // A signature proves the token is ours, not that it carries a subject.
+    // Without one there is no identity to authorize against.
+    // shared with the WS middleware so the two planes cannot drift
+    if (subjectOf(payload) === null) {
+      throw new UnauthorizedException('Token is missing a subject');
+    }
+
+    request.user = {
+      userId: payload.sub,
+      username: typeof payload.name === 'string' ? payload.name : '',
+    };
+    return true;
+  }
+}

--- a/video-sync-backend/src/auth/token-payload.ts
+++ b/video-sync-backend/src/auth/token-payload.ts
@@ -1,0 +1,41 @@
+/**
+ * The ONE JWT contract. Two planes verify these tokens - the WebSocket
+ * handshake (sync/ws-auth.ts) and the REST guard (auth/jwt-auth.guard.ts) -
+ * and both must read the same claims out of them, because they are the same
+ * tokens: issued once by AuthService.issueToken, handed to the browser by
+ * register/login, then sent on the socket handshake AND on every REST call.
+ *
+ * The shape lives here rather than beside either consumer so neither plane
+ * can quietly grow a claim the other does not understand. If a claim is
+ * added (roles, a session id), it is added here and both planes see it.
+ */
+export interface TokenPayload {
+  /** User id. The subject - the only claim authorization ever keys off. */
+  sub: string;
+  /** Display name. Carried for convenience; never trusted for access. */
+  name: string;
+}
+
+/**
+ * Identity as the rest of the app sees it, after a verified token has been
+ * decoded. The WS plane stores this on socket.data; the REST plane attaches
+ * it to the request, where @CurrentUser() reads it.
+ *
+ * A handler that has one of these has an identity the SERVER derived. Any
+ * userId arriving in a body, query or path is a client assertion and is not
+ * this.
+ */
+export interface AuthedUser {
+  userId: string;
+  username: string;
+}
+
+/**
+ * A signature proves a token is ours; it does not prove the token carries a
+ * subject. Both planes must reject a subject-less token, so the check lives
+ * here rather than being written twice and drifting once.
+ */
+export function subjectOf(payload: TokenPayload): string | null {
+  const sub = payload?.sub;
+  return typeof sub === 'string' && sub.length > 0 ? sub : null;
+}

--- a/video-sync-backend/src/rooms/dto/create-room.dto.ts
+++ b/video-sync-backend/src/rooms/dto/create-room.dto.ts
@@ -18,6 +18,11 @@ const trim = ({ value }: { value: unknown }) =>
  * every public-rooms listing and room fetch - like videoUrl's cap, they
  * bound store and wire, not just sanity. The caps are generous; the point
  * is that a megabyte can't become a room name.
+ *
+ * Deliberately NO userId, same as UpdateRoomDto. The creator is the caller,
+ * taken from the verified bearer token by JwtAuthGuard - a body field would
+ * have let anyone create rooms as anyone. With whitelist:true a legacy
+ * client that still sends `userId` is not rejected, it is ignored.
  */
 export class CreateRoomDto {
   @Transform(trim)
@@ -25,12 +30,6 @@ export class CreateRoomDto {
   @IsNotEmpty()
   @MaxLength(120)
   name: string;
-
-  // Identity of the creator. Present here and ONLY here - UpdateRoomDto
-  // deliberately omits it (a PATCH must not reassign ownership).
-  @IsString()
-  @IsNotEmpty()
-  userId: string;
 
   // '' admitted as the "no video yet" sentinel; anything else must pass
   // the shared admission rule. Trimmed first - the rule is strict about

--- a/video-sync-backend/src/rooms/dto/rooms.dto.spec.ts
+++ b/video-sync-backend/src/rooms/dto/rooms.dto.spec.ts
@@ -13,7 +13,8 @@ const asCreate = (body: unknown): Promise<CreateRoomDto> =>
 const asUpdate = (body: unknown): Promise<UpdateRoomDto> =>
   pipe.transform(body, { type: 'body', metatype: UpdateRoomDto, data: '' });
 
-const base = { name: 'movie night', userId: 'user-1' };
+// No userId: the creator is the bearer token's subject, not a body field.
+const base = { name: 'movie night' };
 
 describe('CreateRoomDto through the production pipe', () => {
   it('admits a minimal body and returns a class instance', async () => {
@@ -59,6 +60,16 @@ describe('CreateRoomDto through the production pipe', () => {
     expect('maxUsers' in dto).toBe(false);
   });
 
+  it('strips userId - a CREATE body cannot choose the owner', async () => {
+    // creatorId comes from the verified token (JwtAuthGuard), so a userId
+    // here is a client assertion with nowhere to land. Stripping (rather
+    // than 400) is what lets a not-yet-updated client keep working: it
+    // needs a token, not a smaller body.
+    const dto = await asCreate({ ...base, userId: 'attacker' });
+    expect('userId' in dto).toBe(false);
+    expect(dto.name).toBe('movie night');
+  });
+
   it.each([
     ['javascript scheme', 'javascript:alert(1)'],
     ['data scheme', 'data:text/html,x'],
@@ -72,10 +83,9 @@ describe('CreateRoomDto through the production pipe', () => {
   });
 
   it.each([
-    ['missing name', { userId: 'user-1' }],
+    ['missing name', {}],
     ['empty name', { ...base, name: '' }],
     ['whitespace-only name (empty after trim)', { ...base, name: '   ' }],
-    ['missing userId', { name: 'movie night' }],
     ['non-string tag', { ...base, tags: [42] }],
     // null is NOT absent: @IsOptional would wave these through to Prisma
     // (a 500 on the non-nullable column); SkipIfAbsent makes them a 400

--- a/video-sync-backend/src/rooms/dto/update-room.dto.ts
+++ b/video-sync-backend/src/rooms/dto/update-room.dto.ts
@@ -7,13 +7,14 @@ const trim = ({ value }: { value: unknown }) =>
   typeof value === 'string' ? value.trim() : value;
 
 /**
- * PATCH /rooms/:code body - flows verbatim into Prisma room.update, so
- * every property here is a column any participant can write.
+ * PATCH /rooms/:code body. Still flows into Prisma room.update, so every
+ * property here is a column - but no longer one "any participant can
+ * write": the route is behind JwtAuthGuard and updateRoomByCode refuses a
+ * caller who is not the room's creator.
  *
- * Deliberately NO userId: identity does not belong in an update body, and
- * with whitelist:true the pipe strips it before it can reach room.update
- * as a creator reassignment. If PATCH ever needs authorization it will be
- * the requester's identity from auth context, not a body field.
+ * Deliberately NO userId. It used to be absent so the pipe would strip a
+ * creator reassignment; now it is absent because identity is not a body
+ * field at all - the creator check reads the verified token.
  */
 export class UpdateRoomDto {
   @Transform(trim)

--- a/video-sync-backend/src/rooms/rooms.controller.spec.ts
+++ b/video-sync-backend/src/rooms/rooms.controller.spec.ts
@@ -1,0 +1,205 @@
+import 'reflect-metadata';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { RoomsController } from './rooms.controller';
+import { RoomsService } from './rooms.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { DatabaseService } from '../database/database.service';
+import type { AuthedUser } from '../auth/token-payload';
+import type { UpdateRoomDto } from './dto/update-room.dto';
+import type { CreateRoomDto } from './dto/create-room.dto';
+
+/**
+ * What this file pins: the REST plane's authorization, end to end from the
+ * controller through the real RoomsService (only Prisma is faked).
+ *
+ * Before this change, /rooms trusted whatever userId the caller put in the
+ * body or path. DELETE "checked ownership" against a field the client had
+ * just handed it; PATCH did not check at all. So the tests here are the two
+ * halves of the fix: a non-owner is refused, and the id the service is
+ * given is the TOKEN's - never the body's, never the path's.
+ */
+
+const OWNER: AuthedUser = { userId: 'user-owner', username: 'owner' };
+const INTRUDER: AuthedUser = { userId: 'user-intruder', username: 'mallory' };
+
+const ROOM = {
+  id: 'room-1',
+  code: 'CODE1',
+  name: 'movie night',
+  creatorId: OWNER.userId,
+  participants: [],
+};
+
+describe('RoomsController authorization', () => {
+  let database: DatabaseService;
+  let controller: RoomsController;
+  let db: {
+    room: Record<string, jest.Mock>;
+    participant: Record<string, jest.Mock>;
+    chatMessage: Record<string, jest.Mock>;
+    syncEvent: Record<string, jest.Mock>;
+    $transaction: jest.Mock;
+  };
+
+  beforeEach(() => {
+    db = {
+      room: {
+        findUnique: jest.fn().mockResolvedValue(ROOM),
+        findMany: jest.fn().mockResolvedValue([ROOM]),
+        create: jest
+          .fn()
+          .mockImplementation((args: { data: Record<string, unknown> }) =>
+            Promise.resolve({ ...ROOM, ...args.data }),
+          ),
+        update: jest.fn().mockResolvedValue({ ...ROOM, name: 'renamed' }),
+        delete: jest.fn().mockResolvedValue(ROOM),
+      },
+      participant: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+      chatMessage: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+      syncEvent: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+      $transaction: jest
+        .fn()
+        .mockImplementation((fn: (tx: unknown) => unknown) => fn(db)),
+    };
+    database = db as unknown as DatabaseService;
+    controller = new RoomsController(new RoomsService(database));
+  });
+
+  describe('PATCH /rooms/:code', () => {
+    const patch = { name: 'renamed' } as UpdateRoomDto;
+
+    it('refuses a caller who is not the room creator', async () => {
+      // PATCH had NO ownership check at all: anyone with a code could
+      // rename a room or repoint its video
+      await expect(
+        controller.updateRoom('CODE1', patch, INTRUDER.userId),
+      ).rejects.toThrow(ForbiddenException);
+      expect(db.room.update).not.toHaveBeenCalled();
+    });
+
+    it('lets the creator through, updating by id', async () => {
+      await controller.updateRoom('CODE1', patch, OWNER.userId);
+      expect(db.room.update).toHaveBeenCalledWith({
+        where: { id: ROOM.id },
+        data: patch,
+      });
+    });
+
+    it('404s on an unknown code without leaking it as a 403', async () => {
+      db.room.findUnique.mockResolvedValueOnce(null);
+      await expect(
+        controller.updateRoom('NOPE', patch, OWNER.userId),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('DELETE /rooms/:code', () => {
+    it('refuses a caller who is not the room creator', async () => {
+      // the old signature took { userId } from the BODY and compared the
+      // room's creator to that - self-attested ownership
+      await expect(
+        controller.deleteRoom('CODE1', INTRUDER.userId),
+      ).rejects.toThrow(ForbiddenException);
+      expect(db.$transaction).not.toHaveBeenCalled();
+      expect(db.room.delete).not.toHaveBeenCalled();
+    });
+
+    it('lets the creator through', async () => {
+      const result = await controller.deleteRoom('CODE1', OWNER.userId);
+      expect(db.room.delete).toHaveBeenCalledWith({ where: { id: ROOM.id } });
+      expect(result.deletedRoom.code).toBe('CODE1');
+    });
+  });
+
+  describe('POST /rooms', () => {
+    it('creates the room owned by the token holder, not the body', async () => {
+      // whitelist:true already strips a stray userId from the DTO; this
+      // pins the other half - the controller reads identity from the guard
+      const body = {
+        name: 'movie night',
+        userId: INTRUDER.userId,
+      } as unknown as CreateRoomDto;
+
+      await controller.createRoom(body, OWNER);
+
+      expect(db.room.create).toHaveBeenCalledTimes(1);
+      const calls = db.room.create.mock.calls as Array<
+        [{ data: { creatorId: string } }]
+      >;
+      expect(calls[0][0].data.creatorId).toBe(OWNER.userId);
+    });
+  });
+
+  describe('GET /rooms/user/:userId', () => {
+    it("refuses to list another user's rooms", async () => {
+      await expect(
+        controller.getUserRooms(OWNER.userId, INTRUDER),
+      ).rejects.toThrow(ForbiddenException);
+      expect(db.room.findMany).not.toHaveBeenCalled();
+    });
+
+    it('serves the caller their own rooms', async () => {
+      await controller.getUserRooms(OWNER.userId, OWNER);
+      expect(db.room.findMany).toHaveBeenCalledTimes(1);
+      const calls = db.room.findMany.mock.calls as unknown[][];
+      expect(JSON.stringify(calls[0][0])).toContain(OWNER.userId);
+    });
+
+    it('GET /rooms/mine queries the token holder, with no id to disagree', async () => {
+      await controller.getMyRooms(OWNER.userId);
+      const calls = db.room.findMany.mock.calls as unknown[][];
+      expect(JSON.stringify(calls[0][0])).toContain(OWNER.userId);
+      expect(JSON.stringify(calls[0][0])).not.toContain(INTRUDER.userId);
+    });
+  });
+
+  describe('which routes carry the guard', () => {
+    // Reading the metadata @UseGuards writes is the only way to assert the
+    // policy itself: a handler test passes just as happily on a route
+    // anyone can reach.
+    const guardsOn = (route: keyof RoomsController): unknown[] => {
+      const handler = (
+        RoomsController.prototype as unknown as Record<string, unknown>
+      )[route];
+      return (
+        (Reflect.getMetadata(GUARDS_METADATA, handler as object) as
+          | unknown[]
+          | undefined) ?? []
+      );
+    };
+
+    it.each([
+      ['createRoom'],
+      ['getMyRooms'],
+      ['getUserRooms'],
+      ['getRoom'],
+      ['updateRoom'],
+      ['deleteRoom'],
+    ] as Array<[keyof RoomsController]>)(
+      '%s requires a verified token',
+      (route) => {
+        expect(guardsOn(route)).toContain(JwtAuthGuard);
+      },
+    );
+
+    it('declares the static GET routes before /rooms/:code', () => {
+      // Nest matches in declaration order: if getRoom moved up, /rooms/mine
+      // and /rooms/public would be looked up as room codes and 404. This is
+      // the kind of break that only shows up in the browser.
+      const order = Object.getOwnPropertyNames(RoomsController.prototype);
+      expect(order.indexOf('getPublicRooms')).toBeLessThan(
+        order.indexOf('getRoom'),
+      );
+      expect(order.indexOf('getMyRooms')).toBeLessThan(
+        order.indexOf('getRoom'),
+      );
+    });
+
+    it('getPublicRooms stays open - it is a public listing', () => {
+      // documented decision, not an oversight: the browse page must render
+      // for signed-out visitors
+      expect(guardsOn('getPublicRooms')).toEqual([]);
+    });
+  });
+});

--- a/video-sync-backend/src/rooms/rooms.controller.ts
+++ b/video-sync-backend/src/rooms/rooms.controller.ts
@@ -7,19 +7,51 @@ import {
   Patch,
   Query,
   Delete,
+  ForbiddenException,
+  UseGuards,
 } from '@nestjs/common';
 import { RoomsService } from './rooms.service';
 import { CreateRoomDto } from './dto/create-room.dto';
 import { UpdateRoomDto } from './dto/update-room.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CurrentUser } from '../auth/current-user.decorator';
+import type { AuthedUser } from '../auth/token-payload';
 
+/**
+ * Authorization policy for this controller, stated once:
+ *
+ *   POST   /rooms             auth - the creator is the caller, full stop
+ *   GET    /rooms/public      OPEN  - a public listing is public
+ *   GET    /rooms/mine        auth - the caller's own rooms
+ *   GET    /rooms/user/:id    auth + :id must BE the caller
+ *   GET    /rooms/:code       auth, but NOT membership. Deliberate: a room
+ *                             code is a share link, and a signed-in user
+ *                             who was handed one must be able to look the
+ *                             room up before joining it. Requiring auth
+ *                             still ends anonymous enumeration of rooms
+ *                             (and of their creator/participant lists) by
+ *                             anyone who guesses a code.
+ *   PATCH  /rooms/:code       auth + creator only
+ *   DELETE /rooms/:code       auth + creator only
+ *
+ * The guard is listed per route rather than on the class so that leaving a
+ * route open is a visible decision in the diff, not an omission.
+ *
+ * Identity comes from the bearer token via @CurrentUser(). No handler here
+ * reads a userId out of a body or trusts one from a path.
+ */
 @Controller('rooms')
 export class RoomsController {
   constructor(private roomsService: RoomsService) {}
 
   @Post()
-  async createRoom(@Body() createRoomDto: CreateRoomDto) {
+  @UseGuards(JwtAuthGuard)
+  async createRoom(
+    @Body() createRoomDto: CreateRoomDto,
+    @CurrentUser() user: AuthedUser,
+  ) {
     return await this.roomsService.createRoom(
-      createRoomDto.userId,
+      user.userId,
       createRoomDto.name,
       createRoomDto.videoUrl,
       createRoomDto.isPublic,
@@ -29,37 +61,68 @@ export class RoomsController {
     );
   }
 
-  // IMPORTANT: This route must come BEFORE the :code route
+  // The one unauthenticated route: the browse/discovery listing.
+  // IMPORTANT: this route must come BEFORE the :code route.
   @Get('public')
   async getPublicRooms(@Query('filter') filter?: string) {
     return await this.roomsService.getPublicRooms(filter);
   }
 
-  @Get('user/:userId')
-  async getUserRooms(@Param('userId') userId: string) {
+  // Same listing, addressed by nobody: with no id in the path there is
+  // nothing that can disagree with the token, so there is nothing to
+  // forbid. This is what the web client calls. Like 'public', it MUST stay
+  // above @Get(':code') or 'mine' gets read as a room code.
+  @Get('mine')
+  @UseGuards(JwtAuthGuard)
+  async getMyRooms(@CurrentUser('userId') userId: string) {
     return await this.roomsService.getUserRooms(userId);
   }
 
+  @Get('user/:userId')
+  @UseGuards(JwtAuthGuard)
+  async getUserRooms(
+    @Param('userId') userId: string,
+    @CurrentUser() user: AuthedUser,
+  ) {
+    // The path param is now redundant with the token, and redundancy that
+    // disagrees is an attempt: reject it rather than quietly serving the
+    // caller their own rooms under someone else's id (which would hide a
+    // broken client) or someone else's rooms (which is the bug we came for).
+    if (userId !== user.userId) {
+      throw new ForbiddenException('You can only list your own rooms');
+    }
+    return await this.roomsService.getUserRooms(user.userId);
+  }
+
   @Get(':code')
+  @UseGuards(JwtAuthGuard)
   async getRoom(@Param('code') code: string) {
+    // Auth, not membership - see the policy note above: join-by-link works.
     return await this.roomsService.getRoomByCode(code);
   }
 
   @Patch(':code')
+  @UseGuards(JwtAuthGuard)
   async updateRoom(
     @Param('code') code: string,
     @Body() updateRoomDto: UpdateRoomDto,
+    @CurrentUser('userId') userId: string,
   ) {
-    // Get room by code first to get the ID
-    const room = await this.roomsService.getRoomByCode(code);
-    return await this.roomsService.updateRoom(room.id, updateRoomDto);
+    return await this.roomsService.updateRoomByCode(
+      code,
+      userId,
+      updateRoomDto,
+    );
   }
 
   @Delete(':code')
+  @UseGuards(JwtAuthGuard)
   async deleteRoom(
     @Param('code') code: string,
-    @Body() deleteRoomDto: { userId: string },
+    @CurrentUser('userId') userId: string,
   ) {
-    return await this.roomsService.deleteRoom(code, deleteRoomDto.userId);
+    // No body: the old { userId } was the caller telling us who they were,
+    // and deleteRoom then compared the room's creator against that.
+    return await this.roomsService.deleteRoom(code, userId);
   }
 }

--- a/video-sync-backend/src/rooms/rooms.module.ts
+++ b/video-sync-backend/src/rooms/rooms.module.ts
@@ -1,9 +1,14 @@
 // src/rooms/rooms.module.ts
 import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
 import { RoomsController } from './rooms.controller';
 import { RoomsService } from './rooms.service';
 
 @Module({
+  // for JwtService: JwtAuthGuard on the controller's routes is instantiated
+  // in THIS module's injector, so the JwtModule AuthModule exports (same
+  // secret the WS handshake verifies with) has to be visible here.
+  imports: [AuthModule],
   controllers: [RoomsController],
   providers: [RoomsService],
   exports: [RoomsService],

--- a/video-sync-backend/src/rooms/rooms.service.ts
+++ b/video-sync-backend/src/rooms/rooms.service.ts
@@ -72,7 +72,46 @@ export class RoomsService {
     return room;
   }
 
-  async updateRoom(roomId: string, data: { name?: string; videoUrl?: string }) {
+  /**
+   * Ownership-checked PATCH path, the mirror of deleteRoom. Every method
+   * here takes the caller's id explicitly and the CONTROLLER supplies the
+   * one it got from the verified token - the id is never read off the body.
+   *
+   * PATCH shipped for months with no check at all: any caller who knew a
+   * code could rename someone's room or repoint its video.
+   */
+  async updateRoomByCode(
+    code: string,
+    userId: string,
+    data: { name?: string; videoUrl?: string },
+  ) {
+    const room = await this.database.room.findUnique({
+      where: { code },
+      select: { id: true, creatorId: true },
+    });
+
+    if (!room) {
+      throw new NotFoundException('Room not found');
+    }
+
+    if (room.creatorId !== userId) {
+      throw new ForbiddenException(
+        'Only the room creator can update this room',
+      );
+    }
+
+    return await this.updateRoom(room.id, data);
+  }
+
+  /**
+   * Unchecked by design and by id, not code: the only caller is
+   * updateRoomByCode, which does the ownership check. Nothing that faces a
+   * request should call this directly.
+   */
+  private async updateRoom(
+    roomId: string,
+    data: { name?: string; videoUrl?: string },
+  ) {
     return await this.database.room.update({
       where: { id: roomId },
       data,

--- a/video-sync-backend/src/sync/sync.gateway.ts
+++ b/video-sync-backend/src/sync/sync.gateway.ts
@@ -556,7 +556,13 @@ export class SyncGateway
   ) {
     try {
       const { roomCode, message } = data;
-      console.log(`Chat message in room ${roomCode} from ${message.username}`);
+      // Identity comes from the JWT-verified socket, never from the payload.
+      // This handler used to write `userId: message.userId` straight into the
+      // row, so any room member could post as any user - the same
+      // client-asserted-identity bug the REST guard exists to end. The
+      // client's own userId/username fields are now ignored entirely.
+      const { userId, username } = client.data as AuthedSocketData;
+      console.log(`Chat message in room ${roomCode} from ${username}`);
 
       const room = await this.database.room.findUnique({
         where: { code: roomCode },
@@ -571,7 +577,7 @@ export class SyncGateway
       const savedMessage = await this.database.chatMessage.create({
         data: {
           content: message.message,
-          userId: message.userId,
+          userId,
           roomId: room.id,
         },
         include: {

--- a/video-sync-backend/src/sync/ws-auth.ts
+++ b/video-sync-backend/src/sync/ws-auth.ts
@@ -1,10 +1,8 @@
 import { JwtService } from '@nestjs/jwt';
 import { Socket } from 'socket.io';
-
-interface TokenPayload {
-  sub: string;
-  name: string;
-}
+// One definition, shared with the REST guard (auth/jwt-auth.guard.ts) so the
+// two planes cannot drift on what a token says.
+import { subjectOf, type TokenPayload } from '../auth/token-payload';
 
 /** Shape of socket.data after the middleware accepted the connection. */
 export interface AuthedSocketData {
@@ -29,8 +27,14 @@ export function wsAuthMiddleware(jwt: JwtService) {
     }
     try {
       const payload = jwt.verify<TokenPayload>(token);
+      // shared with the REST guard: a valid signature is not a subject
+      const sub = subjectOf(payload);
+      if (sub === null) {
+        next(new Error('unauthorized: token has no subject'));
+        return;
+      }
       const data = socket.data as AuthedSocketData;
-      data.userId = payload.sub;
+      data.userId = sub;
       data.username = payload.name;
       data.connectedAt = Date.now();
       next();

--- a/video-sync-backend/test-api.sh
+++ b/video-sync-backend/test-api.sh
@@ -15,14 +15,17 @@ USER_RESPONSE=$(curl -s -X POST http://localhost:3000/api/auth/register \
 
 echo "Response: $USER_RESPONSE"
 USER_ID=$(echo $USER_RESPONSE | grep -o '"id":"[^"]*' | cut -d'"' -f4)
+# register/login return the bearer token every guarded REST route needs -
+# identity comes from this token now, never from a userId in a body
+TOKEN=$(echo $USER_RESPONSE | grep -o '"token":"[^"]*' | cut -d'"' -f4)
 
 # 2. Create a room
 echo -e "\n🏠 Creating room..."
 ROOM_RESPONSE=$(curl -s -X POST http://localhost:3000/api/rooms \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
   -d '{
     "name": "Test Room",
-    "userId": "'$USER_ID'",
     "videoUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
   }')
 
@@ -31,6 +34,7 @@ ROOM_CODE=$(echo $ROOM_RESPONSE | grep -o '"code":"[^"]*' | cut -d'"' -f4)
 
 # 3. Get room details
 echo -e "\n🔍 Getting room details..."
-curl -s http://localhost:3000/api/rooms/$ROOM_CODE | jq .
+curl -s http://localhost:3000/api/rooms/$ROOM_CODE \
+  -H "Authorization: Bearer $TOKEN" | jq .
 
 echo -e "\n✅ API test complete!"

--- a/video-sync-frontend/src/contexts/AuthContext.tsx
+++ b/video-sync-frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
 import axios from 'axios';
 import { toast } from 'react-hot-toast';
+import { AUTH_EXPIRED_EVENT } from '../services/api';
 
 interface User {
   id: string;
@@ -33,12 +34,30 @@ const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3000/api';
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
 
-  // Check for stored user on mount
+  // Check for stored user on mount. Wrapped: a corrupt entry (a half-written
+  // value, a schema change) would otherwise throw during render and leave a
+  // blank page instead of a signed-out one.
   useEffect(() => {
     const storedUser = localStorage.getItem('user');
-    if (storedUser) {
+    if (!storedUser) return;
+    try {
       setUser(JSON.parse(storedUser));
+    } catch {
+      localStorage.removeItem('user');
     }
+  }, []);
+
+  // The API layer clears storage and fires this when a request comes back 401
+  // with a token attached - i.e. the token expired or was revoked mid-session.
+  // Without a listener the UI kept rendering as signed-in against a dead
+  // token, and every action failed silently.
+  useEffect(() => {
+    const onExpired = () => {
+      setUser(null);
+      toast.error('Session expired - sign in again');
+    };
+    window.addEventListener(AUTH_EXPIRED_EVENT, onExpired);
+    return () => window.removeEventListener(AUTH_EXPIRED_EVENT, onExpired);
   }, []);
 
   const login = useCallback(async (username: string, password: string) => {

--- a/video-sync-frontend/src/pages/CreateRoomPage.tsx
+++ b/video-sync-frontend/src/pages/CreateRoomPage.tsx
@@ -255,7 +255,6 @@ export const CreateRoomPage: React.FC = () => {
       const response = await apiService.createRoom({
         name: formData.name,
         videoUrl: videoUrl || undefined,
-        userId: user.id,
         isPublic: formData.isPublic,
         description: formData.isPublic ? formData.description : undefined,
         tags: formData.isPublic && formData.tags ? formData.tags.split(',').map(t => t.trim()) : [],

--- a/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
+++ b/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
@@ -327,11 +327,19 @@ export const EnhancedRoomPage: React.FC = () => {
       navigate('/');
       return;
     }
+    // Room details now require a token (the REST guard), and the socket has
+    // always required one. A signed-out visitor arriving on a shared link
+    // should be asked to sign in, not shown "Couldn't load the room" - so
+    // send them to the join page, which explains the room and offers sign-in.
+    if (!user) {
+      navigate(`/join-room/${roomCode}`, { replace: true });
+      return;
+    }
 
     fetchRoomDetails();
-    // intentional: fetch once per room code
+    // intentional: fetch once per room code, and again if auth appears
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [roomCode]);
+  }, [roomCode, user]);
 
   useEffect(() => {
     if (!socket || !connected || !user || !room) return;

--- a/video-sync-frontend/src/pages/HomePage.tsx
+++ b/video-sync-frontend/src/pages/HomePage.tsx
@@ -528,10 +528,12 @@ export const HomePage: React.FC = () => {
 
   // Fetch user's rooms
   const { data: userRooms, isLoading: userRoomsLoading, refetch: refetchUserRooms } = useQuery({
+    // still keyed on the id so the cache busts when a different person signs
+    // in, even though the request itself now carries the identity in its token
     queryKey: ['user-rooms', user?.id],
     queryFn: async () => {
       if (!user) return [];
-      const response = await apiService.getUserRooms(user.id);
+      const response = await apiService.getUserRooms();
       return response.data;
     },
     enabled: !!user,
@@ -569,7 +571,7 @@ export const HomePage: React.FC = () => {
 
   const handleDeleteRoom = async (room: any) => {
     try {
-      await apiService.deleteRoom(room.code, user!.id);
+      await apiService.deleteRoom(room.code);
       toast.success('Room deleted');
       setDeleteModal({ show: false, room: null });
       refetchUserRooms();

--- a/video-sync-frontend/src/services/api.ts
+++ b/video-sync-frontend/src/services/api.ts
@@ -14,42 +14,98 @@ const api = axios.create({
   },
 });
 
+const STORAGE_KEY = 'user';
+
+/** Fired when the server rejects the stored token; nothing keeps a dead session. */
+export const AUTH_EXPIRED_EVENT = 'mustard:auth-expired';
+
+/**
+ * The token the REST layer sends is the same one the socket handshake presents
+ * ({ sub, name }, HS256) - one identity, two planes.
+ *
+ * Read per request, never cached at module load: signing in replaces the stored
+ * user while this module is already evaluated, and a token captured once would
+ * leave the whole tab authenticating as whoever was signed in at boot.
+ */
+const readStoredToken = (): string | null => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const stored = JSON.parse(raw);
+    return typeof stored?.token === 'string' && stored.token ? stored.token : null;
+  } catch {
+    // unparseable storage is a signed-out tab, not a crashed one
+    return null;
+  }
+};
+
+const clearStoredUser = () => {
+  localStorage.removeItem(STORAGE_KEY);
+  window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT));
+};
+
+api.interceptors.request.use(config => {
+  // Never attach to /auth/*: a token is meaningless to login/register, and
+  // sending one there makes a bad-password 401 indistinguishable from an
+  // expired-session 401 in the response interceptor below.
+  if (config.url?.startsWith('/auth/')) return config;
+  const token = readStoredToken();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  response => response,
+  error => {
+    // Only a request that actually carried a token can have had it rejected.
+    // A 401 from /auth/login is bad credentials, and clearing on that would
+    // wipe a perfectly good session because someone fat-fingered a password.
+    const sentToken = Boolean(error?.config?.headers?.Authorization);
+    if (error?.response?.status === 401 && sentToken) {
+      clearStoredUser();
+    }
+    return Promise.reject(error);
+  },
+);
+
 // API methods
 export const apiService = {
   // Auth
   login: (username: string, password: string) =>
     api.post('/auth/login', { username, password }),
-  
+
   register: (username: string, email: string, password: string) =>
     api.post('/auth/register', { username, email, password }),
-  
+
   // Rooms
+  // No userId anywhere below: the server reads the caller off the bearer token,
+  // and a client-supplied id would only be a suggestion it ignores.
   createRoom: (data: {
     name: string;
     videoUrl?: string;
-    userId: string;
     isPublic?: boolean;
     description?: string;
     tags?: string[];
     allowGuestControl?: boolean;
   }) => api.post('/rooms', data),
-  
+
   getRoomByCode: (code: string) =>
     api.get(`/rooms/${code}`),
-  
+
   updateRoom: (code: string, data: {
     name?: string;
     videoUrl?: string;
-    userId?: string;
     allowGuestControl?: boolean;
   }) => api.patch(`/rooms/${code}`, data),
-  
-  deleteRoom: (code: string, userId: string) =>
-    api.delete(`/rooms/${code}`, { data: { userId } }),
-  
-  getUserRooms: (userId: string) =>
-    api.get(`/rooms/user/${userId}`),
-    
+
+  deleteRoom: (code: string) =>
+    api.delete(`/rooms/${code}`),
+
+  getUserRooms: () =>
+    api.get('/rooms/mine'),
+
   getPublicRooms: (filter?: string) =>
     api.get('/rooms/public', { params: { filter } }),
 };


### PR DESCRIPTION
Every REST endpoint trusted a client-supplied `userId`. Creating a room as
somebody else was a body field. `PATCH /rooms/:code` had **no ownership
check at all**. `DELETE`'s check compared the room's creator against a
`userId` the caller handed us — decorative. The WebSocket plane has always
been correct (`ws-auth.ts` verifies a JWT at the handshake and derives
identity server-side), so this makes REST adopt the same token, the same
payload shape, and the same rule: **identity is derived, never asserted.**

## Backend

- `JwtAuthGuard` — `Authorization: Bearer`, verified with the same
  `JwtService`/secret the handshake uses; attaches `{ userId, username }`
  that `@CurrentUser()` hands to handlers.
- `token-payload.ts` — the claim contract *and* the subject check now live
  in one file both planes import, so they cannot drift.
- Ownership enforced where it was missing: PATCH gained the check it never
  had, DELETE reads the creator from the token, `GET /rooms/user/:id` 403s
  on someone else's id.
- `userId` removed from `CreateRoomDto` and the DELETE body.
- `GET /rooms/public` stays open (it is a public listing). `GET /rooms/:code`
  requires auth but **not** membership — a room code is a share link, and a
  signed-in user handed one must be able to look it up before joining. The
  guard is listed per route, not on the class, so an open route is a visible
  decision in the diff.

## Everything that had to move with it

Identity had to stop being a body field *everywhere at once*, or production
and nightly CI both break:

- **Frontend** attaches the token per request (it sent none before — REST
  was entirely unauthenticated from the browser), clears the session on a
  401 that carried a token, and skips `/auth/*` so a bad password isn't
  mistaken for an expired session.
- **AuthContext** now listens for that expiry event. It was dispatched into
  the void, so an expired token left a signed-in UI whose every action
  failed silently.
- **Harness** threads each user's token through `createRoom`; the CI bot
  fleet would 401 otherwise.
- **Room page** sends signed-out visitors to the join page instead of a
  "Couldn't load the room" toast.

## The one the change would have missed

The self-review caught it: `handleChatMessage` wrote `userId` straight from
the socket payload, so **any room member could post chat as any user** — the
same client-asserted-identity bug, on the plane we thought was clean. It now
reads the verified socket identity like every other handler.

## Verified against a live server, not just metadata

Route protection asserted through `@UseGuards` metadata proves wiring, not
behavior — so 12 checks ran against a real backend:

```
PASS  create without token -> 401
PASS  body userId ignored; creator = token subject
PASS  non-owner PATCH -> 403        (this worked before)
PASS  non-owner DELETE -> 403       (this worked before)
PASS  DELETE without token -> 401
PASS  listing another user's rooms -> 403
PASS  garbage token -> 401
PASS  public listing stays open -> 200
PASS  owner PATCH / DELETE -> 200
PASS  room detail carries no password hash
```

184 backend tests, 26 frontend, harness typechecks clean.

## Known, unchanged by this PR

Tokens last 12h, are verified once at socket connect, and there is no
refresh or revocation — a socket outlives its token by design today. Also
`JWT_EXPIRES_IN` remains dead config (`auth.module.ts` hardcodes `12h`).
Both are pre-existing and belong with the OAuth work, where token lifetime
has to be thought about properly.