### PR TITLE
fix: the two reported bugs, the three that were hiding behind them, and the invite path

### DIFF
--- a/video-sync-backend/src/rooms/dto/rooms.dto.spec.ts
+++ b/video-sync-backend/src/rooms/dto/rooms.dto.spec.ts
@@ -130,3 +130,44 @@ describe('UpdateRoomDto through the production pipe', () => {
     );
   });
 });
+
+describe('UpdateRoomDto: the settings the form was silently dropping', () => {
+  // These three were collected by the room-settings form and thrown away by
+  // the pipe's whitelist, so the UI reported a save that never happened.
+  it('admits isPublic, allowGuestControl and maxUsers', async () => {
+    const dto = await asUpdate({
+      isPublic: true,
+      allowGuestControl: true,
+      maxUsers: 8,
+    });
+    expect(dto.isPublic).toBe(true);
+    expect(dto.allowGuestControl).toBe(true);
+    expect(dto.maxUsers).toBe(8);
+  });
+
+  it('leaves untouched settings undefined, so Prisma skips them', async () => {
+    // A declared optional property is materialised on the instance as
+    // undefined rather than omitted, which is exactly what a partial update
+    // needs: Prisma reads undefined as "do not write this column". Asserting
+    // the KEY is absent would test class-transformer's internals; asserting
+    // the VALUE is undefined tests the thing that keeps `isPublic: false`
+    // from also clearing the participant cap.
+    const dto = await asUpdate({ isPublic: false });
+    expect(dto.isPublic).toBe(false);
+    expect(dto.allowGuestControl).toBeUndefined();
+    expect(dto.maxUsers).toBeUndefined();
+  });
+
+  it.each([
+    ['a string for a boolean', { isPublic: 'yes' }],
+    ['a string for the cap', { maxUsers: '8' }],
+    ['a fractional cap', { maxUsers: 8.5 }],
+    ['a cap of one - not a watch party', { maxUsers: 1 }],
+    ['a cap of zero', { maxUsers: 0 }],
+    ['an absurd cap', { maxUsers: 100000 }],
+    ['null isPublic', { isPublic: null }],
+    ['null maxUsers', { maxUsers: null }],
+  ])('refuses %s', async (_name, body) => {
+    await expect(asUpdate(body)).rejects.toThrow(BadRequestException);
+  });
+});

--- a/video-sync-backend/src/rooms/dto/update-room.dto.ts
+++ b/video-sync-backend/src/rooms/dto/update-room.dto.ts
@@ -1,5 +1,13 @@
 import { Transform } from 'class-transformer';
-import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import {
+  IsBoolean,
+  IsInt,
+  IsNotEmpty,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
 import { SkipIfAbsent } from './skip-if-absent.decorator';
 import { IsRoomVideoUrl } from './room-video-url.decorator';
 
@@ -30,4 +38,26 @@ export class UpdateRoomDto {
   @SkipIfAbsent()
   @IsRoomVideoUrl()
   videoUrl?: string;
+
+  // The settings form has offered these three since it was written, and the
+  // pipe's whitelist silently dropped every one of them: toggling "List
+  // publicly" or changing the participant cap did nothing and said it had
+  // worked. They are real columns with real behaviour behind them -
+  // allowGuestControl gates who may drive playback (timeline.service.ts) and
+  // maxUsers is enforced at join (sync.gateway.ts) - so they belong here.
+  @SkipIfAbsent()
+  @IsBoolean()
+  isPublic?: boolean;
+
+  @SkipIfAbsent()
+  @IsBoolean()
+  allowGuestControl?: boolean;
+
+  // Floor of 2: a one-person watch party is a contradiction, and a cap below
+  // the people already in the room would only strand the next reconnect.
+  @SkipIfAbsent()
+  @IsInt()
+  @Min(2)
+  @Max(500)
+  maxUsers?: number;
 }

--- a/video-sync-frontend/public/index.html
+++ b/video-sync-frontend/public/index.html
@@ -26,6 +26,9 @@
       title would need server-side rendering. The generic card is honest
       about what the link is; the room itself is behind sign-in anyway, so
       there is nothing room-specific we would want a crawler to hold.
+      Deliberately NO og:url: every shared link is a room URL, and a fixed
+      one here would tell every chat app that /join-room/ABC123 is really
+      the homepage. Omitting it lets the shared URL speak for itself.
     -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="mustard.watch" />
@@ -34,7 +37,6 @@
       property="og:description"
       content="Join the room and watch in sync - YouTube, Vimeo, HLS, or a plain file."
     />
-    <meta property="og:url" content="https://mustard.watch/" />
     <meta property="og:image" content="https://mustard.watch/logo512.png" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Watch together. Milliseconds apart." />

--- a/video-sync-frontend/public/index.html
+++ b/video-sync-frontend/public/index.html
@@ -18,6 +18,31 @@
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
+      Sharing a room means pasting its link into a chat app, and without
+      these every invite arrived as a naked URL with no title, no
+      description and no image - which reads like a link nobody should
+      click. These are static because this is a single-page app served as
+      one HTML file: a crawler never runs our JavaScript, so a per-room
+      title would need server-side rendering. The generic card is honest
+      about what the link is; the room itself is behind sign-in anyway, so
+      there is nothing room-specific we would want a crawler to hold.
+    -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="mustard.watch" />
+    <meta property="og:title" content="Watch together. Milliseconds apart." />
+    <meta
+      property="og:description"
+      content="Join the room and watch in sync - YouTube, Vimeo, HLS, or a plain file."
+    />
+    <meta property="og:url" content="https://mustard.watch/" />
+    <meta property="og:image" content="https://mustard.watch/logo512.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Watch together. Milliseconds apart." />
+    <meta
+      name="twitter:description"
+      content="Join the room and watch in sync - YouTube, Vimeo, HLS, or a plain file."
+    />
+    <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->

--- a/video-sync-frontend/src/App.tsx
+++ b/video-sync-frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { LoginPage } from './pages/LoginPage';
 import { AuthCallbackPage } from './pages/AuthCallbackPage';
 import { CreateRoomPage } from './pages/CreateRoomPage';
 import { JoinRoomPage } from './pages/JoinRoomPage';
+import { JoinByCodePage } from './pages/JoinByCodePage';
 import { color, font, radius } from './theme';
 import './App.css';
 
@@ -37,6 +38,7 @@ function App() {
                     the OAuth return to '/' and drop the token with it */}
                 <Route path="/auth/callback" element={<AuthCallbackPage />} />
                 <Route path="/create-room" element={<CreateRoomPage />} />
+                <Route path="/join" element={<JoinByCodePage />} />
                 <Route path="/join-room/:roomCode" element={<JoinRoomPage />} />
                 <Route path="/room/:roomCode" element={<EnhancedRoomPage />} />
                 <Route path="*" element={<Navigate to="/" replace />} />

--- a/video-sync-frontend/src/components/ChatPanel.test.tsx
+++ b/video-sync-frontend/src/components/ChatPanel.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { ChatPanel } from './ChatPanel';
+
+type Handler = (payload: any) => void;
+
+const handlers: Record<string, Handler> = {};
+const mockSocket = {
+  on: (event: string, cb: Handler) => {
+    handlers[event] = cb;
+  },
+  off: (event: string) => {
+    delete handlers[event];
+  },
+  emit: jest.fn(),
+};
+
+jest.mock('../contexts/SocketContext', () => ({
+  useSocket: () => ({ socket: mockSocket }),
+}));
+
+jest.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1', username: 'ada' } }),
+}));
+
+const at = (iso: string) => new Date(iso);
+
+const message = (over: Partial<Record<string, unknown>> = {}) => ({
+  id: `m${Math.random()}`,
+  userId: 'u2',
+  username: 'grace',
+  message: 'hello',
+  timestamp: at('2026-08-09T20:30:00Z'),
+  ...over,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  for (const key of Object.keys(handlers)) delete handlers[key];
+  // scrollIntoView does not exist in jsdom
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+const renderChat = () => render(<ChatPanel roomCode="ABC123" />);
+
+describe('chat timestamps', () => {
+  it('shows when a message was sent, with a machine-readable time', () => {
+    renderChat();
+    act(() => handlers['message-history']([message()]));
+
+    const stamp = screen.getByText(/\d{1,2}:\d{2}/);
+    expect(stamp.tagName.toLowerCase()).toBe('time');
+    expect(stamp).toHaveAttribute('dateTime', '2026-08-09T20:30:00.000Z');
+  });
+
+  it('renders a message with an unusable timestamp rather than crashing', () => {
+    // history comes off the wire; a bad value must not take the panel down
+    renderChat();
+    act(() => handlers['message-history']([message({ timestamp: 'nonsense' })]));
+
+    expect(screen.getByText('hello')).toBeInTheDocument();
+    expect(screen.queryByText(/invalid/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('scrolling while reading back', () => {
+  it('follows the conversation when you are at the live end', () => {
+    renderChat();
+    act(() => handlers['chat-message'](message()));
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    expect(screen.queryByText(/new message/i)).not.toBeInTheDocument();
+  });
+
+  it('does not yank you to the bottom when you have scrolled up', () => {
+    renderChat();
+    const area = screen.getByTestId('chat-messages');
+    // put the reader well away from the end
+    Object.defineProperty(area, 'scrollHeight', { value: 1000, configurable: true });
+    Object.defineProperty(area, 'clientHeight', { value: 200, configurable: true });
+    Object.defineProperty(area, 'scrollTop', { value: 0, configurable: true });
+
+    (Element.prototype.scrollIntoView as jest.Mock).mockClear();
+    act(() => handlers['chat-message'](message({ message: 'while you read' })));
+
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+    // and it says what you missed, which is otherwise invisible
+    expect(screen.getByText('1 new message')).toBeInTheDocument();
+  });
+});

--- a/video-sync-frontend/src/components/ChatPanel.test.tsx
+++ b/video-sync-frontend/src/components/ChatPanel.test.tsx
@@ -78,6 +78,11 @@ describe('scrolling while reading back', () => {
     Object.defineProperty(area, 'scrollHeight', { value: 1000, configurable: true });
     Object.defineProperty(area, 'clientHeight', { value: 200, configurable: true });
     Object.defineProperty(area, 'scrollTop', { value: 0, configurable: true });
+    // scrolling in a real browser fires this; the panel reads the reader's
+    // position from the event rather than re-measuring after the append
+    act(() => {
+      area.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
 
     (Element.prototype.scrollIntoView as jest.Mock).mockClear();
     act(() => handlers['chat-message'](message({ message: 'while you read' })));
@@ -85,5 +90,29 @@ describe('scrolling while reading back', () => {
     expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
     // and it says what you missed, which is otherwise invisible
     expect(screen.getByText('1 new message')).toBeInTheDocument();
+  });
+});
+
+describe('a tall message must not look like scrolling away', () => {
+  it('keeps following when the reader was at the end, however tall the message', () => {
+    // The old code measured AFTER React appended the message, so a message
+    // taller than the near-bottom threshold pushed the end out of reach by
+    // itself and the reader was misclassified as reading history.
+    renderChat();
+    const area = screen.getByTestId('chat-messages');
+
+    // reader is at the live end
+    Object.defineProperty(area, 'scrollHeight', { value: 300, configurable: true });
+    Object.defineProperty(area, 'clientHeight', { value: 300, configurable: true });
+    Object.defineProperty(area, 'scrollTop', { value: 0, configurable: true });
+    act(() => { area.dispatchEvent(new Event('scroll', { bubbles: true })); });
+
+    // a very tall message lands: the content now far exceeds the viewport
+    Object.defineProperty(area, 'scrollHeight', { value: 2000, configurable: true });
+    (Element.prototype.scrollIntoView as jest.Mock).mockClear();
+    act(() => handlers['chat-message'](message({ message: 'a'.repeat(2000) })));
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    expect(screen.queryByText(/new message/i)).not.toBeInTheDocument();
   });
 });

--- a/video-sync-frontend/src/components/ChatPanel.tsx
+++ b/video-sync-frontend/src/components/ChatPanel.tsx
@@ -175,6 +175,11 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ roomCode }) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesAreaRef = useRef<HTMLDivElement>(null);
   const [unread, setUnread] = useState(0);
+  // Whether the reader was at the live end BEFORE this message arrived.
+  // Measuring after the render is too late: a message taller than the
+  // near-bottom threshold pushes the end away by itself, so someone who was
+  // reading live gets classed as reading history and stops being followed.
+  const wasNearBottomRef = useRef(true);
 
   useEffect(() => {
     if (!socket) return;
@@ -197,11 +202,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ roomCode }) => {
   // Unconditional scrolling yanked anyone scrolling back through history
   // to the end every time somebody typed.
   useEffect(() => {
-    const area = messagesAreaRef.current;
-    if (!area) return;
-    const distanceFromBottom =
-      area.scrollHeight - area.scrollTop - area.clientHeight;
-    if (distanceFromBottom <= NEAR_BOTTOM_PX) {
+    if (wasNearBottomRef.current) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
       setUnread(0);
     } else {
@@ -238,6 +239,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ roomCode }) => {
           const el = e.currentTarget;
           const atBottom =
             el.scrollHeight - el.scrollTop - el.clientHeight <= NEAR_BOTTOM_PX;
+          wasNearBottomRef.current = atBottom;
           if (atBottom) setUnread(0);
         }}
       >

--- a/video-sync-frontend/src/components/ChatPanel.tsx
+++ b/video-sync-frontend/src/components/ChatPanel.tsx
@@ -2,7 +2,17 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useSocket } from '../contexts/SocketContext';
 import { useAuth } from '../contexts/AuthContext';
 import styled from '@emotion/styled';
-import { card, color, font, input, button, buttonSm, sectionLabel } from '../theme';
+import {
+  card,
+  chip,
+  chipInteractive,
+  color,
+  font,
+  input,
+  button,
+  buttonSm,
+  sectionLabel,
+} from '../theme';
 
 // The chat is a linear log, not a chat-bubble app: one column, sender
 // names carrying the only color distinction. The 400px height and the
@@ -59,6 +69,20 @@ const EmptyHint = styled.div`
   color: ${color.faint};
 `;
 
+/** Sender and time share a line: the time is metadata, not a message. */
+const MessageHead = styled.div`
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+`;
+
+const Timestamp = styled.time`
+  font-family: ${font.mono};
+  font-size: 10.5px;
+  color: ${color.faint};
+  font-variant-numeric: tabular-nums;
+`;
+
 const Sender = styled.div<{ isOwn: boolean }>`
   font-family: ${font.body};
   font-size: 11.5px;
@@ -73,6 +97,21 @@ const MessageText = styled.div`
   color: ${color.text};
   overflow-wrap: break-word;
   word-break: break-word;
+`;
+
+/**
+ * Only appears when you have scrolled away AND missed something - it is the
+ * answer to "did I miss anything", which is otherwise invisible while you
+ * are reading back.
+ */
+const JumpToLatest = styled.button`
+  ${chip.sm}
+  ${chipInteractive}
+  align-self: center;
+  margin-bottom: 8px;
+  background: ${color.mustardFaint};
+  color: ${color.mustard};
+  border-color: ${color.mustardDeep};
 `;
 
 const InputArea = styled.form`
@@ -97,6 +136,25 @@ const SendButton = styled.button`
   flex-shrink: 0;
 `;
 
+/** Within this many pixels of the end counts as "reading the live end". */
+const NEAR_BOTTOM_PX = 48;
+
+/**
+ * A time, not a date: chat is read during a film, so the useful question is
+ * "was that just now or ten minutes ago", and anything older than today is
+ * scrollback where the day matters more than the minute.
+ */
+const formatStamp = (value: Date | string): string => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const sameDay = new Date().toDateString() === date.toDateString();
+  return date.toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+    ...(sameDay ? {} : { month: 'short', day: 'numeric' }),
+  });
+};
+
 interface ChatMessage {
   id: string;
   userId: string;
@@ -115,6 +173,8 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ roomCode }) => {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [inputMessage, setInputMessage] = useState('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesAreaRef = useRef<HTMLDivElement>(null);
+  const [unread, setUnread] = useState(0);
 
   useEffect(() => {
     if (!socket) return;
@@ -133,8 +193,20 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ roomCode }) => {
     };
   }, [socket]);
 
+  // Only follow the conversation if the reader is already at the bottom.
+  // Unconditional scrolling yanked anyone scrolling back through history
+  // to the end every time somebody typed.
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const area = messagesAreaRef.current;
+    if (!area) return;
+    const distanceFromBottom =
+      area.scrollHeight - area.scrollTop - area.clientHeight;
+    if (distanceFromBottom <= NEAR_BOTTOM_PX) {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+      setUnread(0);
+    } else {
+      setUnread((n) => n + 1);
+    }
   }, [messages]);
 
   const sendMessage = (e: React.FormEvent) => {
@@ -159,7 +231,16 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ roomCode }) => {
   return (
     <ChatContainer>
       <PanelTitle>Chat</PanelTitle>
-      <MessagesArea>
+      <MessagesArea
+        data-testid="chat-messages"
+        ref={messagesAreaRef}
+        onScroll={(e) => {
+          const el = e.currentTarget;
+          const atBottom =
+            el.scrollHeight - el.scrollTop - el.clientHeight <= NEAR_BOTTOM_PX;
+          if (atBottom) setUnread(0);
+        }}
+      >
         {messages.length === 0 && (
           <EmptyState>
             <EmptyTitle>No messages yet.</EmptyTitle>
@@ -168,12 +249,31 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ roomCode }) => {
         )}
         {messages.map((msg) => (
           <MessageRow key={msg.id}>
-            <Sender isOwn={msg.userId === user?.id}>{msg.username}</Sender>
+            <MessageHead>
+              <Sender isOwn={msg.userId === user?.id}>{msg.username}</Sender>
+              {formatStamp(msg.timestamp) && (
+                <Timestamp dateTime={new Date(msg.timestamp).toISOString()}>
+                  {formatStamp(msg.timestamp)}
+                </Timestamp>
+              )}
+            </MessageHead>
             <MessageText>{msg.message}</MessageText>
           </MessageRow>
         ))}
         <div ref={messagesEndRef} />
       </MessagesArea>
+
+      {unread > 0 && (
+        <JumpToLatest
+          type="button"
+          onClick={() => {
+            messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+            setUnread(0);
+          }}
+        >
+          {unread} new {unread === 1 ? 'message' : 'messages'}
+        </JumpToLatest>
+      )}
 
       <InputArea onSubmit={sendMessage}>
         <Input

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.test.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.test.tsx
@@ -161,3 +161,31 @@ test('a hostile scheme never reaches a media element', () => {
   expect(screen.queryByTestId('html5-video')).toBeNull();
   expect(document.getElementById('youtube-player')).toBeNull();
 });
+
+describe('the stored volume', () => {
+  // Number(null) === 0, so reading a missing key straight through Number()
+  // made silence the default for every first-time visitor.
+  it('defaults to full volume when nothing has been stored', () => {
+    localStorage.removeItem('mustard:volume');
+    const raw = localStorage.getItem('mustard:volume');
+    const resolved =
+      raw === null
+        ? 1
+        : Number.isFinite(Number(raw)) && Number(raw) >= 0 && Number(raw) <= 1
+          ? Number(raw)
+          : 1;
+    expect(resolved).toBe(1);
+  });
+
+  it('honours a stored level, and ignores a corrupt one', () => {
+    const resolve = (raw: string | null) => {
+      if (raw === null) return 1;
+      const n = Number(raw);
+      return Number.isFinite(n) && n >= 0 && n <= 1 ? n : 1;
+    };
+    expect(resolve('0')).toBe(0);
+    expect(resolve('0.4')).toBe(0.4);
+    expect(resolve('nonsense')).toBe(1);
+    expect(resolve('7')).toBe(1);
+  });
+});

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -267,6 +267,38 @@ const CollaborativeIndicator = styled.div<{ enabled: boolean }>`
   color: ${props => (props.enabled ? color.ok : color.dim)};
 `;
 
+const BufferingChip = styled.div`
+  ${chip.sm}
+  ${chipStatic}
+  background: ${color.bg2};
+  color: ${color.dim};
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+`;
+
+const Spinner = styled.span`
+  width: 9px;
+  height: 9px;
+  flex: none;
+  border-radius: 50%;
+  border: 1.5px solid ${color.lineBright};
+  border-top-color: ${color.mustard};
+  animation: spin 700ms linear infinite;
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  /* a perpetual spinner is a headache for anyone who asked not to have one */
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    border-top-color: ${color.lineBright};
+  }
+`;
+
 const RttReadout = styled.div`
   font-family: ${font.mono};
   font-size: 12px;
@@ -348,6 +380,7 @@ const EMPTY_STATUS: EngineStatus = {
   fractionalRateOK: false,
   needsGesture: false,
   seeksIssued: 0,
+  playerState: 'unstarted',
 };
 
 /** Keyboard seek step, in seconds - the arrow-key grain of the seek bar. */
@@ -370,6 +403,9 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
   const { socket, connected } = useSocket();
   const [isReady, setIsReady] = useState(false);
   const [failure, setFailure] = useState<string | null>(null);
+  // Bumped by Retry: it rides in the mount's key, so a retry tears the dead
+  // player down and builds a fresh one rather than poking at the corpse.
+  const [playerEpoch, setPlayerEpoch] = useState(0);
   const [syncEnabled, setSyncEnabled] = useState(true);
   const syncEnabledRef = useRef(true);
   const [status, setStatus] = useState<EngineStatus>(EMPTY_STATUS);
@@ -585,6 +621,13 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
         title="Couldn't play this video"
         detail={failure}
         url={activeVideoUrl}
+        onRetry={() => {
+          // A dead CDN, a flaky network or an ad-blocker swallowing the
+          // frame are all transient, and the only recovery on offer was
+          // reloading the whole page - which drops you out of the room.
+          setFailure(null);
+          setPlayerEpoch((n) => n + 1);
+        }}
       />
     );
   } else {
@@ -593,7 +636,7 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
         // key: a new video id must tear the old player down, not mutate it
         mount = (
           <YouTubeMount
-            key={source.videoId}
+            key={`${source.videoId}:${playerEpoch}`}
             videoId={source.videoId}
             onAdapter={handleAdapter}
             onFailure={handleFailure}
@@ -604,7 +647,7 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
       case 'file':
         mount = (
           <Html5Mount
-            key={source.url}
+            key={`${source.url}:${playerEpoch}`}
             url={source.url}
             hls={source.kind === 'hls'}
             onAdapter={handleAdapter}
@@ -615,7 +658,7 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
       case 'vimeo':
         mount = (
           <VimeoMount
-            key={source.videoId}
+            key={`${source.videoId}:${playerEpoch}`}
             videoId={source.videoId}
             hash={source.hash}
             onAdapter={handleAdapter}
@@ -792,6 +835,16 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
                 <StatusDot tone={connected ? color.ok : color.danger} />
                 {connected ? 'Connected' : 'Disconnected'}
               </ConnectionState>
+
+              {/* "it is loading" and "it is broken" look identical when the
+                  stage is just black - and during a stall everyone stares at
+                  it wondering whose connection is at fault */}
+              {status.playerState === 'buffering' && (
+                <BufferingChip role="status">
+                  <Spinner />
+                  Buffering
+                </BufferingChip>
+              )}
 
               <CollaborativeIndicator enabled={allowGuestControl}>
                 {allowGuestControl ? <IconUsers size={13} /> : <IconCrown size={13} />}

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -14,6 +14,7 @@ import { FailureCard } from './player/FailureCard';
 import { YouTubeMount } from './player/YouTubeMount';
 import { Html5Mount } from './player/Html5Mount';
 import { VimeoMount } from './player/VimeoMount';
+import { toggleFullscreen } from './player/fullscreen';
 import {
   button,
   card,
@@ -438,7 +439,11 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
   // Persisted so the level survives a reload mid-film; a room you had muted
   // must not come back at full volume with people asleep next door.
   const [volume, setVolumeState] = useState(() => {
-    const stored = Number(localStorage.getItem(VOLUME_KEY));
+    // Read the raw string first: Number(null) is 0, not NaN, so parsing
+    // straight from a missing key made every new visitor's default silence.
+    const raw = localStorage.getItem(VOLUME_KEY);
+    if (raw === null) return 1;
+    const stored = Number(raw);
     return Number.isFinite(stored) && stored >= 0 && stored <= 1 ? stored : 1;
   });
   const [muted, setMutedState] = useState(
@@ -471,16 +476,8 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
     return () => document.removeEventListener('fullscreenchange', onChange);
   }, []);
 
-  const toggleFullscreen = useCallback(() => {
-    const el = shellRef.current;
-    if (!el) return;
-    if (document.fullscreenElement) {
-      void document.exitFullscreen().catch(() => undefined);
-    } else {
-      // Safari <16.4 and any embedded webview can refuse; a rejected promise
-      // here is a browser saying no, not a bug to surface.
-      void el.requestFullscreen?.().catch(() => undefined);
-    }
+  const handleToggleFullscreen = useCallback(() => {
+    void toggleFullscreen(shellRef.current, document);
   }, []);
 
   // ---- keyboard ----
@@ -503,7 +500,7 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
           break;
         case 'f':
           e.preventDefault();
-          toggleFullscreen();
+          handleToggleFullscreen();
           break;
         case 'm':
           e.preventDefault();
@@ -517,7 +514,7 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
     return () => window.removeEventListener('keydown', onKey);
     // handlePlayPause closes over live status/canControl, so it must be a dep
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [toggleFullscreen, toggleMuted, status.roomPlaying, canControl, isReady]);
+  }, [handleToggleFullscreen, toggleMuted, status.roomPlaying, canControl, isReady]);
 
   // Mount callbacks: stable so mounts don't remount on shell re-renders
   const handleAdapter = useCallback((adapter: EngineAdapter | null) => {
@@ -777,7 +774,7 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
 
             <IconControl
               type="button"
-              onClick={toggleFullscreen}
+              onClick={handleToggleFullscreen}
               aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
               title={isFullscreen ? 'Exit fullscreen (f)' : 'Fullscreen (f)'}
             >

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -25,17 +25,59 @@ import {
   font,
   radius,
 } from '../theme';
-import { IconCrown, IconPause, IconPlay, IconSync, IconUsers } from './Icons';
+import {
+  IconCrown,
+  IconExitFullscreen,
+  IconFullscreen,
+  IconPause,
+  IconPlay,
+  IconSync,
+  IconUsers,
+  IconVolume,
+  IconVolumeOff,
+} from './Icons';
 
-const PlayerContainer = styled.div`
+
+const VOLUME_KEY = 'mustard:volume';
+const MUTED_KEY = 'mustard:muted';
+
+/**
+ * Is this keystroke destined for a text field? Chat sits on the same page as
+ * the player, so every global shortcut has to yield to it.
+ */
+const isTypingTarget = (target: EventTarget | null): boolean => {
+  const el = target as HTMLElement | null;
+  if (!el || !el.tagName) return false;
+  const tag = el.tagName.toLowerCase();
+  return (
+    tag === 'input' ||
+    tag === 'textarea' ||
+    tag === 'select' ||
+    el.isContentEditable === true
+  );
+};
+
+const PlayerContainer = styled.div<{ fullscreen?: boolean }>`
   ${card}
   width: 100%;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+
+  /* In fullscreen the shell IS the screen: square off the card, drop the
+     border, and let the stage take everything the controls do not. */
+  ${(props) =>
+    props.fullscreen
+      ? `
+    height: 100vh;
+    border-radius: 0;
+    border: none;
+    background: #000;
+  `
+      : ''}
 `;
 
-const VideoWrapper = styled.div`
+const VideoWrapper = styled.div<{ fullscreen?: boolean }>`
   position: relative;
   width: 100%;
   aspect-ratio: 16 / 9;
@@ -47,6 +89,17 @@ const VideoWrapper = styled.div`
   margin: 0 auto;
   background: #000;
   overflow: hidden;
+
+  /* the 16:9 cap is there to keep Play above the fold on a laptop; in
+     fullscreen there is no fold, and the cap would letterbox twice */
+  ${(props) =>
+    props.fullscreen
+      ? `
+    aspect-ratio: auto;
+    flex: 1;
+    max-height: none;
+  `
+      : ''}
 `;
 
 const GestureChip = styled.button`
@@ -229,6 +282,50 @@ const SyncToggle = styled.button<{ active?: boolean }>`
   border-color: ${props => (props.active ? color.mustardDeep : color.lineBright)};
 `;
 
+
+/** Icon-only control: square, quiet, same focus ring as everything else. */
+const IconControl = styled.button`
+  ${chip.sm}
+  ${chipInteractive}
+  background: ${color.bg2};
+  color: ${color.dim};
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+
+  &:hover {
+    color: ${color.text};
+  }
+`;
+
+/* The slider only appears on hover/focus-within so the bar stays quiet, but
+   it never collapses on touch, where there is no hover to reveal it. */
+const VolumeGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: none;
+`;
+
+const VolumeSlider = styled.input`
+  width: 84px;
+  accent-color: ${color.mustard};
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: ${focusRing};
+  }
+
+  @media (max-width: 880px) {
+    display: none;
+  }
+`;
+
 interface VideoPlayerProps {
   videoUrl: string;
   roomCode: string;
@@ -337,14 +434,90 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
     };
   }, [socket, roomCode]);
 
-  // HUD toggle on backtick
+  // ---- local audio: never synced, never sent (see EngineAdapter) ----
+  // Persisted so the level survives a reload mid-film; a room you had muted
+  // must not come back at full volume with people asleep next door.
+  const [volume, setVolumeState] = useState(() => {
+    const stored = Number(localStorage.getItem(VOLUME_KEY));
+    return Number.isFinite(stored) && stored >= 0 && stored <= 1 ? stored : 1;
+  });
+  const [muted, setMutedState] = useState(
+    () => localStorage.getItem(MUTED_KEY) === '1',
+  );
+
+  // Re-applied whenever the adapter changes: a source switch builds a new
+  // player at its own default, which would otherwise blast an unmuted 100%.
+  useEffect(() => {
+    const adapter = adapterRef.current;
+    if (!adapter) return;
+    adapter.setVolume?.(muted ? 0 : volume);
+    adapter.setMuted?.(muted);
+    localStorage.setItem(VOLUME_KEY, String(volume));
+    localStorage.setItem(MUTED_KEY, muted ? '1' : '0');
+  }, [volume, muted, isReady]);
+
+  const toggleMuted = useCallback(() => setMutedState((m) => !m), []);
+
+  // ---- fullscreen ----
+  // The whole shell goes fullscreen, not the video element: the controls,
+  // sync readout and chat toggle have to remain reachable, and on the
+  // YouTube path the element is a cross-origin iframe we cannot decorate.
+  const shellRef = useRef<HTMLDivElement | null>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    const onChange = () => setIsFullscreen(document.fullscreenElement !== null);
+    document.addEventListener('fullscreenchange', onChange);
+    return () => document.removeEventListener('fullscreenchange', onChange);
+  }, []);
+
+  const toggleFullscreen = useCallback(() => {
+    const el = shellRef.current;
+    if (!el) return;
+    if (document.fullscreenElement) {
+      void document.exitFullscreen().catch(() => undefined);
+    } else {
+      // Safari <16.4 and any embedded webview can refuse; a rejected promise
+      // here is a browser saying no, not a bug to surface.
+      void el.requestFullscreen?.().catch(() => undefined);
+    }
+  }, []);
+
+  // ---- keyboard ----
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === '`') setShowHud((v) => !v);
+      if (e.key === '`') {
+        setShowHud((v) => !v);
+        return;
+      }
+      // Never steal a key from someone typing - chat lives on this page, and
+      // a space that pauses the film mid-sentence is worse than no shortcut.
+      if (isTypingTarget(e.target) || e.metaKey || e.ctrlKey || e.altKey) return;
+
+      switch (e.key) {
+        case ' ':
+        case 'k':
+          // space scrolls the page by default, which is what it did before
+          e.preventDefault();
+          handlePlayPause();
+          break;
+        case 'f':
+          e.preventDefault();
+          toggleFullscreen();
+          break;
+        case 'm':
+          e.preventDefault();
+          toggleMuted();
+          break;
+        default:
+          break;
+      }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, []);
+    // handlePlayPause closes over live status/canControl, so it must be a dep
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toggleFullscreen, toggleMuted, status.roomPlaying, canControl, isReady]);
 
   // Mount callbacks: stable so mounts don't remount on shell re-renders
   const handleAdapter = useCallback((adapter: EngineAdapter | null) => {
@@ -521,8 +694,8 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
   };
 
   return (
-    <PlayerContainer>
-      <VideoWrapper>
+    <PlayerContainer ref={shellRef} fullscreen={isFullscreen}>
+      <VideoWrapper fullscreen={isFullscreen}>
         {mount ?? overlay}
         {mount && status.needsGesture && (
           <GestureChip onClick={() => engineRef.current?.resumeFromGesture()}>
@@ -570,6 +743,50 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
             <TimeDisplay>
               {formatTime(shownTime)} / {formatTime(status.durationS)}
             </TimeDisplay>
+
+            <VolumeGroup>
+              <IconControl
+                type="button"
+                onClick={toggleMuted}
+                aria-label={muted ? 'Unmute' : 'Mute'}
+                aria-pressed={muted}
+                title={muted ? 'Unmute (m)' : 'Mute (m)'}
+              >
+                {muted || volume === 0 ? (
+                  <IconVolumeOff size={15} />
+                ) : (
+                  <IconVolume size={15} />
+                )}
+              </IconControl>
+              <VolumeSlider
+                type="range"
+                min={0}
+                max={1}
+                step={0.01}
+                value={muted ? 0 : volume}
+                aria-label="Volume"
+                onChange={(e) => {
+                  const next = Number(e.target.value);
+                  setVolumeState(next);
+                  // dragging off zero is an unmute; nobody drags a slider up
+                  // and means "still silent"
+                  if (next > 0 && muted) setMutedState(false);
+                }}
+              />
+            </VolumeGroup>
+
+            <IconControl
+              type="button"
+              onClick={toggleFullscreen}
+              aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+              title={isFullscreen ? 'Exit fullscreen (f)' : 'Fullscreen (f)'}
+            >
+              {isFullscreen ? (
+                <IconExitFullscreen size={15} />
+              ) : (
+                <IconFullscreen size={15} />
+              )}
+            </IconControl>
           </ControlRow>
 
           <StatusRow>

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -491,8 +491,11 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
   useEffect(() => {
     const adapter = adapterRef.current;
     if (!adapter) return;
-    adapter.setVolume?.(muted ? 0 : volume);
+    // Order matters: Vimeo has no mute call, so its setMuted is really
+    // "volume 0 or 1" - applying it AFTER setVolume threw away a chosen
+    // level of 0.4 on every unmute. Mute first, level last.
     adapter.setMuted?.(muted);
+    adapter.setVolume?.(muted ? 0 : volume);
     localStorage.setItem(VOLUME_KEY, String(volume));
     localStorage.setItem(MUTED_KEY, muted ? '1' : '0');
   }, [volume, muted, isReady]);
@@ -519,13 +522,15 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
   // ---- keyboard ----
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      // Never steal a key from someone typing - chat lives on this page, and
+      // a space that pauses the film mid-sentence is worse than no shortcut.
+      // This guards the HUD key too: a backtick belongs to the message.
+      if (isTypingTarget(e.target) || e.metaKey || e.ctrlKey || e.altKey) return;
+
       if (e.key === '`') {
         setShowHud((v) => !v);
         return;
       }
-      // Never steal a key from someone typing - chat lives on this page, and
-      // a space that pauses the film mid-sentence is worse than no shortcut.
-      if (isTypingTarget(e.target) || e.metaKey || e.ctrlKey || e.altKey) return;
 
       switch (e.key) {
         case ' ':

--- a/video-sync-frontend/src/components/Icons.tsx
+++ b/video-sync-frontend/src/components/Icons.tsx
@@ -86,6 +86,20 @@ export const IconHeadphones = (p: P) =>
 export const IconHeadphonesOff = (p: P) =>
   base(p, <><path d="M4.5 14v-2c0-1.2.28-2.34.78-3.35" /><path d="M8.2 5.5A7.47 7.47 0 0 1 19.5 12v2" /><rect x="3.5" y="13.5" width="4" height="6.5" rx="1.6" /><rect x="16.5" y="13.5" width="4" height="6.5" rx="1.6" /><path d="M4 4l16 16" /></>);
 
+export const IconVolume = (p: P) =>
+  base(p, <><path d="M11 5.5 6.8 9H4a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h2.8L11 18.5a.6.6 0 0 0 1-.46V5.96a.6.6 0 0 0-1-.46z" /><path d="M15.4 9.2a4 4 0 0 1 0 5.6" /><path d="M18.2 6.6a8 8 0 0 1 0 10.8" /></>);
+
+/** Muted: the same speaker, struck through - one shape, two states. */
+export const IconVolumeOff = (p: P) =>
+  base(p, <><path d="M11 5.5 6.8 9H4a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h2.8L11 18.5a.6.6 0 0 0 1-.46V5.96a.6.6 0 0 0-1-.46z" /><path d="M16 10l4 4" /><path d="M20 10l-4 4" /></>);
+
+export const IconFullscreen = (p: P) =>
+  base(p, <><path d="M4 9V5.6A1.6 1.6 0 0 1 5.6 4H9" /><path d="M15 4h3.4A1.6 1.6 0 0 1 20 5.6V9" /><path d="M20 15v3.4a1.6 1.6 0 0 1-1.6 1.6H15" /><path d="M9 20H5.6A1.6 1.6 0 0 1 4 18.4V15" /></>);
+
+/** Arrows turned inward: the same corners, pointing the other way. */
+export const IconExitFullscreen = (p: P) =>
+  base(p, <><path d="M9 4v3.4A1.6 1.6 0 0 1 7.4 9H4" /><path d="M20 9h-3.4A1.6 1.6 0 0 1 15 7.4V4" /><path d="M15 20v-3.4a1.6 1.6 0 0 1 1.6-1.6H20" /><path d="M4 15h3.4A1.6 1.6 0 0 1 9 16.6V20" /></>);
+
 export const IconFilm = (p: P) =>
   base(p, <><rect x="3.5" y="5" width="17" height="14" rx="2" /><path d="M3.5 9.5L20.5 9.5" /><path d="M7.5 5.2L9.8 9.4" /><path d="M12.4 5.2l2.3 4.2" /><path d="M17.3 5.2l2.3 4.2" /></>);
 

--- a/video-sync-frontend/src/components/RoomSettings.test.tsx
+++ b/video-sync-frontend/src/components/RoomSettings.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { RoomSettings } from './RoomSettings';
+import { apiService } from '../services/api';
+
+jest.mock('../services/api', () => ({
+  AUTH_EXPIRED_EVENT: 'mustard:auth-expired',
+  apiBaseUrl: 'http://api.test/api',
+  apiService: { updateRoom: jest.fn(), deleteRoom: jest.fn() },
+}));
+
+const mockSendSetVideo = jest.fn((..._args: unknown[]) => true);
+jest.mock('../sync/SyncEngine', () => ({
+  sendSetVideo: (...args: unknown[]) => mockSendSetVideo(...args),
+}));
+
+const mockSocket = { id: 'sock' };
+jest.mock('../contexts/SocketContext', () => ({
+  useSocket: () => ({ socket: mockSocket }),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const updateRoom = apiService.updateRoom as jest.Mock;
+const deleteRoom = apiService.deleteRoom as jest.Mock;
+
+const room = {
+  id: 'r1',
+  code: 'ABC123',
+  name: 'Movie night',
+  videoUrl: 'https://www.youtube.com/watch?v=aqz-KE-bpKQ',
+  isPublic: false,
+  allowGuestControl: false,
+  maxUsers: 20,
+};
+
+const renderSettings = (overrides = {}) => {
+  const onClose = jest.fn();
+  const onUpdate = jest.fn();
+  render(
+    <MemoryRouter>
+      <RoomSettings
+        room={{ ...room, ...overrides }}
+        onClose={onClose}
+        onUpdate={onUpdate}
+      />
+    </MemoryRouter>,
+  );
+  return { onClose, onUpdate };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  updateRoom.mockResolvedValue({ data: {} });
+  deleteRoom.mockResolvedValue({ data: {} });
+  mockSendSetVideo.mockReturnValue(true);
+});
+
+describe('settings that used to be collected and thrown away', () => {
+  it('sends the public flag to the server when it is toggled', async () => {
+    renderSettings();
+    await userEvent.click(screen.getByLabelText('List publicly'));
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(updateRoom).toHaveBeenCalled());
+    expect(updateRoom).toHaveBeenCalledWith('ABC123', { isPublic: true });
+  });
+
+  it('sends guest control - the toggle that decides who may press play', async () => {
+    renderSettings();
+    await userEvent.click(
+      screen.getByLabelText('Let everyone control playback'),
+    );
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(updateRoom).toHaveBeenCalledWith('ABC123', {
+        allowGuestControl: true,
+      }),
+    );
+  });
+
+  it('sends a renamed room', async () => {
+    renderSettings();
+    const field = screen.getByLabelText('Room name');
+    await userEvent.clear(field);
+    await userEvent.type(field, 'Sunday matinee');
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(updateRoom).toHaveBeenCalledWith('ABC123', {
+        name: 'Sunday matinee',
+      }),
+    );
+  });
+
+  it('sends nothing at all when nothing changed', async () => {
+    // an unchanged save must not rewrite the row, and must NOT re-broadcast
+    // the video - that would restart playback for everyone in the room
+    renderSettings();
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByText(/saving/i)).not.toBeInTheDocument(),
+    );
+    expect(updateRoom).not.toHaveBeenCalled();
+    expect(mockSendSetVideo).not.toHaveBeenCalled();
+  });
+
+  it('refuses to save a room with no name', async () => {
+    renderSettings();
+    await userEvent.clear(screen.getByLabelText('Room name'));
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(updateRoom).not.toHaveBeenCalled());
+  });
+});
+
+describe('the video still travels as a synced control', () => {
+  it('broadcasts a changed video instead of PATCHing it', async () => {
+    renderSettings();
+    const field = screen.getByLabelText('Video URL');
+    await userEvent.clear(field);
+    await userEvent.type(field, 'https://cdn.example.com/film.mp4');
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(mockSendSetVideo).toHaveBeenCalled());
+    expect(mockSendSetVideo).toHaveBeenCalledWith(
+      mockSocket,
+      'ABC123',
+      'https://cdn.example.com/film.mp4',
+    );
+    // the video is NOT a column write from here
+    expect(updateRoom).not.toHaveBeenCalled();
+  });
+
+  it('refuses a URL no player can take, without touching the server', async () => {
+    renderSettings();
+    const field = screen.getByLabelText('Video URL');
+    await userEvent.clear(field);
+    await userEvent.type(field, 'javascript:alert(1)');
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(mockSendSetVideo).not.toHaveBeenCalled());
+    expect(updateRoom).not.toHaveBeenCalled();
+  });
+});
+
+describe('End room', () => {
+  it('actually ends the room', async () => {
+    // it used to toast "Room ended" and navigate away with the delete
+    // commented out, so the room carried on with everyone still in it
+    window.confirm = jest.fn(() => true);
+    renderSettings();
+    await userEvent.click(screen.getByRole('button', { name: /end room/i }));
+
+    await waitFor(() => expect(deleteRoom).toHaveBeenCalledWith('ABC123'));
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('does nothing when the confirmation is declined', async () => {
+    window.confirm = jest.fn(() => false);
+    renderSettings();
+    await userEvent.click(screen.getByRole('button', { name: /end room/i }));
+
+    expect(deleteRoom).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('keeps you in the room when the delete fails', async () => {
+    window.confirm = jest.fn(() => true);
+    deleteRoom.mockRejectedValue({ response: { data: { message: 'nope' } } });
+    renderSettings();
+    await userEvent.click(screen.getByRole('button', { name: /end room/i }));
+
+    await waitFor(() => expect(deleteRoom).toHaveBeenCalled());
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/video-sync-frontend/src/components/RoomSettings.tsx
+++ b/video-sync-frontend/src/components/RoomSettings.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { toast } from 'react-hot-toast';
 import { useSocket } from '../contexts/SocketContext';
+import { apiService } from '../services/api';
 import { isAcceptableVideoUrl } from '../shared/media-source';
 import { sendSetVideo } from '../sync/SyncEngine';
 import { card, color, font, input, button, ghostIconButton, radius, focusRing, sectionLabel } from '../theme';
@@ -146,7 +148,11 @@ interface RoomSettingsProps {
 const DEFAULT_MAX_USERS = 20;
 
 export const RoomSettings: React.FC<RoomSettingsProps> = ({ room, onClose, onUpdate }) => {
+  const [name, setName] = useState<string>(room.name || '');
   const [isPublic, setIsPublic] = useState(room.isPublic || false);
+  const [allowGuestControl, setAllowGuestControl] = useState(
+    Boolean(room.allowGuestControl),
+  );
   // '' is a legal intermediate state: a number field being retyped is empty
   // for a keystroke, and parsing that into NaN would blank the control and
   // make React complain about the value attribute. Blur settles it back to a
@@ -155,12 +161,9 @@ export const RoomSettings: React.FC<RoomSettingsProps> = ({ room, onClose, onUpd
   const [videoUrl, setVideoUrl] = useState(room.videoUrl || '');
   const [loading, setLoading] = useState(false);
   const { socket } = useSocket();
+  const navigate = useNavigate();
 
-  const handleUpdateSettings = () => {
-    // Changing the video is a SYNCED CONTROL, not a REST write: everyone in
-    // the room switches together through the sync:timeline broadcast, with
-    // the same exactly-once machinery as play/pause/seek. The server
-    // persists the room row from the committed timeline.
+  const handleUpdateSettings = async () => {
     const url = videoUrl.trim();
     if (url !== '' && !isAcceptableVideoUrl(url)) {
       // the same shared rule the gateway enforces - refused here it is
@@ -168,33 +171,83 @@ export const RoomSettings: React.FC<RoomSettingsProps> = ({ room, onClose, onUpd
       toast.error("That URL can't be played - use a video link or YouTube id");
       return;
     }
-    setLoading(true);
-    if (socket !== null && sendSetVideo(socket, room.code, url)) {
-      // wait-for-broadcast: the player switches when sync:timeline arrives
-      toast.success('Video changed for everyone in the room');
-      if (onUpdate) onUpdate();
-    } else {
-      // dropped, never buffered: a stale reconnect flush must not change
-      // the room's video minutes later
-      toast.error('Not connected - try again in a moment');
-    }
-    setLoading(false);
-  };
 
-  const handleEndRoom = async () => {
-    if (!window.confirm('Are you sure you want to end this room? All participants will be disconnected.')) {
+    const trimmedName = name.trim();
+    if (trimmedName === '') {
+      toast.error('A room needs a name');
       return;
     }
 
+    setLoading(true);
     try {
-      // For now, just navigate away - room deletion handled separately
-      // await apiService.updateRoom(room.code, {
-      //   isActive: false,
-      // });
+      // Two different kinds of change, deliberately on two different paths.
+      //
+      // The room's PROPERTIES are a REST write: they are facts about the row,
+      // nobody's playhead moves, and the creator check lives on the route.
+      // Until now this function never sent them at all - the name, the public
+      // flag, the participant cap and guest control were collected by the form
+      // and dropped on the floor, and the toast still said it had saved.
+      const changed: Record<string, unknown> = {};
+      if (trimmedName !== room.name) changed.name = trimmedName;
+      if (isPublic !== Boolean(room.isPublic)) changed.isPublic = isPublic;
+      if (allowGuestControl !== Boolean(room.allowGuestControl)) {
+        changed.allowGuestControl = allowGuestControl;
+      }
+      if (typeof maxUsers === 'number' && maxUsers !== room.maxUsers) {
+        changed.maxUsers = maxUsers;
+      }
+      if (Object.keys(changed).length > 0) {
+        await apiService.updateRoom(room.code, changed);
+      }
+
+      // The VIDEO is a synced control, not a REST write: everyone switches
+      // together through the sync:timeline broadcast, with the same
+      // exactly-once machinery as play/pause/seek.
+      const videoChanged = url !== (room.videoUrl || '');
+      if (videoChanged) {
+        if (socket === null || !sendSetVideo(socket, room.code, url)) {
+          // dropped, never buffered: a stale reconnect flush must not change
+          // the room's video minutes later
+          toast.error('Not connected - the video was not changed');
+          return;
+        }
+      }
+
+      toast.success(
+        videoChanged
+          ? 'Saved - the video changed for everyone in the room'
+          : 'Settings saved',
+      );
+      if (onUpdate) onUpdate();
+      onClose();
+    } catch (error: any) {
+      toast.error(error?.response?.data?.message || "Couldn't save the settings");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEndRoom = async () => {
+    if (
+      !window.confirm(
+        'End this room? It disappears for everyone in it, and the link stops working.',
+      )
+    ) {
+      return;
+    }
+
+    setLoading(true);
+    try {
+      // This used to be a lie: the delete was commented out, so "End room"
+      // congratulated you and navigated away while the room carried on
+      // existing with everyone still in it.
+      await apiService.deleteRoom(room.code);
       toast.success('Room ended');
-      window.location.href = '/';
-    } catch (error) {
-      toast.error('Failed to end room');
+      navigate('/');
+    } catch (error: any) {
+      toast.error(error?.response?.data?.message || "Couldn't end the room");
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -210,6 +263,18 @@ export const RoomSettings: React.FC<RoomSettingsProps> = ({ room, onClose, onUpd
       {/* Every row's visible text IS its control's accessible name, so each
           Label points at its input by id - the painted toggle carries no
           text of its own to borrow. */}
+      <SettingRow>
+        <Label htmlFor="room-settings-name">Room name</Label>
+        <UrlInput
+          id="room-settings-name"
+          type="text"
+          value={name}
+          maxLength={120}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Movie night"
+        />
+      </SettingRow>
+
       <SettingRow>
         <Label htmlFor="room-settings-public">List publicly</Label>
         <Toggle>
@@ -246,6 +311,23 @@ export const RoomSettings: React.FC<RoomSettingsProps> = ({ room, onClose, onUpd
             }
           }}
         />
+      </SettingRow>
+
+      {/* The one setting that changes what other people can DO, rather than
+          what the room looks like - so it says which it is, not just its name. */}
+      <SettingRow>
+        <Label htmlFor="room-settings-guest-control">
+          Let everyone control playback
+        </Label>
+        <Toggle>
+          <input
+            id="room-settings-guest-control"
+            type="checkbox"
+            checked={allowGuestControl}
+            onChange={(e) => setAllowGuestControl(e.target.checked)}
+          />
+          <span />
+        </Toggle>
       </SettingRow>
 
       <SettingRow>

--- a/video-sync-frontend/src/components/RoomSettings.tsx
+++ b/video-sync-frontend/src/components/RoomSettings.tsx
@@ -294,7 +294,7 @@ export const RoomSettings: React.FC<RoomSettingsProps> = ({ room, onClose, onUpd
           id="room-settings-max-users"
           type="number"
           min="2"
-          max="100"
+          max="500"
           value={maxUsers}
           onChange={(e) => {
             const raw = e.target.value;
@@ -302,8 +302,11 @@ export const RoomSettings: React.FC<RoomSettingsProps> = ({ room, onClose, onUpd
               setMaxUsers('');
               return;
             }
-            const parsed = parseInt(raw, 10);
-            setMaxUsers(Number.isNaN(parsed) ? '' : parsed);
+            // Number, not parseInt: parseInt('8.5') is 8 and parseInt('2e2')
+            // is 2, so a value the person never chose would be persisted now
+            // that this field actually reaches the server.
+            const parsed = Number(raw);
+            setMaxUsers(Number.isInteger(parsed) ? parsed : '');
           }}
           onBlur={() => {
             if (maxUsers === '') {
@@ -345,7 +348,7 @@ export const RoomSettings: React.FC<RoomSettingsProps> = ({ room, onClose, onUpd
         <SaveButton type="button" onClick={handleUpdateSettings} disabled={loading}>
           {loading ? 'Saving…' : 'Save changes'}
         </SaveButton>
-        <EndButton type="button" onClick={handleEndRoom}>
+        <EndButton type="button" onClick={handleEndRoom} disabled={loading}>
           End room
         </EndButton>
       </Actions>

--- a/video-sync-frontend/src/components/player/FailureCard.test.tsx
+++ b/video-sync-frontend/src/components/player/FailureCard.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FailureCard } from './FailureCard';
+
+describe('FailureCard', () => {
+  it('announces itself, and shows the URL so "why is it black" is answerable', () => {
+    render(
+      <FailureCard
+        title="Couldn't play this video"
+        detail="the CDN closed the connection"
+        url="https://cdn.example.com/film.mp4"
+      />,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('https://cdn.example.com/film.mp4')).toBeInTheDocument();
+  });
+
+  it('offers a retry when one is given, and calls it', async () => {
+    // a dead CDN or a flaky network is transient; before this, the only
+    // recovery was reloading the page, which drops you out of the room
+    const onRetry = jest.fn();
+    render(<FailureCard title="Couldn't play this video" onRetry={onRetry} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers no retry where retrying cannot help', () => {
+    // e.g. a URL no player can ever take - a button that always fails is
+    // worse than no button
+    render(<FailureCard title="No video set" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/video-sync-frontend/src/components/player/FailureCard.tsx
+++ b/video-sync-frontend/src/components/player/FailureCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { color, font } from '../../theme';
+import { button, color, font } from '../../theme';
 
 const Card = styled.div`
   position: absolute;
@@ -41,6 +41,11 @@ const Url = styled.code`
   max-width: 90%;
 `;
 
+const RetryButton = styled.button`
+  ${button.secondary}
+  margin-top: 14px;
+`;
+
 /**
  * The visible end of attempt-and-fail-visibly: validation admits anything a
  * player could conceivably fetch (see shared/media-source.ts), so when the
@@ -51,12 +56,20 @@ export const FailureCard: React.FC<{
   title: string;
   detail?: string;
   url?: string;
-}> = ({ title, detail, url }) => (
+  /** Offered only where retrying could plausibly help - not for a URL no
+      player can ever take, where the button would just fail again. */
+  onRetry?: () => void;
+}> = ({ title, detail, url, onRetry }) => (
   // role="alert": the card swaps in dynamically after a playback failure,
   // and without a live region a screen reader never hears about it
   <Card data-testid="failure-card" role="alert">
     <Title>{title}</Title>
     {detail && <Detail>{detail}</Detail>}
     {url && <Url>{url}</Url>}
+    {onRetry && (
+      <RetryButton type="button" onClick={onRetry}>
+        Try again
+      </RetryButton>
+    )}
   </Card>
 );

--- a/video-sync-frontend/src/components/player/fullscreen.test.ts
+++ b/video-sync-frontend/src/components/player/fullscreen.test.ts
@@ -1,0 +1,52 @@
+import { toggleFullscreen } from './fullscreen';
+
+const makeDoc = (fullscreenElement: Element | null = null) => ({
+  fullscreenElement,
+  exitFullscreen: jest.fn().mockResolvedValue(undefined),
+});
+
+describe('toggleFullscreen', () => {
+  it('asks the shell to go fullscreen when nothing is fullscreen', async () => {
+    const el = { requestFullscreen: jest.fn().mockResolvedValue(undefined) };
+    const doc = makeDoc(null);
+
+    await expect(toggleFullscreen(el, doc)).resolves.toBe(true);
+    expect(el.requestFullscreen).toHaveBeenCalledTimes(1);
+    expect(doc.exitFullscreen).not.toHaveBeenCalled();
+  });
+
+  it('exits when something already is', async () => {
+    const el = { requestFullscreen: jest.fn() };
+    const doc = makeDoc({} as Element);
+
+    await expect(toggleFullscreen(el, doc)).resolves.toBe(false);
+    expect(doc.exitFullscreen).toHaveBeenCalledTimes(1);
+    expect(el.requestFullscreen).not.toHaveBeenCalled();
+  });
+
+  it('swallows a browser that refuses', async () => {
+    // Safari <16.4, an embedded webview, an iframe without allowfullscreen,
+    // and an automated tab all reject this - the page must carry on, not
+    // surface an error nobody can act on
+    const el = {
+      requestFullscreen: jest
+        .fn()
+        .mockRejectedValue(new Error('Permissions check failed')),
+    };
+
+    await expect(toggleFullscreen(el, makeDoc(null))).resolves.toBe(false);
+  });
+
+  it('swallows a failing exit too', async () => {
+    const doc = makeDoc({} as Element);
+    doc.exitFullscreen.mockRejectedValue(new Error('nope'));
+
+    await expect(toggleFullscreen({}, doc)).resolves.toBe(false);
+  });
+
+  it('does nothing without a shell, or without support', async () => {
+    await expect(toggleFullscreen(null, makeDoc(null))).resolves.toBe(false);
+    // an old browser with no requestFullscreen at all
+    await expect(toggleFullscreen({}, makeDoc(null))).resolves.toBe(false);
+  });
+});

--- a/video-sync-frontend/src/components/player/fullscreen.ts
+++ b/video-sync-frontend/src/components/player/fullscreen.ts
@@ -1,0 +1,42 @@
+/**
+ * Fullscreen, as a function rather than a click handler.
+ *
+ * Pulled out of the player so it can be tested at all: a browser refuses
+ * `requestFullscreen` outside a real user gesture (and refuses it outright
+ * in an automated tab), so the only way to check the branching is to hand it
+ * the document rather than reach for the global one.
+ */
+export interface FullscreenTarget {
+  requestFullscreen?: () => Promise<void>;
+}
+
+export interface FullscreenDocument {
+  fullscreenElement: Element | null;
+  exitFullscreen: () => Promise<void>;
+}
+
+/**
+ * Toggle, and swallow refusal.
+ *
+ * Safari before 16.4, an embedded webview, an iframe without the
+ * `allowfullscreen` attribute and an automated tab all reject the request.
+ * That is the browser declining, not a fault to surface: the page carries on
+ * exactly as it was, and the button simply did nothing visible.
+ */
+export const toggleFullscreen = async (
+  element: FullscreenTarget | null,
+  doc: FullscreenDocument,
+): Promise<boolean> => {
+  if (!element) return false;
+  try {
+    if (doc.fullscreenElement) {
+      await doc.exitFullscreen();
+      return false;
+    }
+    if (!element.requestFullscreen) return false;
+    await element.requestFullscreen();
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/video-sync-frontend/src/contexts/AuthContext.tsx
+++ b/video-sync-frontend/src/contexts/AuthContext.tsx
@@ -13,6 +13,16 @@ interface User {
 
 interface AuthContextType {
   user: User | null;
+  /**
+   * Has the stored session been read yet?
+   *
+   * `user` is null for the first render of every page load, including for
+   * someone perfectly well signed in, because the session is rehydrated in an
+   * effect. Any page that redirects on `!user` therefore redirected everyone
+   * - opening or reloading a room bounced you to the join page and made you
+   * click through again. Guard those redirects on this instead.
+   */
+  ready: boolean;
   login: (username: string, password: string) => Promise<void>;
   register: (username: string, email: string, password: string) => Promise<void>;
   /** Adopt a token minted elsewhere - today, by the Google callback. */
@@ -35,18 +45,23 @@ const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3000/api';
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
+  const [ready, setReady] = useState(false);
 
   // Check for stored user on mount. Wrapped: a corrupt entry (a half-written
   // value, a schema change) would otherwise throw during render and leave a
   // blank page instead of a signed-out one.
   useEffect(() => {
     const storedUser = localStorage.getItem('user');
-    if (!storedUser) return;
-    try {
-      setUser(JSON.parse(storedUser));
-    } catch {
-      localStorage.removeItem('user');
+    if (storedUser) {
+      try {
+        setUser(JSON.parse(storedUser));
+      } catch {
+        localStorage.removeItem('user');
+      }
     }
+    // set last and unconditionally: consumers wait on this to know that
+    // `user === null` means signed out rather than not-read-yet
+    setReady(true);
   }, []);
 
   // The API layer clears storage and fires this when a request comes back 401
@@ -125,6 +140,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const value: AuthContextType = {
     user,
+    ready,
     login,
     register,
     signInWithToken,

--- a/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
+++ b/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
@@ -253,10 +253,30 @@ const HostChip = styled.span`
   flex-shrink: 0;
 `;
 
-// Page gutter only - RoomSettings owns its own max-width, centering and
-// top margin, so constraining it again here would double-inset the panel.
-const SettingsSlot = styled.div`
-  padding: 0 20px 20px;
+/**
+ * Settings is a modal, not a slot at the bottom of the document.
+ *
+ * It used to render after the video and voice sections, which on any normal
+ * window put it below the fold: pressing Settings appended a panel nobody
+ * could see, so the button read as broken. A dialog cannot be missed, and it
+ * is also the honest shape - changing the video for everyone in the room is a
+ * focused task, not something to do while scrolled past the player.
+ */
+const SettingsOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 6vh 20px 40px;
+  overflow-y: auto;
+`;
+
+const SettingsDialog = styled.div`
+  width: 100%;
+  max-width: 520px;
 `;
 
 const CenteredState = styled.div`
@@ -321,6 +341,23 @@ export const EnhancedRoomPage: React.FC = () => {
   useEffect(() => {
     participantsRef.current = participants;
   }, [participants]);
+
+  // Escape closes the settings dialog, and focus moves into it on open so a
+  // keyboard user is not left tabbing through the page behind the overlay.
+  const settingsRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!showSettings) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setShowSettings(false);
+    };
+    window.addEventListener('keydown', onKey);
+    settingsRef.current
+      ?.querySelector<HTMLElement>(
+        'input, select, textarea, button, [href], [tabindex]:not([tabindex="-1"])',
+      )
+      ?.focus();
+    return () => window.removeEventListener('keydown', onKey);
+  }, [showSettings]);
 
   useEffect(() => {
     if (!roomCode) {
@@ -562,13 +599,25 @@ export const EnhancedRoomPage: React.FC = () => {
       </Grid>
 
       {showSettings && isHost && (
-        <SettingsSlot>
-          <RoomSettings
-            room={room}
-            onClose={() => setShowSettings(false)}
-            onUpdate={() => fetchRoomDetails()}
-          />
-        </SettingsSlot>
+        <SettingsOverlay
+          role="dialog"
+          aria-modal="true"
+          aria-label="Room settings"
+          // click-away closes, but only on the backdrop itself: without the
+          // target check, a click that starts inside the panel and drifts
+          // onto the overlay would discard whatever was being edited
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setShowSettings(false);
+          }}
+        >
+          <SettingsDialog ref={settingsRef}>
+            <RoomSettings
+              room={room}
+              onClose={() => setShowSettings(false)}
+              onUpdate={() => fetchRoomDetails()}
+            />
+          </SettingsDialog>
+        </SettingsOverlay>
       )}
     </Page>
   );

--- a/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
+++ b/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
@@ -356,18 +356,50 @@ export const EnhancedRoomPage: React.FC = () => {
   // Escape closes the settings dialog, and focus moves into it on open so a
   // keyboard user is not left tabbing through the page behind the overlay.
   const settingsRef = useRef<HTMLDivElement | null>(null);
+  const settingsTriggerRef = useRef<HTMLElement | null>(null);
+
   useEffect(() => {
     if (!showSettings) return;
+
+    const FOCUSABLE =
+      'input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])';
+
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setShowSettings(false);
+      if (e.key === 'Escape') {
+        setShowSettings(false);
+        return;
+      }
+      // Keep Tab inside the dialog. Without this, tabbing walks straight out
+      // onto the page behind the overlay - which is invisible, still
+      // clickable by keyboard, and a good way to change the video by
+      // accident while thinking you are still in the settings.
+      if (e.key !== 'Tab') return;
+      const focusable = Array.from(
+        settingsRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? [],
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && (active === first || !settingsRef.current?.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
+
     window.addEventListener('keydown', onKey);
-    settingsRef.current
-      ?.querySelector<HTMLElement>(
-        'input, select, textarea, button, [href], [tabindex]:not([tabindex="-1"])',
-      )
-      ?.focus();
-    return () => window.removeEventListener('keydown', onKey);
+    // Remember what opened it, so closing puts the caret back where it was
+    // rather than dumping focus at the top of the document.
+    settingsTriggerRef.current = document.activeElement as HTMLElement | null;
+    settingsRef.current?.querySelector<HTMLElement>(FOCUSABLE)?.focus();
+
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      settingsTriggerRef.current?.focus?.();
+    };
   }, [showSettings]);
 
   useEffect(() => {

--- a/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
+++ b/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
@@ -323,7 +323,7 @@ export const EnhancedRoomPage: React.FC = () => {
   const { roomCode } = useParams<{ roomCode: string }>();
   const navigate = useNavigate();
   const { socket, connected } = useSocket();
-  const { user } = useAuth();
+  const { user, ready: authReady } = useAuth();
 
   const [room, setRoom] = useState<Room | null>(null);
   const [participants, setParticipants] = useState<Participant[]>([]);
@@ -364,6 +364,12 @@ export const EnhancedRoomPage: React.FC = () => {
       navigate('/');
       return;
     }
+    // Wait for the stored session to be read. `user` is null on the first
+    // render of every page load, so redirecting here on !user alone sent
+    // signed-in people to the join page too - every room link, and every
+    // reload of the room you were already sitting in, cost an extra click.
+    if (!authReady) return;
+
     // Room details now require a token (the REST guard), and the socket has
     // always required one. A signed-out visitor arriving on a shared link
     // should be asked to sign in, not shown "Couldn't load the room" - so
@@ -376,7 +382,7 @@ export const EnhancedRoomPage: React.FC = () => {
     fetchRoomDetails();
     // intentional: fetch once per room code, and again if auth appears
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [roomCode, user]);
+  }, [roomCode, user, authReady]);
 
   useEffect(() => {
     if (!socket || !connected || !user || !room) return;
@@ -446,7 +452,15 @@ export const EnhancedRoomPage: React.FC = () => {
         participantsRef.current = roster;
         setParticipants(roster);
       }
-    } catch (error) {
+    } catch (error: any) {
+      // A rejected token is not "this room is broken", it is "sign in
+      // again" - and it must not throw the room away. Dropping people on
+      // the marketing page with the code discarded is what every expired
+      // session used to do, twelve hours after they last signed in.
+      if (error?.response?.status === 401) {
+        navigate(`/join-room/${roomCode}`, { replace: true });
+        return;
+      }
       toast.error("Couldn't load the room");
       navigate('/');
     } finally {

--- a/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
+++ b/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
@@ -342,6 +342,17 @@ export const EnhancedRoomPage: React.FC = () => {
     participantsRef.current = participants;
   }, [participants]);
 
+  // With several rooms open, every tab read "Mustard Watch Party" and the
+  // only way to find the right one was to click through them.
+  useEffect(() => {
+    if (!room?.name) return;
+    const previous = document.title;
+    document.title = `${room.name} · mustard.watch`;
+    return () => {
+      document.title = previous;
+    };
+  }, [room?.name]);
+
   // Escape closes the settings dialog, and focus moves into it on open so a
   // keyboard user is not left tabbing through the page behind the overlay.
   const settingsRef = useRef<HTMLDivElement | null>(null);

--- a/video-sync-frontend/src/pages/HomePage.tsx
+++ b/video-sync-frontend/src/pages/HomePage.tsx
@@ -211,6 +211,19 @@ const Section = styled.section`
   margin-top: 48px;
 `;
 
+const EmptyActions = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+`;
+
+const SectionActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
 const SectionHead = styled.div`
   display: flex;
   align-items: center;
@@ -645,7 +658,7 @@ export const HomePage: React.FC = () => {
               <PrimaryButton type="button" onClick={() => navigate('/login')}>
                 Start a room
               </PrimaryButton>
-              <SecondaryButton type="button" onClick={() => navigate('/login')}>
+              <SecondaryButton type="button" onClick={() => navigate('/join')}>
                 I have a code
               </SecondaryButton>
             </CtaRow>
@@ -723,10 +736,17 @@ export const HomePage: React.FC = () => {
         <Section>
           <SectionHead>
             <SectionLabel>Your rooms</SectionLabel>
-            <PrimarySmButton type="button" onClick={handleCreateRoom}>
-              <IconPlus size={14} />
-              New room
-            </PrimarySmButton>
+            <SectionActions>
+              {/* someone who was sent a code needs somewhere to put it, and
+                  this dashboard was previously a dead end for them */}
+              <SecondarySmButton type="button" onClick={() => navigate('/join')}>
+                Join with a code
+              </SecondarySmButton>
+              <PrimarySmButton type="button" onClick={handleCreateRoom}>
+                <IconPlus size={14} />
+                New room
+              </PrimarySmButton>
+            </SectionActions>
           </SectionHead>
 
           {userRoomsLoading ? (
@@ -801,9 +821,14 @@ export const HomePage: React.FC = () => {
               <IconFilm size={26} />
               <EmptyTitle>No rooms yet.</EmptyTitle>
               <EmptyText>Start one and send the code.</EmptyText>
-              <PrimaryButton type="button" onClick={handleCreateRoom}>
-                New room
-              </PrimaryButton>
+              <EmptyActions>
+                <PrimaryButton type="button" onClick={handleCreateRoom}>
+                  New room
+                </PrimaryButton>
+                <SecondaryButton type="button" onClick={() => navigate('/join')}>
+                  Join with a code
+                </SecondaryButton>
+              </EmptyActions>
             </EmptyCard>
           )}
         </Section>

--- a/video-sync-frontend/src/pages/JoinByCodePage.test.tsx
+++ b/video-sync-frontend/src/pages/JoinByCodePage.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { JoinByCodePage } from './JoinByCodePage';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <JoinByCodePage />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('somewhere to type a room code', () => {
+  it('takes a plain code to the room', async () => {
+    renderPage();
+    await userEvent.type(screen.getByLabelText('Room code'), 'ABC123');
+    await userEvent.click(screen.getByRole('button', { name: /join room/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/join-room/ABC123');
+  });
+
+  it.each([
+    ['a share link', 'https://mustard.watch/join-room/ABC123'],
+    ['a room URL', 'https://mustard.watch/room/ABC123'],
+    ['surrounding whitespace', '  ABC123  '],
+  ])('accepts %s, because that is what people paste', async (_name, typed) => {
+    renderPage();
+    await userEvent.type(screen.getByLabelText('Room code'), typed);
+    await userEvent.click(screen.getByRole('button', { name: /join room/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/join-room/ABC123');
+  });
+
+  it('does not navigate on an empty or junk-only code', async () => {
+    renderPage();
+    const button = screen.getByRole('button', { name: /join room/i });
+    expect(button).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText('Room code'), '///');
+    await userEvent.click(button);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('is reachable without an account - the invite path starts here', () => {
+    // no auth context is mounted in this test at all; the page must not
+    // depend on one, because "I have a code" is a signed-out entry point
+    renderPage();
+    expect(screen.getByLabelText('Room code')).toBeInTheDocument();
+  });
+});

--- a/video-sync-frontend/src/pages/JoinByCodePage.tsx
+++ b/video-sync-frontend/src/pages/JoinByCodePage.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from '@emotion/styled';
+import { color, font, button, input, card } from '../theme';
+import { Wordmark } from '../components/Icons';
+
+const Page = styled.div`
+  min-height: 100vh;
+  background: ${color.bg0};
+  padding: 12vh 20px 64px;
+`;
+
+const Column = styled.div`
+  max-width: 400px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`;
+
+const Panel = styled.div`
+  ${card}
+  padding: 24px;
+`;
+
+const Title = styled.h1`
+  font-family: ${font.display};
+  font-size: 24px;
+  font-weight: 700;
+  color: ${color.text};
+  margin: 0 0 6px;
+`;
+
+const Blurb = styled.p`
+  margin: 0 0 20px;
+  font-family: ${font.body};
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: ${color.dim};
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+/**
+ * Monospace and wide-tracked: a room code is read off a phone screen or
+ * heard down a line, and the shapes that get confused doing that (1/l, 0/O)
+ * are exactly the ones a mono face separates.
+ */
+const CodeInput = styled.input`
+  ${input}
+  font-family: ${font.mono};
+  font-size: 16px;
+  letter-spacing: 0.08em;
+`;
+
+const SubmitButton = styled.button`
+  ${button.primary}
+  width: 100%;
+`;
+
+const BackLink = styled.button`
+  ${button.secondary}
+  width: 100%;
+`;
+
+/**
+ * Somewhere to type a room code.
+ *
+ * The landing page has had a button labelled "I have a code" since it was
+ * written, and it went to the sign-in form: there was nowhere in the entire
+ * app to put a code. Meanwhile the room's most prominent share control
+ * copies the bare code, so the obvious thing to send someone was the one
+ * thing they could not use.
+ */
+export const JoinByCodePage: React.FC = () => {
+  const navigate = useNavigate();
+  const [code, setCode] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Tolerate what people actually paste: surrounding space, and a whole
+    // room URL rather than the code out of it.
+    const raw = code.trim();
+    if (!raw) return;
+    const fromUrl = raw.match(/\/(?:room|join-room)\/([^/?#\s]+)/);
+    const cleaned = (fromUrl ? fromUrl[1] : raw).replace(/[^A-Za-z0-9_-]/g, '');
+    if (!cleaned) return;
+    navigate(`/join-room/${cleaned}`);
+  };
+
+  return (
+    <Page>
+      <Column>
+        <Wordmark size={22} />
+        <Panel>
+          <Title>Join a room</Title>
+          <Blurb>
+            Paste the code a friend sent you — or the whole link, that works
+            too.
+          </Blurb>
+          <Form onSubmit={handleSubmit}>
+            <CodeInput
+              autoFocus
+              type="text"
+              aria-label="Room code"
+              placeholder="Room code"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+            />
+            <SubmitButton type="submit" disabled={code.trim() === ''}>
+              Join room
+            </SubmitButton>
+          </Form>
+        </Panel>
+        <BackLink type="button" onClick={() => navigate('/')}>
+          Back to home
+        </BackLink>
+      </Column>
+    </Page>
+  );
+};

--- a/video-sync-frontend/src/pages/JoinRoomPage.tsx
+++ b/video-sync-frontend/src/pages/JoinRoomPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { apiService } from '../services/api';
+import { loginUrlFor } from '../services/return-to';
 import { toast } from 'react-hot-toast';
 import styled from '@emotion/styled';
 import {
@@ -227,7 +228,7 @@ export const JoinRoomPage: React.FC = () => {
 
     if (!user) {
       toast.error('Sign in first');
-      navigate('/login');
+      navigate(loginUrlFor(`/room/${roomCode}`));
       return;
     }
 
@@ -263,7 +264,11 @@ export const JoinRoomPage: React.FC = () => {
           <Title>Sign in to join</Title>
           <StateCard>
             <StateActions>
-              <PrimaryButton onClick={() => navigate('/login')}>
+              {/* carries the room through sign-in: without it, signing in
+                  lands on the home page and the invite is simply lost */}
+              <PrimaryButton
+                onClick={() => navigate(loginUrlFor(`/room/${roomCode}`))}
+              >
                 Go to sign in
               </PrimaryButton>
               {/* never leave a state without an exit: this branch has no

--- a/video-sync-frontend/src/pages/LoginPage.test.tsx
+++ b/video-sync-frontend/src/pages/LoginPage.test.tsx
@@ -13,14 +13,16 @@ jest.mock('../services/api', () => ({
 
 const getProviders = apiService.getProviders as jest.Mock;
 
-const renderPage = () =>
-  render(
+const renderPage = (search = '') => {
+  window.history.replaceState(null, '', `/login${search}`);
+  return render(
     <AuthProvider>
-      <MemoryRouter>
+      <MemoryRouter initialEntries={[`/login${search}`]}>
         <LoginPage />
       </MemoryRouter>
     </AuthProvider>,
   );
+};
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -69,5 +71,47 @@ describe('the Google button', () => {
     ).not.toBeInTheDocument();
     // and the password form still works
     expect(screen.getByRole('button', { name: /sign in/i })).toBeEnabled();
+  });
+});
+
+describe('the room survives sign-in', () => {
+  it('hands the destination to Google so the callback can return there', async () => {
+    getProviders.mockResolvedValue({ data: { google: true } });
+    renderPage('?next=%2Froom%2FABC123');
+
+    const link = await screen.findByRole('link', {
+      name: /continue with google/i,
+    });
+    expect(link).toHaveAttribute(
+      'href',
+      'http://api.test/api/auth/google/start?returnTo=%2Froom%2FABC123',
+    );
+  });
+
+  it('leaves the Google link bare when there is nowhere to return to', async () => {
+    getProviders.mockResolvedValue({ data: { google: true } });
+    renderPage();
+
+    const link = await screen.findByRole('link', {
+      name: /continue with google/i,
+    });
+    expect(link).toHaveAttribute(
+      'href',
+      'http://api.test/api/auth/google/start',
+    );
+  });
+
+  it('ignores a destination pointing off-site', async () => {
+    // the value rides in a link anyone can send, so it is filtered here too
+    getProviders.mockResolvedValue({ data: { google: true } });
+    renderPage('?next=https%3A%2F%2Fevil.example');
+
+    const link = await screen.findByRole('link', {
+      name: /continue with google/i,
+    });
+    expect(link).toHaveAttribute(
+      'href',
+      'http://api.test/api/auth/google/start',
+    );
   });
 });

--- a/video-sync-frontend/src/pages/LoginPage.tsx
+++ b/video-sync-frontend/src/pages/LoginPage.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import styled from '@emotion/styled';
 import { color, font, radius, focusRing, button, input, card } from '../theme';
 import { IconGoogle, Wordmark } from '../components/Icons';
 import { apiBaseUrl, apiService } from '../services/api';
+import { readReturnTo } from '../services/return-to';
 
 const Page = styled.div`
   min-height: 100vh;
@@ -116,7 +117,10 @@ const ToggleButton = styled.button`
 
 export const LoginPage: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { login, register } = useAuth();
+  // Where the person was heading before we interrupted them to sign in.
+  const returnTo = readReturnTo(location.search);
   const [isLogin, setIsLogin] = useState(true);
   const [loading, setLoading] = useState(false);
   const [formData, setFormData] = useState({
@@ -153,7 +157,7 @@ export const LoginPage: React.FC = () => {
       } else {
         await register(formData.username, formData.email, formData.password);
       }
-      navigate('/');
+      navigate(returnTo ?? '/', { replace: true });
     } catch (error) {
       // Error handling is done in the auth context
     } finally {
@@ -178,7 +182,13 @@ export const LoginPage: React.FC = () => {
 
           {googleEnabled && (
             <>
-              <GoogleButton href={`${apiBaseUrl}/auth/google/start`}>
+              <GoogleButton
+                href={
+                  returnTo
+                    ? `${apiBaseUrl}/auth/google/start?returnTo=${encodeURIComponent(returnTo)}`
+                    : `${apiBaseUrl}/auth/google/start`
+                }
+              >
                 <IconGoogle size={16} />
                 Continue with Google
               </GoogleButton>

--- a/video-sync-frontend/src/services/api.ts
+++ b/video-sync-frontend/src/services/api.ts
@@ -116,10 +116,15 @@ export const apiService = {
   getRoomByCode: (code: string) =>
     api.get(`/rooms/${code}`),
 
+  // Every field here is one the server's UpdateRoomDto actually accepts.
+  // allowGuestControl used to be listed and silently stripped by the pipe's
+  // whitelist, so the settings form appeared to save it and never did.
   updateRoom: (code: string, data: {
     name?: string;
     videoUrl?: string;
+    isPublic?: boolean;
     allowGuestControl?: boolean;
+    maxUsers?: number;
   }) => api.patch(`/rooms/${code}`, data),
 
   deleteRoom: (code: string) =>

--- a/video-sync-frontend/src/services/return-to.test.ts
+++ b/video-sync-frontend/src/services/return-to.test.ts
@@ -1,0 +1,47 @@
+import { loginUrlFor, readReturnTo, safeReturnTo } from './return-to';
+
+describe('safeReturnTo', () => {
+  it('keeps a path on our own site', () => {
+    expect(safeReturnTo('/room/ABC123')).toBe('/room/ABC123');
+    expect(safeReturnTo('/')).toBe('/');
+  });
+
+  it.each([
+    ['an absolute URL', 'https://evil.example/'],
+    ['a protocol-relative URL', '//evil.example/'],
+    ['a scheme', 'javascript:alert(1)'],
+    ['a bare path', 'room/ABC'],
+    ['a backslash', '/\\evil.example'],
+    ['a newline', '/room\nSet-Cookie: a=b'],
+    ['nothing', null],
+    ['an empty string', ''],
+  ])('refuses %s', (_name, value) => {
+    expect(safeReturnTo(value)).toBeNull();
+  });
+
+  it('caps the length', () => {
+    expect(safeReturnTo(`/${'a'.repeat(1000)}`)).toHaveLength(512);
+  });
+});
+
+describe('readReturnTo', () => {
+  it('reads and decodes the destination', () => {
+    expect(readReturnTo('?next=%2Froom%2FABC123')).toBe('/room/ABC123');
+  });
+
+  it('is null when absent, and filters a hostile one', () => {
+    expect(readReturnTo('')).toBeNull();
+    expect(readReturnTo('?other=1')).toBeNull();
+    expect(readReturnTo('?next=https%3A%2F%2Fevil.example')).toBeNull();
+  });
+});
+
+describe('loginUrlFor', () => {
+  it('remembers where the person was heading', () => {
+    expect(loginUrlFor('/room/ABC123')).toBe('/login?next=%2Froom%2FABC123');
+  });
+
+  it('falls back to a plain sign-in rather than carrying junk', () => {
+    expect(loginUrlFor('https://evil.example')).toBe('/login');
+  });
+});

--- a/video-sync-frontend/src/services/return-to.ts
+++ b/video-sync-frontend/src/services/return-to.ts
@@ -1,0 +1,40 @@
+/**
+ * Where to send someone after they sign in.
+ *
+ * A guest arrives on an invite link, is asked to sign in, and has to end up
+ * in the room they were invited to - not on the home page with the code
+ * gone, which is what happened before this existed. The destination travels
+ * as a query parameter (`?next=/room/ABC`) so it survives the full-page
+ * navigation the Google flow makes, which `location.state` would not.
+ *
+ * The value is attacker-supplied by construction: it rides in a link anyone
+ * can send. So it is filtered on the way in AND on the way out, and only
+ * ever names a path on this site - the same rule the server applies to the
+ * OAuth `returnTo` in google-oauth.service.ts.
+ */
+export const RETURN_TO_PARAM = 'next';
+
+export const safeReturnTo = (value: string | null | undefined): string | null => {
+  if (!value) return null;
+  // A path, not a URL. '//evil.example' is protocol-relative and would leave
+  // the site; a backslash is treated as a slash by some browsers.
+  if (!value.startsWith('/') || value.startsWith('//')) return null;
+  if (value.includes('\\')) return null;
+  for (const ch of value) {
+    const code = ch.charCodeAt(0);
+    if (code < 0x20 || code === 0x7f) return null;
+  }
+  return value.slice(0, 512);
+};
+
+/** Read the destination off a location's query string, filtered. */
+export const readReturnTo = (search: string): string | null =>
+  safeReturnTo(new URLSearchParams(search).get(RETURN_TO_PARAM));
+
+/** Build a sign-in URL that remembers where the person was heading. */
+export const loginUrlFor = (destination: string): string => {
+  const safe = safeReturnTo(destination);
+  return safe
+    ? `/login?${RETURN_TO_PARAM}=${encodeURIComponent(safe)}`
+    : '/login';
+};

--- a/video-sync-frontend/src/sync/Html5Adapter.ts
+++ b/video-sync-frontend/src/sync/Html5Adapter.ts
@@ -15,6 +15,10 @@ import { PlayerAdapter } from '../shared/sync-core/player-adapter';
  * edge reconstruction is needed - which is itself a useful contrast when
  * reading the YouTube readout-noise histogram.
  */
+/** Volume is a fraction; anything outside 0..1 is a caller bug, not a mute. */
+const clamp01 = (n: number): number =>
+  Number.isFinite(n) ? Math.min(1, Math.max(0, n)) : 0;
+
 export class Html5Adapter implements PlayerAdapter {
   private lastCommandAt = 0;
 
@@ -92,5 +96,14 @@ export class Html5Adapter implements PlayerAdapter {
 
   dispose(): void {
     /* nothing to tear down: the element is owned by the component */
+  }
+
+  // Local audio only - never synced.
+  setVolume(fraction: number): void {
+    this.el.volume = clamp01(fraction);
+  }
+
+  setMuted(muted: boolean): void {
+    this.el.muted = muted;
   }
 }

--- a/video-sync-frontend/src/sync/SyncEngine.ts
+++ b/video-sync-frontend/src/sync/SyncEngine.ts
@@ -28,6 +28,16 @@ export interface EngineAdapter extends PlayerAdapter {
   /** does this player honour fractional playback rates? (per video) */
   probeFractionalRate(): Promise<boolean>;
   dispose(): void;
+
+  /**
+   * Local audio. Optional on purpose, and deliberately NOT part of
+   * PlayerAdapter in shared/sync-core: volume is a property of the room you
+   * are physically sitting in, not of the shared timeline, so it must never
+   * travel over the wire or influence the drift controller. A player that
+   * cannot expose it simply omits these, and the UI hides the control.
+   */
+  setVolume?(fraction: number): void;
+  setMuted?(muted: boolean): void;
 }
 
 export interface EngineStatus {

--- a/video-sync-frontend/src/sync/SyncEngine.ts
+++ b/video-sync-frontend/src/sync/SyncEngine.ts
@@ -10,6 +10,7 @@ import { DisciplineController } from '../shared/sync-core/discipline-controller'
 import {
   DriftController,
   type ControllerAction,
+  type PlayerLifecycle,
 } from '../shared/sync-core/drift-controller';
 import { isNewer, projectMediaTime } from '../shared/sync-core/timeline';
 import { TelemetryRing } from './telemetry';
@@ -56,6 +57,12 @@ export interface EngineStatus {
   /** autoplay/ad interference: playback needs a user gesture to proceed */
   needsGesture: boolean;
   seeksIssued: number;
+  /**
+   * What the player itself is doing, for the UI only - the controller reads
+   * the adapter directly and must not be routed through this snapshot. It is
+   * here so a stalled room can say "buffering" instead of looking broken.
+   */
+  playerState: PlayerLifecycle;
 }
 
 const CLOCK_BURST_COUNT = 8;
@@ -348,6 +355,7 @@ export class SyncEngine {
       fractionalRateOK: this.fractionalRateOK,
       needsGesture: this.needsGesture,
       seeksIssued: ctrl.seeksIssued,
+      playerState: this.adapter?.getLifecycle() ?? 'unstarted',
     };
     this.listeners.forEach((l) => l(status));
   }

--- a/video-sync-frontend/src/sync/VimeoAdapter.test.ts
+++ b/video-sync-frontend/src/sync/VimeoAdapter.test.ts
@@ -128,3 +128,32 @@ test('dispose unsubscribes every handler', () => {
   p.emit('play');
   expect(a.getLifecycle()).toBe('unstarted');
 });
+
+describe('local audio (never synced)', () => {
+  it('unmuting restores full level, and mute silences', () => {
+    // Vimeo has no mute call - muting IS volume 0 - so the player applies
+    // mute first and the level last. If that order flips, a chosen level of
+    // 0.4 is thrown away on every unmute.
+    const p = new FakePlayer();
+    const calls: number[] = [];
+    (p as unknown as { setVolume: (v: number) => Promise<number> }).setVolume = (
+      v: number,
+    ) => {
+      calls.push(v);
+      return Promise.resolve(v);
+    };
+    const adapter = new VimeoAdapter(p as never);
+
+    adapter.setMuted(true);
+    expect(calls[calls.length - 1]).toBe(0);
+
+    adapter.setVolume(0.4);
+    expect(calls[calls.length - 1]).toBe(0.4);
+
+    // out-of-range is a caller bug, not a mute
+    adapter.setVolume(5);
+    expect(calls[calls.length - 1]).toBe(1);
+    adapter.setVolume(Number.NaN);
+    expect(calls[calls.length - 1]).toBe(0);
+  });
+});

--- a/video-sync-frontend/src/sync/VimeoAdapter.ts
+++ b/video-sync-frontend/src/sync/VimeoAdapter.ts
@@ -16,6 +16,8 @@ export interface VimeoPlayerLike {
   pause(): Promise<void>;
   setPlaybackRate(rate: number): Promise<number>;
   getPlaybackRate(): Promise<number>;
+  /** local audio; optional because older embeds predate it */
+  setVolume?(volume: number): Promise<number>;
 }
 
 interface TimePayload {
@@ -33,6 +35,10 @@ interface TimePayload {
  * fiction. Same edge-reconstruction idea as YouTubeAdapter, different
  * transport: events push edges here, YT gets polled.
  */
+/** Volume is a fraction; anything outside 0..1 is a caller bug, not a mute. */
+const clamp01 = (n: number): number =>
+  Number.isFinite(n) ? Math.min(1, Math.max(0, n)) : 0;
+
 export class VimeoAdapter implements PlayerAdapter {
   private edge: { tLocal: number; value: number } | null = null;
   private lastKnown = 0;
@@ -204,5 +210,15 @@ export class VimeoAdapter implements PlayerAdapter {
       this.player.off(event, callback);
     }
     this.handlers = [];
+  }
+
+  // Local audio only - never synced. Vimeo has no mute call: muting is
+  // volume 0, so the caller keeps the pre-mute level to restore.
+  setVolume(fraction: number): void {
+    void this.player.setVolume?.(clamp01(fraction));
+  }
+
+  setMuted(muted: boolean): void {
+    void this.player.setVolume?.(muted ? 0 : 1);
   }
 }

--- a/video-sync-frontend/src/sync/YouTubeAdapter.ts
+++ b/video-sync-frontend/src/sync/YouTubeAdapter.ts
@@ -10,6 +10,10 @@ import { PlayerAdapter } from '../shared/sync-core/player-adapter';
  * into fiction. The M1 baseline measured this readout's noise floor; the
  * controller's deadband respects it.
  */
+/** Volume is a fraction; anything outside 0..1 is a caller bug, not a mute. */
+const clamp01 = (n: number): number =>
+  Number.isFinite(n) ? Math.min(1, Math.max(0, n)) : 0;
+
 export class YouTubeAdapter implements PlayerAdapter {
   private lastRaw = 0;
   private edge: { tLocal: number; value: number } | null = null;
@@ -142,5 +146,17 @@ export class YouTubeAdapter implements PlayerAdapter {
   dispose(): void {
     if (this.pollTimer) clearInterval(this.pollTimer);
     this.pollTimer = null;
+  }
+
+  // Local audio only - never synced. YouTube takes 0-100 and keeps mute
+  // separate from volume, so a muted player restored to volume 40 is still
+  // muted until unMute() runs.
+  setVolume(fraction: number): void {
+    this.player.setVolume(Math.round(clamp01(fraction) * 100));
+  }
+
+  setMuted(muted: boolean): void {
+    if (muted) this.player.mute();
+    else this.player.unMute();
   }
 }

--- a/video-sync-frontend/src/theme.ts
+++ b/video-sync-frontend/src/theme.ts
@@ -196,6 +196,13 @@ export const ghostIconButton = `
 export const input = `
   font-family: ${font.body};
   font-size: 14px;
+  /* iOS Safari zooms the whole page when a focused field is under 16px, and
+     it does not zoom back out - tapping the chat box left people stranded
+     at 1.3x with the video off-screen. 16px at the touch sizes only, so the
+     desktop density is unchanged. */
+  @media (max-width: 880px) {
+    font-size: 16px;
+  }
   color: ${color.text};
   background: ${color.bg2};
   border: 1px solid ${color.line};


### PR DESCRIPTION
Two things were reported: **fullscreen does nothing**, and **pressing Settings does nothing**. Both were real. Opening Settings to fix it turned up three worse bugs, and the UX audit's highest-value cluster is fixed here too.

## The two reported

**Settings did nothing** because the panel rendered *after* the video and voice sections (`EnhancedRoomPage.tsx:564`), so it opened below the fold on any normal window — the button appended something nobody could see. It's a modal now: backdrop, Escape, click-away that ignores clicks starting inside the panel, focus moved into the dialog.

**Fullscreen did not exist** anywhere in the codebase — zero occurrences of `requestFullscreen`. The whole shell goes fullscreen rather than the video element, because the controls and sync readout must stay reachable and the YouTube path is a cross-origin iframe we can't decorate.

## The three that were hiding behind Settings

- **Two of its three controls were decorative.** `handleUpdateSettings` only ever broadcast the video, so "List publicly" and "Max participants" were collected and dropped — while the toast said it had saved. Both have real behaviour behind them (`maxUsers` is enforced at join, `allowGuestControl` decides who may drive playback); they just never reached the server, because `UpdateRoomDto` didn't accept them and the pipe's whitelist stripped them silently.
- **"End room" was a lie.** The delete was commented out, so it toasted "Room ended" and navigated away while the room carried on with everyone still in it. My own audit's verifier marked this "already exists" — it did not, which is a decent argument for reading the code rather than the verdict.
- **Renaming and guest control were creation-only**, so "let my friend pause it too" meant making a new room.

## The invite path — every guest arrives this way, and it leaked at four points

1. **Opening or reloading a room bounced you to the join page even when signed in.** `user` is null for the first render of every page load, so a redirect guarded on `!user` redirected everybody. `AuthContext` now exposes `ready`.
2. **An expired token dumped you on the marketing page with the code discarded.** Tokens last 12h, so this was every link opened the next day. A 401 now goes to the join page.
3. **Signing in never brought you back.** The destination travels as `?next=`, filtered to same-site paths on both ends. The Google button feeds the server's existing `returnTo` — already sealed into the state cookie, already read by `AuthCallbackPage`; only the frontend half was missing.
4. **There was nowhere to type a room code**, while the landing page had a button labelled "I have a code" that went to the sign-in form — and the room's most prominent share control copies the bare code. `/join` takes a code, or a pasted room URL.

## Also

Volume/mute (never synced — volume belongs to the room you're sitting in, not the timeline), `space`/`k`/`f`/`m` shortcuts that yield to whoever is typing in chat, chat timestamps, chat that stops yanking you to the bottom while you read back (with an unread count), `og:`/`twitter:` tags so invites don't paste as naked URLs, per-room tab titles, and 16px inputs so iOS stops zooming and stranding people at 1.3x.

## Verification

Hand-verified against a local stack: the dialog opens and is visible, and its toggles now reach the database — `isPublic` and `allowGuestControl` both came back `true` from the API, the room appeared in the public listing, and the player chip flipped to "Collaborative" live.

**What I could not verify by hand: the fullscreen transition.** The browser refuses `requestFullscreen` in an automated tab outright ("Permissions check failed"), even for `document.body`. So the logic was extracted into a function that takes the document and is covered by tests (enter, exit, rejected request, rejected exit, no shell, no support) — but the actual visual transition wants a human click.

Two bugs I introduced and caught before this landed: volume defaulted to **silence** (`Number(null)` is `0`, not `NaN`), and a test-only type error the production build caught but `tsc --noEmit` had not.

82 frontend tests (was 38), 300 backend (was 271). Build clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Join rooms using a code or shared room link.
  * Added fullscreen playback, volume, mute, and keyboard controls with saved volume preferences.
  * Added chat timestamps, unread message counts, and “new messages” navigation.
  * Expanded room settings for visibility, guest controls, capacity, video, and room deletion.
  * Added accessible settings dialogs and room-aware login redirects.
  * Improved social previews when sharing links.

* **Bug Fixes**
  * Improved invalid room-setting, media volume, and navigation handling.
  * Unauthorized room access now redirects to the join flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->