### PR TITLE
test: a disabled OAuth route must have no side effects, not just no redirect

### DIFF
--- a/video-sync-backend/src/auth/auth.controller.spec.ts
+++ b/video-sync-backend/src/auth/auth.controller.spec.ts
@@ -58,21 +58,31 @@ const controllerWith = (enabled: boolean) =>
 const emptyReq = { headers: {} } as Request;
 
 describe('the OAuth routes when the provider is off', () => {
-  it('404s /google/start rather than bouncing anyone to Google', () => {
+  it('404s /google/start without touching the response', () => {
     const res = makeRes();
     expect(() =>
       controllerWith(false).start(undefined, res as unknown as Response),
     ).toThrow(NotFoundException);
     expect(res.redirectedTo).toBeUndefined();
+    // no half-started flow left behind: a sealed cookie handed out by a
+    // route that then 404s is a live CSRF/PKCE pair with nothing to redeem it
+    expect(res.cookies).toHaveLength(0);
   });
 
-  it('404s /google/callback instead of redirecting', async () => {
+  it('404s /google/callback without touching the response or calling Google', async () => {
     // The provider can be off BECAUSE the frontend origin is loopback. If
     // the callback still redirected on error, it would send the visitor to
     // that loopback address - the exact hazard the guard exists to stop.
     const res = makeRes();
+    const controller = controllerWith(false);
+    const verifyCallback = (
+      controller as unknown as {
+        google: { verifyCallback: jest.Mock };
+      }
+    ).google.verifyCallback;
+
     await expect(
-      controllerWith(false).callback(
+      controller.callback(
         'c',
         's',
         undefined,
@@ -80,7 +90,13 @@ describe('the OAuth routes when the provider is off', () => {
         res as unknown as Response,
       ),
     ).rejects.toBeInstanceOf(NotFoundException);
+
     expect(res.redirectedTo).toBeUndefined();
+    // These two are the ordering, not decoration: assertEnabled() runs BEFORE
+    // clearCookie and before any exchange, so a disabled route neither
+    // mutates the caller's cookies nor spends a round trip to Google.
+    expect(res.cleared).toHaveLength(0);
+    expect(verifyCallback).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
From CodeRabbit's review of #46 — a fair catch on tests I wrote.

The disabled-provider tests asserted the routes 404 and don't redirect. That is weaker than what `e6cbb94` actually changed: the fix was moving `assertEnabled()` **above** `clearCookie` and above the exchange, and nothing in the suite failed if it drifted back down.

Now pinned:

- `/google/start` must not hand out a sealed cookie before 404ing. A cookie issued by a route that then fails is a live CSRF/PKCE pair with nothing left to redeem it.
- `/google/callback` must not clear the caller's cookie and must not spend a round trip to Google.

Both assertions fail if the guard moves back inside the `try`, which is the regression worth catching.

Test-only; no production code changes. `#46` remains the review record for the three commits that reached `main` directly — this is the follow-up from it, going through the normal flow.