### PR TITLE
fix: succession was dead at the last inch, the room on a phone, and connection states that tell the truth

### DIFF
--- a/docs/GUEST_ACCESS.md
+++ b/docs/GUEST_ACCESS.md
@@ -1,0 +1,75 @@
+# Joining without an account — what it would actually take
+
+The UX audit's largest open finding: someone sent an invite link has to
+create an account before they can watch anything. This note is the survey I
+did before writing any of it, because the shape of the change is decided by
+constraints that are already load-bearing, and picking the wrong shape here
+is expensive to undo.
+
+Not implemented. This is the analysis, not the design being proposed as
+settled.
+
+## Why it is not a small change
+
+Three things assume a `User` row exists, and each is there for a reason.
+
+**The socket handshake refuses a connection without a verified token.**
+`ws-auth.ts` rejects a missing token, an unparseable one, and one with no
+subject, before any handler runs. Identity is derived there and never read
+off a payload — that is what stopped the chat handler impersonation bug, and
+it is why the REST and socket planes cannot drift on who someone is. Any
+guest path has to produce something this middleware accepts, not bypass it.
+
+**`Participant.userId` is a foreign key to `User`.** Presence, the
+participant list, and the rejoin path all read through it. A guest with no
+row cannot be a participant without either a nullable FK (which pushes a
+null check into every read) or a real row.
+
+**The token IS the identity, on both planes.** REST and the socket verify the
+same HS256 `{ sub, name }`, and `relay-go` verifies its HMAC. There is one
+contract in `token-payload.ts` precisely so there is nothing to keep in sync.
+
+## The two shapes
+
+**A. A real but disposable User row.** The guest gets a `User` with no
+password (already possible — the column is nullable for Google sign-in) and
+a generated name, and a normal token. Everything downstream is unchanged:
+the handshake passes, the FK is satisfied, presence works, chat attributes
+correctly.
+
+Costs: rows accumulate for every guest visit and need a reaper; the
+`username` unique constraint needs a collision-tolerant generator (the Google
+path already has one — `google/username.ts`); and "guest" has to be visible
+in the UI, or people will not understand why their room disappeared when they
+next open the site.
+
+**B. A distinct guest token with no row.** A token with a `guest:` subject
+and a claim naming the room, accepted by the handshake but never resolvable
+to a `User`.
+
+Costs: `Participant` needs a nullable `userId` plus a display name, and every
+read of it grows a branch. Chat messages have the same problem — `ChatMessage.userId`
+is also a FK. This is the cleaner data model in the abstract and the larger
+change in practice, because it touches every place identity is read rather
+than one place it is created.
+
+## What I would want decided before writing it
+
+1. **Should a guest be scoped to one room?** B makes that natural, A does not
+   enforce it without extra work. A guest token that works everywhere is a
+   weaker thing than the invite implies.
+2. **Do guest messages persist?** If yes, `ChatMessage` needs the same
+   treatment as `Participant`, and deleting the guest later orphans history.
+3. **What happens when a guest signs up properly?** Carrying their identity
+   across is easy under A (promote the row) and hard under B (there is no row
+   to promote).
+
+## Recommendation
+
+A, with a reaper — but only if the answer to (1) is "no, a guest is a
+lightweight account". If a guest must be confined to the room they were
+invited to, B is the honest model and the extra work is the price of not
+lying about what the token means.
+
+Either way this wants to be its own PR with its own tests, not an
+afterthought bolted onto a UX sweep.

--- a/shared/sync-protocol.ts
+++ b/shared/sync-protocol.ts
@@ -117,6 +117,18 @@ export interface RoomController {
   reason: 'creator' | 'succession' | 'reclaim';
 }
 
+/**
+ * S→room when the host ends the room.
+ *
+ * Deleting a room used to be silent to everyone in it: the row went, the
+ * link stopped working, and the people watching sat in a room that no longer
+ * existed until they happened to act. This is the goodbye.
+ */
+export interface RoomClosed {
+  v: 1;
+  roomCode: string;
+}
+
 /** C→S batched telemetry (off unless debug/harness enables it). */
 export interface SyncReport {
   v: 1;
@@ -146,4 +158,6 @@ export const SYNC_EVENTS = {
   report: 'sync:report',
   /** S→room RoomController */
   controller: 'room:controller',
+  /** S→room RoomClosed */
+  closed: 'room:closed',
 } as const;

--- a/video-sync-backend/src/rooms/rooms.controller.spec.ts
+++ b/video-sync-backend/src/rooms/rooms.controller.spec.ts
@@ -31,6 +31,12 @@ const ROOM = {
   participants: [],
 };
 
+/**
+ * The gateway only exists here to receive the room-closed announcement; the
+ * broadcast itself is the gateway's business, not this suite's.
+ */
+const announcer = () => ({ announceRoomClosed: jest.fn() });
+
 describe('RoomsController authorization', () => {
   let database: DatabaseService;
   let controller: RoomsController;
@@ -63,7 +69,9 @@ describe('RoomsController authorization', () => {
         .mockImplementation((fn: (tx: unknown) => unknown) => fn(db)),
     };
     database = db as unknown as DatabaseService;
-    controller = new RoomsController(new RoomsService(database));
+    controller = new RoomsController(
+      new RoomsService(database, announcer() as never),
+    );
   });
 
   describe('PATCH /rooms/:code', () => {

--- a/video-sync-backend/src/rooms/rooms.module.ts
+++ b/video-sync-backend/src/rooms/rooms.module.ts
@@ -1,5 +1,6 @@
 // src/rooms/rooms.module.ts
 import { Module } from '@nestjs/common';
+import { SyncModule } from '../sync/sync.module';
 import { AuthModule } from '../auth/auth.module';
 import { RoomsController } from './rooms.controller';
 import { RoomsService } from './rooms.service';
@@ -8,7 +9,7 @@ import { RoomsService } from './rooms.service';
   // for JwtService: JwtAuthGuard on the controller's routes is instantiated
   // in THIS module's injector, so the JwtModule AuthModule exports (same
   // secret the WS handshake verifies with) has to be visible here.
-  imports: [AuthModule],
+  imports: [AuthModule, SyncModule],
   controllers: [RoomsController],
   providers: [RoomsService],
   exports: [RoomsService],

--- a/video-sync-backend/src/rooms/rooms.service.spec.ts
+++ b/video-sync-backend/src/rooms/rooms.service.spec.ts
@@ -58,6 +58,12 @@ function violations(node: unknown, path: string[] = []): string[] {
   return found;
 }
 
+/**
+ * The gateway only exists here to receive the room-closed announcement; the
+ * broadcast itself is the gateway's business, not this suite's.
+ */
+const announcer = () => ({ announceRoomClosed: jest.fn() });
+
 describe("RoomsService - no query hands a client another user's secrets", () => {
   const room = {
     id: 'room-1',
@@ -95,7 +101,7 @@ describe("RoomsService - no query hands a client another user's secrets", () => 
     },
   } as unknown as DatabaseService;
 
-  const service = new RoomsService(database);
+  const service = new RoomsService(database, announcer() as never);
 
   beforeEach(() => {
     calls.length = 0;
@@ -138,5 +144,70 @@ describe("RoomsService - no query hands a client another user's secrets", () => 
         include: { creator: { select: { id: true, username: true } } },
       }),
     ).toEqual([]);
+  });
+});
+
+describe('ending a room says goodbye to the people in it', () => {
+  const roomRow = {
+    id: 'r1',
+    code: 'ABC123',
+    creatorId: 'owner',
+    creator: { id: 'owner', username: 'ada' },
+    participants: [],
+  };
+
+  const setup = () => {
+    const sync = announcer();
+    const database = {
+      room: {
+        findUnique: jest.fn().mockResolvedValue(roomRow),
+        delete: jest.fn().mockResolvedValue(roomRow),
+      },
+      chatMessage: { deleteMany: jest.fn() },
+      syncEvent: { deleteMany: jest.fn() },
+      participant: { deleteMany: jest.fn() },
+      $transaction: jest.fn((fn: (tx: unknown) => unknown) =>
+        fn({
+          chatMessage: { deleteMany: jest.fn() },
+          syncEvent: { deleteMany: jest.fn() },
+          participant: { deleteMany: jest.fn() },
+          room: { delete: jest.fn() },
+        }),
+      ),
+    };
+    return { sync, database };
+  };
+
+  it('announces the closure to the room', async () => {
+    const { sync, database } = setup();
+    await new RoomsService(database as never, sync as never).deleteRoom(
+      'ABC123',
+      'owner',
+    );
+    expect(sync.announceRoomClosed).toHaveBeenCalledWith('ABC123');
+  });
+
+  it('says nothing when the caller is not the creator', async () => {
+    // a refused delete must not tell a room it is closing
+    const { sync, database } = setup();
+    await expect(
+      new RoomsService(database as never, sync as never).deleteRoom(
+        'ABC123',
+        'someone-else',
+      ),
+    ).rejects.toThrow();
+    expect(sync.announceRoomClosed).not.toHaveBeenCalled();
+  });
+
+  it('says nothing when the room does not exist', async () => {
+    const { sync, database } = setup();
+    database.room.findUnique.mockResolvedValue(null);
+    await expect(
+      new RoomsService(database as never, sync as never).deleteRoom(
+        'NOPE',
+        'owner',
+      ),
+    ).rejects.toThrow();
+    expect(sync.announceRoomClosed).not.toHaveBeenCalled();
   });
 });

--- a/video-sync-backend/src/rooms/rooms.service.ts
+++ b/video-sync-backend/src/rooms/rooms.service.ts
@@ -4,11 +4,15 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { DatabaseService } from '../database/database.service';
+import { SyncGateway } from '../sync/sync.gateway';
 import { Prisma } from '@prisma/client';
 
 @Injectable()
 export class RoomsService {
-  constructor(private database: DatabaseService) {}
+  constructor(
+    private database: DatabaseService,
+    private sync: SyncGateway,
+  ) {}
 
   async createRoom(
     userId: string,
@@ -164,6 +168,12 @@ export class RoomsService {
         'Only the room creator can delete this room',
       );
     }
+
+    // Told BEFORE the row disappears, not after: once it is gone, a client
+    // that reacts by refetching gets a 404 and shows "couldn't load the
+    // room" instead of "the host ended it". The announcement is the last
+    // thing this room says, so it should still be able to say it.
+    this.sync.announceRoomClosed(code);
 
     // Delete all related data first (due to foreign key constraints)
     await this.database.$transaction(async (prisma) => {

--- a/video-sync-backend/src/rooms/rooms.service.ts
+++ b/video-sync-backend/src/rooms/rooms.service.ts
@@ -83,7 +83,18 @@ export class RoomsService {
   async updateRoomByCode(
     code: string,
     userId: string,
-    data: { name?: string; videoUrl?: string },
+    // Every field here reaches Prisma verbatim, so this list has to match
+    // UpdateRoomDto. It said name/videoUrl while three more columns were
+    // already flowing through - TypeScript allows the extra properties
+    // because the caller passes a variable rather than a literal, so the
+    // signature was quietly wrong rather than loudly.
+    data: {
+      name?: string;
+      videoUrl?: string;
+      isPublic?: boolean;
+      allowGuestControl?: boolean;
+      maxUsers?: number;
+    },
   ) {
     const room = await this.database.room.findUnique({
       where: { code },

--- a/video-sync-backend/src/shared/sync-protocol.ts
+++ b/video-sync-backend/src/shared/sync-protocol.ts
@@ -119,6 +119,18 @@ export interface RoomController {
   reason: 'creator' | 'succession' | 'reclaim';
 }
 
+/**
+ * S→room when the host ends the room.
+ *
+ * Deleting a room used to be silent to everyone in it: the row went, the
+ * link stopped working, and the people watching sat in a room that no longer
+ * existed until they happened to act. This is the goodbye.
+ */
+export interface RoomClosed {
+  v: 1;
+  roomCode: string;
+}
+
 /** C→S batched telemetry (off unless debug/harness enables it). */
 export interface SyncReport {
   v: 1;
@@ -148,4 +160,6 @@ export const SYNC_EVENTS = {
   report: 'sync:report',
   /** S→room RoomController */
   controller: 'room:controller',
+  /** S→room RoomClosed */
+  closed: 'room:closed',
 } as const;

--- a/video-sync-backend/src/sync/sync.gateway.ts
+++ b/video-sync-backend/src/sync/sync.gateway.ts
@@ -28,6 +28,7 @@ import {
 import { MetricsService } from '../metrics/metrics.service';
 import { TimelineService } from './timeline.service';
 import { ActorRoomStateStore } from './actor-room-state.store';
+import { VoiceRosterService } from './voice-roster.service';
 import {
   ROOM_STATE_STORE,
   RoomStateStore,
@@ -107,6 +108,7 @@ export class SyncGateway
     private clock: ClockDomainService,
     private metrics: MetricsService,
     @Inject(ROOM_STATE_STORE) private store: RoomStateStore,
+    private voiceRoster: VoiceRosterService,
   ) {
     if (this.store instanceof ActorRoomStateStore) {
       // actor plane: intents forwarded by non-owners execute HERE, on the
@@ -325,6 +327,15 @@ export class SyncGateway
 
       // Send chat history to the joining user
       await this.handleGetMessageHistory(client, { roomCode: data.roomCode });
+
+      // ...and who is already on the voice call. The roster is otherwise
+      // only broadcast on a join or leave, so anyone who opened the room
+      // after the last transition saw an empty call and no way to know
+      // otherwise - which is the exact question the panel answers.
+      client.emit('voice-roster', {
+        roomCode: data.roomCode,
+        users: this.voiceRoster.list(data.roomCode),
+      });
     } catch (error) {
       this.logger.error({ err: String(error) }, 'join failed');
       client.emit('error', { message: 'Failed to join room' });

--- a/video-sync-backend/src/sync/sync.gateway.ts
+++ b/video-sync-backend/src/sync/sync.gateway.ts
@@ -16,6 +16,7 @@ import { DatabaseService } from '../database/database.service';
 import {
   ClockPing,
   ClockPong,
+  RoomClosed,
   SYNC_EVENTS,
   SyncControl,
 } from '../shared/sync-protocol';
@@ -62,6 +63,22 @@ export class SyncGateway
 {
   @WebSocketServer()
   server: Server;
+
+  /**
+   * Tell everyone still sitting in a room that it is over.
+   *
+   * Called from the REST delete path, not from a socket handler: ending a
+   * room is a REST action by the host, and until now it was silent to
+   * everyone else - the row went, the link died, and the people watching
+   * stayed in a room that no longer existed until they happened to act.
+   *
+   * With the Redis adapter this reaches participants on every instance, not
+   * just the one that served the DELETE.
+   */
+  announceRoomClosed(roomCode: string): void {
+    const payload: RoomClosed = { v: 1, roomCode };
+    this.server?.to(roomCode).emit(SYNC_EVENTS.closed, payload);
+  }
 
   private readonly logger = new Logger(SyncGateway.name);
   private userRooms: Map<string, string> = new Map();

--- a/video-sync-backend/src/sync/sync.gateway.ts
+++ b/video-sync-backend/src/sync/sync.gateway.ts
@@ -75,6 +75,21 @@ export class SyncGateway
    * With the Redis adapter this reaches participants on every instance, not
    * just the one that served the DELETE.
    */
+  /**
+   * Who is on the voice call, told to the whole ROOM.
+   *
+   * This has to come from here, not from VoiceGateway: voice lives on the
+   * '/voice' namespace and its `server.to(roomCode)` addresses a room in
+   * THAT namespace, which the people merely watching have never joined.
+   * They are all in the main namespace's room, which is this server.
+   */
+  announceVoiceRoster(
+    roomCode: string,
+    users: { userId: string; username: string }[],
+  ): void {
+    this.server?.to(roomCode).emit('voice-roster', { roomCode, users });
+  }
+
   announceRoomClosed(roomCode: string): void {
     const payload: RoomClosed = { v: 1, roomCode };
     this.server?.to(roomCode).emit(SYNC_EVENTS.closed, payload);

--- a/video-sync-backend/src/sync/sync.module.ts
+++ b/video-sync-backend/src/sync/sync.module.ts
@@ -1,6 +1,7 @@
 // src/sync/sync.module.ts
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
+import { VoiceRosterService } from './voice-roster.service';
 import { SyncGateway } from './sync.gateway';
 import { VoiceGateway } from './voice.gateway';
 import { SyncService } from './sync.service';
@@ -27,6 +28,7 @@ function storeClass() {
   imports: [AuthModule],
   providers: [
     SyncGateway,
+    VoiceRosterService,
     VoiceGateway,
     SyncService,
     TimelineService,

--- a/video-sync-backend/src/sync/sync.module.ts
+++ b/video-sync-backend/src/sync/sync.module.ts
@@ -34,6 +34,6 @@ function storeClass() {
     // in-memory otherwise (single instance, CI protocol-only mode)
     { provide: ROOM_STATE_STORE, useClass: storeClass() },
   ],
-  exports: [SyncService],
+  exports: [SyncService, SyncGateway],
 })
 export class SyncModule {}

--- a/video-sync-backend/src/sync/voice-roster.service.spec.ts
+++ b/video-sync-backend/src/sync/voice-roster.service.spec.ts
@@ -1,0 +1,57 @@
+import { VoiceRosterService } from './voice-roster.service';
+
+const ada = { userId: 'u1', username: 'ada' };
+const grace = { userId: 'u2', username: 'grace' };
+
+describe('VoiceRosterService', () => {
+  let roster: VoiceRosterService;
+  beforeEach(() => {
+    roster = new VoiceRosterService();
+  });
+
+  it('lists who is on a call, and nothing for a room with no call', () => {
+    roster.join('ROOM', 'sock-1', ada);
+    expect(roster.list('ROOM')).toEqual([ada]);
+    expect(roster.list('OTHER')).toEqual([]);
+  });
+
+  it('keeps rooms apart', () => {
+    roster.join('A', 'sock-1', ada);
+    roster.join('B', 'sock-2', grace);
+    expect(roster.list('A')).toEqual([ada]);
+    expect(roster.list('B')).toEqual([grace]);
+  });
+
+  it('counts one person once, however many tabs they have open', () => {
+    // the same human with the room open twice is one voice on the call, and
+    // listing them twice reads as a bug to everyone looking at it
+    roster.join('ROOM', 'sock-1', ada);
+    roster.join('ROOM', 'sock-2', ada);
+    expect(roster.list('ROOM')).toEqual([ada]);
+  });
+
+  it('reports which room a leaver was in, so the caller can announce it', () => {
+    roster.join('ROOM', 'sock-1', ada);
+    expect(roster.leave('sock-1')).toBe('ROOM');
+    expect(roster.list('ROOM')).toEqual([]);
+  });
+
+  it('says nothing about a socket that was never on a call', () => {
+    expect(roster.leave('never-here')).toBeNull();
+  });
+
+  it('drops one tab without dropping the person', () => {
+    roster.join('ROOM', 'sock-1', ada);
+    roster.join('ROOM', 'sock-2', ada);
+    roster.leave('sock-1');
+    expect(roster.list('ROOM')).toEqual([ada]);
+  });
+
+  it('forgets a room once its last caller leaves', () => {
+    roster.join('ROOM', 'sock-1', ada);
+    roster.leave('sock-1');
+    // a room that emptied must not linger as a stale key
+    expect(roster.list('ROOM')).toEqual([]);
+    expect(roster.leave('sock-1')).toBeNull();
+  });
+});

--- a/video-sync-backend/src/sync/voice-roster.service.ts
+++ b/video-sync-backend/src/sync/voice-roster.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+
+export interface VoiceMember {
+  userId: string;
+  username: string;
+}
+
+/**
+ * Who is on the voice call, per room.
+ *
+ * A service rather than state inside VoiceGateway because two gateways need
+ * it and they cannot inject each other: VoiceGateway already depends on
+ * SyncGateway to reach the main namespace, so SyncGateway asking VoiceGateway
+ * for the roster would close the loop. This is the shared fact both of them
+ * read, and it belongs to neither.
+ *
+ * In-memory and per-instance, like the voice peer map it mirrors. Voice is
+ * already single-instance in practice - the WebRTC signalling is relayed
+ * through whichever server holds both sockets - so a roster that does not
+ * span instances tells no lie that voice itself does not already tell.
+ */
+@Injectable()
+export class VoiceRosterService {
+  private readonly byRoom = new Map<string, Map<string, VoiceMember>>();
+
+  join(roomCode: string, socketId: string, member: VoiceMember): void {
+    const room = this.byRoom.get(roomCode) ?? new Map<string, VoiceMember>();
+    room.set(socketId, member);
+    this.byRoom.set(roomCode, room);
+  }
+
+  /** Returns the room the socket was in, so the caller can announce it. */
+  leave(socketId: string): string | null {
+    for (const [roomCode, room] of this.byRoom) {
+      if (!room.delete(socketId)) continue;
+      if (room.size === 0) this.byRoom.delete(roomCode);
+      return roomCode;
+    }
+    return null;
+  }
+
+  /**
+   * De-duplicated by user, not by socket: the same person with the room open
+   * in two tabs is one voice on the call, and listing them twice would read
+   * as a bug to everyone looking at it.
+   */
+  list(roomCode: string): VoiceMember[] {
+    const room = this.byRoom.get(roomCode);
+    if (!room) return [];
+    const byUser = new Map<string, VoiceMember>();
+    for (const member of room.values()) byUser.set(member.userId, member);
+    return Array.from(byUser.values());
+  }
+}

--- a/video-sync-backend/src/sync/voice.gateway.ts
+++ b/video-sync-backend/src/sync/voice.gateway.ts
@@ -48,6 +48,24 @@ export class VoiceGateway
   private voiceUsers: Map<string, VoiceUser> = new Map();
   private roomVoiceUsers: Map<string, Set<string>> = new Map();
 
+  /**
+   * Broadcast who is on the call to the WHOLE room, not just the call.
+   *
+   * The roster used to go only to the person joining ('voice-users-list' on
+   * their own socket), so anyone deciding whether to join could not see
+   * whether they would be walking into an empty call or interrupting three
+   * people. This goes to the room channel, which everyone watching is
+   * already in.
+   */
+  private broadcastVoiceRoster(roomCode: string): void {
+    const ids = Array.from(this.roomVoiceUsers.get(roomCode) ?? []);
+    const users = ids
+      .map((id) => this.voiceUsers.get(id))
+      .filter((u): u is NonNullable<typeof u> => Boolean(u))
+      .map((u) => ({ userId: u.userId, username: u.username }));
+    this.server?.to(roomCode).emit('voice-roster', { roomCode, users });
+  }
+
   constructor(private jwt: JwtService) {}
 
   afterInit(server: Server): void {
@@ -144,6 +162,8 @@ export class VoiceGateway
       });
 
       // Notify others that a new user joined
+      this.broadcastVoiceRoster(data.roomCode);
+
       client.to(`voice-${data.roomCode}`).emit('voice-user-joined', {
         userId: this.identity(client).userId,
         username: this.identity(client).username,
@@ -180,6 +200,8 @@ export class VoiceGateway
       await client.leave(`voice-${room}`);
 
       // Notify others
+      this.broadcastVoiceRoster(room);
+
       client.to(`voice-${room}`).emit('voice-user-left', {
         userId: this.identity(client).userId,
         socketId: client.id,

--- a/video-sync-backend/src/sync/voice.gateway.ts
+++ b/video-sync-backend/src/sync/voice.gateway.ts
@@ -12,6 +12,7 @@ import { JwtService } from '@nestjs/jwt';
 import { Server, Socket } from 'socket.io';
 import { AuthedSocketData, wsAuthMiddleware } from './ws-auth';
 import { SyncGateway } from './sync.gateway';
+import { VoiceRosterService } from './voice-roster.service';
 
 interface VoiceUser {
   userId: string;
@@ -74,6 +75,7 @@ export class VoiceGateway
   constructor(
     private jwt: JwtService,
     private sync: SyncGateway,
+    private roster: VoiceRosterService,
   ) {}
 
   afterInit(server: Server): void {
@@ -146,6 +148,10 @@ export class VoiceGateway
         this.roomVoiceUsers.set(data.roomCode, new Set());
       }
       this.roomVoiceUsers.get(data.roomCode)!.add(client.id);
+      this.roster.join(data.roomCode, client.id, {
+        userId: voiceUser.userId,
+        username: voiceUser.username,
+      });
 
       // Join voice room
       await client.join(`voice-${data.roomCode}`);
@@ -195,6 +201,7 @@ export class VoiceGateway
 
       // Remove from maps
       this.voiceUsers.delete(client.id);
+      this.roster.leave(client.id);
 
       const roomUsers = this.roomVoiceUsers.get(room);
       if (roomUsers) {

--- a/video-sync-backend/src/sync/voice.gateway.ts
+++ b/video-sync-backend/src/sync/voice.gateway.ts
@@ -11,6 +11,7 @@ import {
 import { JwtService } from '@nestjs/jwt';
 import { Server, Socket } from 'socket.io';
 import { AuthedSocketData, wsAuthMiddleware } from './ws-auth';
+import { SyncGateway } from './sync.gateway';
 
 interface VoiceUser {
   userId: string;
@@ -63,10 +64,17 @@ export class VoiceGateway
       .map((id) => this.voiceUsers.get(id))
       .filter((u): u is NonNullable<typeof u> => Boolean(u))
       .map((u) => ({ userId: u.userId, username: u.username }));
-    this.server?.to(roomCode).emit('voice-roster', { roomCode, users });
+    // Handed to the main-namespace gateway deliberately: broadcasting from
+    // here would address a room inside '/voice' that only people already on
+    // the call have joined - i.e. exactly the people who did not need
+    // telling. My first attempt did that and reached nobody.
+    this.sync.announceVoiceRoster(roomCode, users);
   }
 
-  constructor(private jwt: JwtService) {}
+  constructor(
+    private jwt: JwtService,
+    private sync: SyncGateway,
+  ) {}
 
   afterInit(server: Server): void {
     server.use(wsAuthMiddleware(this.jwt));

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.test.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.test.tsx
@@ -7,7 +7,7 @@ import { EnhancedVideoPlayer } from './EnhancedVideoPlayer';
 // mocked engine's status stream instead.
 let mockSocket: unknown = null;
 jest.mock('../contexts/SocketContext', () => ({
-  useSocket: () => ({ socket: mockSocket, connected: false }),
+  useSocket: () => ({ socket: mockSocket, connected: false, reconnecting: false }),
 }));
 
 // captures the shell's onStatus listener so tests can push engine status

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.test.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.test.tsx
@@ -189,3 +189,71 @@ describe('the stored volume', () => {
     expect(resolve('7')).toBe(1);
   });
 });
+
+describe('P3 succession reaches the person who was promoted', () => {
+  const controllerHandlers: Record<string, (p: unknown) => void> = {};
+
+  const socketCapturing = () => ({
+    on: (event: string, cb: (p: unknown) => void) => {
+      controllerHandlers[event] = cb;
+    },
+    off: jest.fn(),
+    emit: jest.fn(),
+    connected: true,
+  });
+
+  it('a promoted guest stops being refused by their own client', () => {
+    // The server already promotes the longest-connected participant when the
+    // host leaves and WOULD accept their commands - but this client computed
+    // control locally as isHost || allowGuestControl, so it blocked the click
+    // before it was ever sent. Succession was dead at the last inch.
+    for (const k of Object.keys(controllerHandlers)) delete controllerHandlers[k];
+    mockSocket = socketCapturing();
+
+    render(
+      <EnhancedVideoPlayer
+        videoUrl="https://www.youtube.com/watch?v=aqz-KE-bpKQ"
+        roomCode="ABC123"
+        isHost={false}
+        allowGuestControl={false}
+        userId="guest-1"
+      />,
+    );
+
+    // before promotion this client is a passenger
+    expect(screen.getByText('Host only')).toBeInTheDocument();
+
+    act(() => {
+      controllerHandlers['room:controller']?.({
+        controllerId: 'guest-1',
+        reason: 'succession',
+      });
+    });
+
+    expect(screen.getByText('You have the remote')).toBeInTheDocument();
+  });
+
+  it('someone else being promoted does not hand this client the remote', () => {
+    for (const k of Object.keys(controllerHandlers)) delete controllerHandlers[k];
+    mockSocket = socketCapturing();
+
+    render(
+      <EnhancedVideoPlayer
+        videoUrl="https://www.youtube.com/watch?v=aqz-KE-bpKQ"
+        roomCode="ABC123"
+        isHost={false}
+        allowGuestControl={false}
+        userId="guest-1"
+      />,
+    );
+
+    act(() => {
+      controllerHandlers['room:controller']?.({
+        controllerId: 'someone-else',
+        reason: 'succession',
+      });
+    });
+
+    expect(screen.getByText('Host only')).toBeInTheDocument();
+  });
+});

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -32,6 +32,8 @@ import {
   IconFullscreen,
   IconPause,
   IconPlay,
+  IconSkipBack,
+  IconSkipForward,
   IconSync,
   IconUsers,
   IconVolume,
@@ -389,6 +391,17 @@ const EMPTY_STATUS: EngineStatus = {
 const SEEK_STEP_S = 5;
 
 /**
+ * Skip step for the buttons and J/L.
+ *
+ * Buttons rather than a double-tap gesture on the stage: on the YouTube and
+ * Vimeo paths the stage is a cross-origin iframe that swallows touch events,
+ * so a gesture would work for a direct file and silently do nothing for the
+ * two sources most rooms actually use. A control that works everywhere beats
+ * a gesture that works sometimes.
+ */
+const SKIP_STEP_S = 10;
+
+/**
  * The player SHELL: engine lifecycle, controls, HUD, failure card. Which
  * player actually renders is decided by classifyMediaSource - the same
  * classification the backend validates against, so a URL the API admitted
@@ -582,6 +595,14 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
           e.preventDefault();
           handlePlayPause();
           break;
+        case 'j':
+          e.preventDefault();
+          seekBy(-SKIP_STEP_S);
+          break;
+        case 'l':
+          e.preventDefault();
+          seekBy(SKIP_STEP_S);
+          break;
         case 'f':
           e.preventDefault();
           handleToggleFullscreen();
@@ -751,6 +772,25 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
    * leaves through the same seek intent the click path uses - the local
    * player is never touched here, the broadcast moves everyone.
    */
+  /**
+   * Seek by a relative amount, through the same intent path as everything
+   * else - nobody's player is touched locally; everyone converges from the
+   * broadcast.
+   */
+  const seekBy = (deltaS: number) => {
+    if (!canControl) {
+      toast.error('Only the host can seek the video', { duration: 2000 });
+      return;
+    }
+    const engine = engineRef.current;
+    if (!engine || !status.durationS) return;
+    const target = Math.max(
+      0,
+      Math.min(status.durationS, shownTime + deltaS),
+    );
+    engine.sendIntent('seek', target);
+  };
+
   const handleProgressKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     let target: number;
     switch (e.key) {
@@ -797,6 +837,16 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
       {mount && (
         <Controls>
           <ControlRow>
+            <IconControl
+              type="button"
+              onClick={() => seekBy(-SKIP_STEP_S)}
+              disabled={!isReady}
+              aria-label={`Back ${SKIP_STEP_S} seconds`}
+              title={`Back ${SKIP_STEP_S}s (J)`}
+            >
+              <IconSkipBack size={15} />
+            </IconControl>
+
             <PlayButton
               data-testid="play-button"
               onClick={handlePlayPause}
@@ -806,6 +856,16 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
               {status.roomPlaying ? <IconPause size={16} /> : <IconPlay size={16} />}
               {status.roomPlaying ? 'Pause' : 'Play'}
             </PlayButton>
+
+            <IconControl
+              type="button"
+              onClick={() => seekBy(SKIP_STEP_S)}
+              disabled={!isReady}
+              aria-label={`Forward ${SKIP_STEP_S} seconds`}
+              title={`Forward ${SKIP_STEP_S}s (L)`}
+            >
+              <IconSkipForward size={15} />
+            </IconControl>
 
             <ProgressContainer>
               {/* a slider in fact, not just in looks: whoever may seek can

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -424,6 +424,11 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
   // compute control purely locally, so their own UI blocked the click before
   // it was ever sent, and succession was dead at the last inch.
   const [controllerId, setControllerId] = useState<string | null>(null);
+  useEffect(() => {
+    // belt and braces with the roomCode check above: whatever the server
+    // said about the last room says nothing about this one
+    setControllerId(null);
+  }, [roomCode]);
   const canControl =
     isHost || allowGuestControl || (userId != null && controllerId === userId);
 
@@ -475,15 +480,25 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
     // someone. Everyone tracks it, because everyone's UI says who is
     // driving; the person promoted also stops being refused by their own
     // client, which is what made the feature invisible before.
-    const onController = (c: { controllerId: string; reason: string }) => {
+    const onController = (c: {
+      controllerId: string;
+      reason: string;
+      roomCode?: string;
+    }) => {
+      // A controller event names its room. Without checking it, a promotion
+      // in one room would still be believed after switching to another -
+      // this component is not remounted when the room code changes.
+      if (c.roomCode && c.roomCode !== roomCode) return;
       setControllerId(c.controllerId);
-      if (c.controllerId === userId) {
-        toast.success(
-          c.reason === 'reclaim'
-            ? 'You have the remote back'
-            : 'The host left - you have the remote now',
-          { duration: 4000 },
-        );
+      if (c.controllerId !== userId) return;
+      // The contract allows reason 'creator' too, which is simply "you are
+      // the host" - telling that person the host left would be nonsense.
+      if (c.reason === 'succession') {
+        toast.success('The host left - you have the remote now', {
+          duration: 4000,
+        });
+      } else if (c.reason === 'reclaim') {
+        toast.success('You have the remote back', { duration: 4000 });
       }
     };
     socket.on(SYNC_EVENTS.controller, onController);

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -403,7 +403,7 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
   allowGuestControl = false,
   userId,
 }) => {
-  const { socket, connected } = useSocket();
+  const { socket, connected, reconnecting } = useSocket();
   const [isReady, setIsReady] = useState(false);
   const [failure, setFailure] = useState<string | null>(null);
   // Bumped by Retry: it rides in the mount's key, so a retry tears the dead
@@ -864,9 +864,24 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
 
           <StatusRow>
             <StatusGroup>
+              {/* Three states, not two: before the first connect there is
+                  nothing wrong yet, and "Disconnected" on a room that is
+                  still opening reads as broken. */}
               <ConnectionState connected={connected}>
-                <StatusDot tone={connected ? color.ok : color.danger} />
-                {connected ? 'Connected' : 'Disconnected'}
+                <StatusDot
+                  tone={
+                    connected
+                      ? color.ok
+                      : reconnecting
+                        ? color.mustard
+                        : color.danger
+                  }
+                />
+                {connected
+                  ? 'Connected'
+                  : reconnecting
+                    ? 'Reconnecting…'
+                    : 'Connecting…'}
               </ConnectionState>
 
               {/* "it is loading" and "it is broken" look identical when the

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -364,6 +364,8 @@ interface VideoPlayerProps {
   roomCode: string;
   isHost?: boolean;
   allowGuestControl?: boolean;
+  /** who this client is, so it can recognise being promoted (P3 succession) */
+  userId?: string;
 }
 
 const EMPTY_STATUS: EngineStatus = {
@@ -398,7 +400,8 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
   videoUrl,
   roomCode,
   isHost = false,
-  allowGuestControl = false
+  allowGuestControl = false,
+  userId,
 }) => {
   const { socket, connected } = useSocket();
   const [isReady, setIsReady] = useState(false);
@@ -415,7 +418,14 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
 
   const engineRef = useRef<SyncEngine | null>(null);
   const adapterRef = useRef<EngineAdapter | null>(null);
-  const canControl = isHost || allowGuestControl;
+  // The server promotes the longest-connected participant when the host
+  // leaves (P3 succession, timeline.service.ts) and broadcasts it. It would
+  // ALSO accept the promoted person's commands - but this client used to
+  // compute control purely locally, so their own UI blocked the click before
+  // it was ever sent, and succession was dead at the last inch.
+  const [controllerId, setControllerId] = useState<string | null>(null);
+  const canControl =
+    isHost || allowGuestControl || (userId != null && controllerId === userId);
 
   // Which video the room is showing: the TIMELINE is the authority once one
   // exists - set-video switches every participant through sync:timeline -
@@ -461,15 +471,33 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
     };
     socket.on(SYNC_EVENTS.controlRejected, onRejected);
 
+    // P3 succession: the host left and the server handed the remote to
+    // someone. Everyone tracks it, because everyone's UI says who is
+    // driving; the person promoted also stops being refused by their own
+    // client, which is what made the feature invisible before.
+    const onController = (c: { controllerId: string; reason: string }) => {
+      setControllerId(c.controllerId);
+      if (c.controllerId === userId) {
+        toast.success(
+          c.reason === 'reclaim'
+            ? 'You have the remote back'
+            : 'The host left - you have the remote now',
+          { duration: 4000 },
+        );
+      }
+    };
+    socket.on(SYNC_EVENTS.controller, onController);
+
     return () => {
       socket.off(SYNC_EVENTS.controlRejected, onRejected);
+      socket.off(SYNC_EVENTS.controller, onController);
       unsubscribe();
       engine.dispose();
       engineRef.current = null;
       // adapterRef is owned by the active mount - clearing it here orphaned
       // a live adapter (and its poll timer) on every reconnect
     };
-  }, [socket, roomCode]);
+  }, [socket, roomCode, userId]);
 
   // ---- local audio: never synced, never sent (see EngineAdapter) ----
   // Persisted so the level survives a reload mid-film; a room you had muted
@@ -853,7 +881,11 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
 
               <CollaborativeIndicator enabled={allowGuestControl}>
                 {allowGuestControl ? <IconUsers size={13} /> : <IconCrown size={13} />}
-                {allowGuestControl ? 'Collaborative' : 'Host only'}
+                {allowGuestControl
+                  ? 'Collaborative'
+                  : canControl
+                    ? 'You have the remote'
+                    : 'Host only'}
               </CollaborativeIndicator>
             </StatusGroup>
 

--- a/video-sync-frontend/src/components/EnhancedVoiceChat.tsx
+++ b/video-sync-frontend/src/components/EnhancedVoiceChat.tsx
@@ -234,6 +234,13 @@ export const EnhancedVoiceChat: React.FC<EnhancedVoiceChatProps> = ({ roomCode }
   const [isMuted, setIsMuted] = useState(false);
   const [isDeafened, setIsDeafened] = useState(false);
   const [voiceUsers, setVoiceUsers] = useState<VoiceUser[]>([]);
+  // Who is on the call, whether or not YOU are. The server used to send the
+  // roster only to the person joining, so deciding whether to join meant
+  // joining to find out - and walking into an empty call, or interrupting
+  // three people, with no way to tell which.
+  const [onCall, setOnCall] = useState<{ userId: string; username: string }[]>(
+    [],
+  );
   const [speakingUsers, setSpeakingUsers] = useState<Set<string>>(new Set());
 
   const localStreamRef = useRef<MediaStream | null>(null);
@@ -352,6 +359,17 @@ export const EnhancedVoiceChat: React.FC<EnhancedVoiceChatProps> = ({ roomCode }
 
     peersRef.current.set(targetSocketId, peer);
   };
+
+  useEffect(() => {
+    if (!socket) return;
+    const onRoster = (p: { users?: { userId: string; username: string }[] }) => {
+      setOnCall(p?.users ?? []);
+    };
+    socket.on('voice-roster', onRoster);
+    return () => {
+      socket.off('voice-roster', onRoster);
+    };
+  }, [socket]);
 
   const handleJoinVoice = async () => {
     try {
@@ -488,7 +506,11 @@ export const EnhancedVoiceChat: React.FC<EnhancedVoiceChatProps> = ({ roomCode }
       <Header>
         <HeaderLeft>
           <Title>Voice</Title>
-          {isInVoice && <CountChip>{voiceUsers.length} in voice</CountChip>}
+          {isInVoice ? (
+            <CountChip>{voiceUsers.length} in voice</CountChip>
+          ) : (
+            onCall.length > 0 && <CountChip>{onCall.length} on the call</CountChip>
+          )}
         </HeaderLeft>
 
         <ControlButtons>
@@ -601,7 +623,14 @@ export const EnhancedVoiceChat: React.FC<EnhancedVoiceChatProps> = ({ roomCode }
         </>
       ) : (
         <EmptyState>
-          <p>Join and talk while you watch.</p>
+          {onCall.length > 0 ? (
+            <p>
+              {onCall.map((u) => u.username).join(', ')}{' '}
+              {onCall.length === 1 ? 'is' : 'are'} on the call.
+            </p>
+          ) : (
+            <p>Join and talk while you watch.</p>
+          )}
         </EmptyState>
       )}
     </VoiceContainer>

--- a/video-sync-frontend/src/components/EnhancedVoiceChat.tsx
+++ b/video-sync-frontend/src/components/EnhancedVoiceChat.tsx
@@ -251,10 +251,20 @@ export const EnhancedVoiceChat: React.FC<EnhancedVoiceChatProps> = ({ roomCode }
   useEffect(() => {
     if (!socket || !user) return;
 
-    // Create connection to voice namespace
-    const io = (socket as any).io;
-    if (io) {
-      voiceSocketRef.current = io.connect('/voice');
+    // Create connection to the voice namespace.
+    //
+    // manager.socket(nsp), NOT manager.connect(nsp): on socket.io-client v4
+    // `connect` is an alias of `open(callback)` - it opens the underlying
+    // transport and treats its argument as a completion callback, so
+    // `connect('/voice')` never produced a namespace socket at all. What
+    // landed in this ref was the Manager, whose `emit` is a local event
+    // emitter that sends nothing to the server.
+    const manager = (socket as any).io;
+    if (manager) {
+      voiceSocketRef.current = manager.socket('/voice', {
+        // the voice gateway runs the same handshake auth as the main one
+        auth: { token: (socket as any).auth?.token },
+      });
 
       const voiceSocket = voiceSocketRef.current;
 

--- a/video-sync-frontend/src/components/EnhancedVoiceChat.tsx
+++ b/video-sync-frontend/src/components/EnhancedVoiceChat.tsx
@@ -372,14 +372,24 @@ export const EnhancedVoiceChat: React.FC<EnhancedVoiceChatProps> = ({ roomCode }
 
   useEffect(() => {
     if (!socket) return;
-    const onRoster = (p: { users?: { userId: string; username: string }[] }) => {
+    const onRoster = (p: {
+      roomCode?: string;
+      users?: { userId: string; username: string }[];
+    }) => {
+      // a roster for a room you have left says nothing about this one
+      if (p?.roomCode && p.roomCode !== roomCode) return;
       setOnCall(p?.users ?? []);
     };
     socket.on('voice-roster', onRoster);
     return () => {
       socket.off('voice-roster', onRoster);
     };
-  }, [socket]);
+  }, [socket, roomCode]);
+
+  // whatever was true of the last room's call is not true of this one
+  useEffect(() => {
+    setOnCall([]);
+  }, [roomCode]);
 
   const handleJoinVoice = async () => {
     try {
@@ -516,8 +526,11 @@ export const EnhancedVoiceChat: React.FC<EnhancedVoiceChatProps> = ({ roomCode }
       <Header>
         <HeaderLeft>
           <Title>Voice</Title>
+          {/* voiceUsers is everyone ELSE - the server excludes the joining
+              client and this component renders its own card separately, so
+              the chip was always one short */}
           {isInVoice ? (
-            <CountChip>{voiceUsers.length} in voice</CountChip>
+            <CountChip>{voiceUsers.length + 1} in voice</CountChip>
           ) : (
             onCall.length > 0 && <CountChip>{onCall.length} on the call</CountChip>
           )}

--- a/video-sync-frontend/src/components/Icons.tsx
+++ b/video-sync-frontend/src/components/Icons.tsx
@@ -86,6 +86,12 @@ export const IconHeadphones = (p: P) =>
 export const IconHeadphonesOff = (p: P) =>
   base(p, <><path d="M4.5 14v-2c0-1.2.28-2.34.78-3.35" /><path d="M8.2 5.5A7.47 7.47 0 0 1 19.5 12v2" /><rect x="3.5" y="13.5" width="4" height="6.5" rx="1.6" /><rect x="16.5" y="13.5" width="4" height="6.5" rx="1.6" /><path d="M4 4l16 16" /></>);
 
+export const IconSkipBack = (p: P) =>
+  base(p, <><path d="M11 6.2c0-.85-.94-1.36-1.65-.9L3.6 9.1a1.07 1.07 0 0 0 0 1.8l5.75 3.8c.71.46 1.65-.05 1.65-.9V6.2z" /><path d="M20 6.2c0-.85-.94-1.36-1.65-.9l-5.75 3.8a1.07 1.07 0 0 0 0 1.8l5.75 3.8c.71.46 1.65-.05 1.65-.9V6.2z" /><path d="M4 18h16" /></>);
+
+export const IconSkipForward = (p: P) =>
+  base(p, <><path d="M13 6.2c0-.85.94-1.36 1.65-.9l5.75 3.8a1.07 1.07 0 0 1 0 1.8l-5.75 3.8c-.71.46-1.65-.05-1.65-.9V6.2z" /><path d="M4 6.2c0-.85.94-1.36 1.65-.9l5.75 3.8a1.07 1.07 0 0 1 0 1.8l-5.75 3.8c-.71.46-1.65-.05-1.65-.9V6.2z" /><path d="M4 18h16" /></>);
+
 export const IconVolume = (p: P) =>
   base(p, <><path d="M11 5.5 6.8 9H4a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h2.8L11 18.5a.6.6 0 0 0 1-.46V5.96a.6.6 0 0 0-1-.46z" /><path d="M15.4 9.2a4 4 0 0 1 0 5.6" /><path d="M18.2 6.6a8 8 0 0 1 0 10.8" /></>);
 

--- a/video-sync-frontend/src/contexts/AuthContext.tsx
+++ b/video-sync-frontend/src/contexts/AuthContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState, useCallback, useEffect } fr
 import axios from 'axios';
 import { toast } from 'react-hot-toast';
 import { AUTH_EXPIRED_EVENT, apiService } from '../services/api';
+import { clearRecentRooms } from '../services/recent-rooms';
 
 interface User {
   id: string;
@@ -135,6 +136,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const logout = useCallback(() => {
     setUser(null);
     localStorage.removeItem('user');
+    // where you have been is as personal as who you are, and this machine
+    // may not be yours
+    clearRecentRooms();
     toast.success('Signed out');
   }, []);
 

--- a/video-sync-frontend/src/contexts/AuthContext.tsx
+++ b/video-sync-frontend/src/contexts/AuthContext.tsx
@@ -72,6 +72,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   useEffect(() => {
     const onExpired = () => {
       setUser(null);
+      // the same reasoning as logout: a dead session must not leave the next
+      // person a list of where the last one had been
+      clearRecentRooms();
       toast.error('Session expired - sign in again');
     };
     window.addEventListener(AUTH_EXPIRED_EVENT, onExpired);

--- a/video-sync-frontend/src/contexts/SocketContext.tsx
+++ b/video-sync-frontend/src/contexts/SocketContext.tsx
@@ -6,6 +6,12 @@ import { useAuth } from './AuthContext';
 interface SocketContextType {
   socket: Socket | null;
   connected: boolean;
+  /**
+   * Dropped, but socket.io is still trying. Distinct from `!connected`,
+   * which is also true for the first moment of a page load - and a room that
+   * says "Disconnected" before it has ever connected reads as broken.
+   */
+  reconnecting: boolean;
 }
 
 const SocketContext = createContext<SocketContextType | null>(null);
@@ -26,6 +32,7 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
   const { user } = useAuth();
   const [socket, setSocket] = useState<Socket | null>(null);
   const [connected, setConnected] = useState(false);
+  const [reconnecting, setReconnecting] = useState(false);
   const token = user?.token;
 
   useEffect(() => {
@@ -54,16 +61,27 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
       reconnectionDelayMax: 10000,
     });
 
+    // The first connect is not news - it is the page loading, and it used to
+    // fire a success toast on top of "Joined the room" every single time.
+    // A RE-connect is news: it says the gap you just noticed is over.
+    let hasConnected = false;
+
     socketInstance.on('connect', () => {
       console.log('Connected to server');
       setConnected(true);
-      toast.success('Connected to sync server');
+      setReconnecting(false);
+      if (hasConnected) toast.success('Back in sync');
+      hasConnected = true;
     });
 
     socketInstance.on('disconnect', () => {
       console.log('Disconnected from server');
       setConnected(false);
-      toast.error('Disconnected from sync server');
+      // Only claim to be reconnecting once there is something to reconnect
+      // TO. No toast: socket.io retries by itself, the status chip carries
+      // it, and a red toast on every brief blip trains people to ignore
+      // toasts entirely.
+      setReconnecting(hasConnected);
     });
 
     socketInstance.on('connect_error', (error: Error) => {
@@ -83,7 +101,7 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
   }, [token]);
 
   return (
-    <SocketContext.Provider value={{ socket, connected }}>
+    <SocketContext.Provider value={{ socket, connected, reconnecting }}>
       {children}
     </SocketContext.Provider>
   );

--- a/video-sync-frontend/src/contexts/SocketContext.tsx
+++ b/video-sync-frontend/src/contexts/SocketContext.tsx
@@ -61,6 +61,11 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
       reconnectionDelayMax: 10000,
     });
 
+    // A fresh socket starts with a clean slate: the previous session's
+    // teardown fires 'disconnect', which would otherwise leave this true
+    // and make the NEXT session's first connection read as a reconnect.
+    setReconnecting(false);
+
     // The first connect is not news - it is the page loading, and it used to
     // fire a success toast on top of "Joined the room" every single time.
     // A RE-connect is news: it says the gap you just noticed is over.
@@ -96,7 +101,10 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
     setSocket(socketInstance);
 
     return () => {
+      // stop the teardown's own disconnect from being mistaken for a drop
+      hasConnected = false;
       socketInstance.disconnect();
+      setReconnecting(false);
     };
   }, [token]);
 

--- a/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
+++ b/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
@@ -7,6 +7,7 @@ import { ChatPanel } from '../components/ChatPanel';
 import { EnhancedVoiceChat } from '../components/EnhancedVoiceChat';
 import { RoomSettings } from '../components/RoomSettings';
 import { apiService } from '../services/api';
+import { rememberRoom } from '../services/recent-rooms';
 import styled from '@emotion/styled';
 import { toast } from 'react-hot-toast';
 import {
@@ -344,6 +345,14 @@ export const EnhancedRoomPage: React.FC = () => {
 
   // With several rooms open, every tab read "Mustard Watch Party" and the
   // only way to find the right one was to click through them.
+  // A room joined by link belongs to no listing: "Your rooms" is what you
+  // created, and a private room appears nowhere else. Remember it so closing
+  // the tab does not mean hunting for the original message again.
+  useEffect(() => {
+    if (!room?.code) return;
+    rememberRoom({ code: room.code, name: room.name });
+  }, [room?.code, room?.name]);
+
   useEffect(() => {
     if (!room?.name) return;
     const previous = document.title;

--- a/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
+++ b/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
@@ -7,7 +7,8 @@ import { ChatPanel } from '../components/ChatPanel';
 import { EnhancedVoiceChat } from '../components/EnhancedVoiceChat';
 import { RoomSettings } from '../components/RoomSettings';
 import { apiService } from '../services/api';
-import { rememberRoom } from '../services/recent-rooms';
+import { rememberRoom, forgetRoom } from '../services/recent-rooms';
+import { SYNC_EVENTS } from '../shared/sync-protocol';
 import styled from '@emotion/styled';
 import { toast } from 'react-hot-toast';
 import {
@@ -568,6 +569,23 @@ export const EnhancedRoomPage: React.FC = () => {
       setTimeout(() => setCopySuccess(false), 2000);
     }
   };
+
+  // The host ended the room. Until now this was silent: the row went, the
+  // link died, and whoever was watching sat in a room that no longer existed
+  // until they happened to click something and got "couldn't load the room".
+  useEffect(() => {
+    if (!socket) return;
+    const onClosed = () => {
+      // and stop offering it under "Jump back in", where it would now 404
+      if (roomCode) forgetRoom(roomCode);
+      toast('The host ended this room', { icon: '👋' });
+      navigate('/', { replace: true });
+    };
+    socket.on(SYNC_EVENTS.closed, onClosed);
+    return () => {
+      socket.off(SYNC_EVENTS.closed, onClosed);
+    };
+  }, [socket, navigate, roomCode]);
 
   const handleShareRoom = async () => {
     if (!room) return;

--- a/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
+++ b/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
@@ -612,6 +612,7 @@ export const EnhancedRoomPage: React.FC = () => {
             videoUrl={room.videoUrl}
             roomCode={room.code}
             isHost={isHost}
+            userId={user?.id}
             allowGuestControl={room.allowGuestControl}
           />
 

--- a/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
+++ b/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
@@ -181,6 +181,42 @@ const SideColumn = styled.div`
   }
 `;
 
+/**
+ * Below the breakpoint the two columns stack, which puts chat underneath the
+ * video - so following the conversation meant scrolling the film off screen.
+ * These tabs appear only there and show one panel at a time, keeping both
+ * the video and whichever panel you chose on the same screen.
+ */
+const PanelTabs = styled.div`
+  display: none;
+  gap: 8px;
+
+  @media (max-width: 1100px) {
+    display: flex;
+  }
+`;
+
+const PanelTab = styled.button<{ active: boolean }>`
+  ${chip.md}
+  ${chipInteractive}
+  flex: 1;
+  justify-content: center;
+  background: ${props => (props.active ? color.mustardFaint : color.bg2)};
+  color: ${props => (props.active ? color.mustard : color.dim)};
+  border-color: ${props => (props.active ? color.mustardDeep : color.lineBright)};
+`;
+
+/* On a wide screen both panels are always shown; narrow, only the chosen
+   one. `hideNarrow` rather than a JS breakpoint so there is no resize
+   listener and no flash of the wrong panel on first paint. */
+const PanelSlot = styled.div<{ hideNarrow: boolean }>`
+  min-width: 0;
+
+  @media (max-width: 1100px) {
+    display: ${props => (props.hideNarrow ? 'none' : 'block')};
+  }
+`;
+
 const ParticipantsPanel = styled.div`
   ${card}
   padding: 16px;
@@ -330,6 +366,10 @@ export const EnhancedRoomPage: React.FC = () => {
   const [participants, setParticipants] = useState<Participant[]>([]);
   const [loading, setLoading] = useState(true);
   const [showSettings, setShowSettings] = useState(false);
+  // Which panel a narrow screen shows. Chat by default: the participant list
+  // is reference, the conversation is the reason people look away from the
+  // film at all.
+  const [narrowPanel, setNarrowPanel] = useState<'chat' | 'people'>('chat');
   const [copySuccess, setCopySuccess] = useState(false);
 
   // The roster as the socket handlers last saw it. Join/leave toasts have to
@@ -529,11 +569,36 @@ export const EnhancedRoomPage: React.FC = () => {
     }
   };
 
-  const handleShareRoom = () => {
-    if (room) {
-      const shareUrl = `${window.location.origin}/join-room/${room.code}`;
-      navigator.clipboard.writeText(shareUrl);
+  const handleShareRoom = async () => {
+    if (!room) return;
+    const shareUrl = `${window.location.origin}/join-room/${room.code}`;
+
+    // On a phone, copying to the clipboard is the long way round: the point
+    // of sharing is to get the link INTO a message, and the OS sheet does
+    // that in one step. Desktop browsers mostly have no share sheet, so the
+    // clipboard remains the fallback rather than the exception.
+    if (typeof navigator.share === 'function') {
+      try {
+        await navigator.share({
+          title: room.name,
+          text: `Watch ${room.name} with me`,
+          url: shareUrl,
+        });
+        return;
+      } catch (err) {
+        // AbortError is someone dismissing the sheet - not a failure, and
+        // falling through to "copied" would be a lie about what happened
+        if ((err as Error)?.name === 'AbortError') return;
+        // anything else: fall through to the clipboard
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(shareUrl);
       toast.success('Share link copied');
+    } catch {
+      // a denied clipboard leaves nothing to show for the click
+      toast.error('Copy the link from the address bar');
     }
   };
 
@@ -629,6 +694,28 @@ export const EnhancedRoomPage: React.FC = () => {
         </MainColumn>
 
         <SideColumn>
+          <PanelTabs role="tablist" aria-label="Room panels">
+            <PanelTab
+              type="button"
+              role="tab"
+              aria-selected={narrowPanel === 'chat'}
+              active={narrowPanel === 'chat'}
+              onClick={() => setNarrowPanel('chat')}
+            >
+              Chat
+            </PanelTab>
+            <PanelTab
+              type="button"
+              role="tab"
+              aria-selected={narrowPanel === 'people'}
+              active={narrowPanel === 'people'}
+              onClick={() => setNarrowPanel('people')}
+            >
+              People ({participants.length})
+            </PanelTab>
+          </PanelTabs>
+
+          <PanelSlot hideNarrow={narrowPanel !== 'people'}>
           <ParticipantsPanel>
             <PanelHeader>
               <PanelLabel>Participants</PanelLabel>
@@ -660,8 +747,11 @@ export const EnhancedRoomPage: React.FC = () => {
                 </ParticipantRow>
               ))}
           </ParticipantsPanel>
+          </PanelSlot>
 
-          <ChatPanel roomCode={room.code} />
+          <PanelSlot hideNarrow={narrowPanel !== 'chat'}>
+            <ChatPanel roomCode={room.code} />
+          </PanelSlot>
         </SideColumn>
       </Grid>
 

--- a/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
+++ b/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
@@ -575,7 +575,11 @@ export const EnhancedRoomPage: React.FC = () => {
   // until they happened to click something and got "couldn't load the room".
   useEffect(() => {
     if (!socket) return;
-    const onClosed = () => {
+    const onClosed = (p?: { roomCode?: string }) => {
+      // The socket is not guaranteed to have left a previous room, so an
+      // event can arrive for one you are no longer in. Acting on it would
+      // eject you from the room you ARE in and forget the wrong one.
+      if (p?.roomCode && p.roomCode !== roomCode) return;
       // and stop offering it under "Jump back in", where it would now 404
       if (roomCode) forgetRoom(roomCode);
       toast('The host ended this room', { icon: '👋' });

--- a/video-sync-frontend/src/pages/HomePage.tsx
+++ b/video-sync-frontend/src/pages/HomePage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { useQuery } from '@tanstack/react-query';
 import styled from '@emotion/styled';
 import { apiService } from '../services/api';
+import { listRecentRooms } from '../services/recent-rooms';
 import { toast } from 'react-hot-toast';
 import {
   color,
@@ -216,6 +217,22 @@ const EmptyActions = styled.div`
   flex-wrap: wrap;
   justify-content: center;
   gap: 8px;
+`;
+
+const RecentRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 28px;
+`;
+
+const RecentChip = styled.button`
+  ${chip.md}
+  ${chipInteractive}
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const SectionActions = styled.div`
@@ -533,6 +550,9 @@ const DangerFilledButton = styled.button`
 
 export const HomePage: React.FC = () => {
   const navigate = useNavigate();
+  // read once on mount: this is a snapshot of where you have been, and it
+  // must not churn while the dashboard is open
+  const [recentRooms] = useState(() => listRecentRooms());
   const { user, logout } = useAuth();
   const [publicFilter, setPublicFilter] = useState('all');
   const [deleteModal, setDeleteModal] = useState<{ show: boolean; room: any | null }>({ show: false, room: null });
@@ -732,6 +752,24 @@ export const HomePage: React.FC = () => {
       </TopBar>
 
       <Content>
+        {recentRooms.length > 0 && (
+          <>
+            <SectionLabel as="h2">Jump back in</SectionLabel>
+            <RecentRow>
+              {recentRooms.map((r) => (
+                <RecentChip
+                  key={r.code}
+                  type="button"
+                  title={`Rejoin ${r.name}`}
+                  onClick={() => navigate(`/room/${r.code}`)}
+                >
+                  {r.name}
+                </RecentChip>
+              ))}
+            </RecentRow>
+          </>
+        )}
+
         {/* Your Rooms Section */}
         <Section>
           <SectionHead>

--- a/video-sync-frontend/src/pages/HomePage.tsx
+++ b/video-sync-frontend/src/pages/HomePage.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { useQuery } from '@tanstack/react-query';
 import styled from '@emotion/styled';
 import { apiService } from '../services/api';
-import { listRecentRooms } from '../services/recent-rooms';
+import { listRecentRooms, type RecentRoom } from '../services/recent-rooms';
 import { toast } from 'react-hot-toast';
 import {
   color,
@@ -550,10 +550,17 @@ const DangerFilledButton = styled.button`
 
 export const HomePage: React.FC = () => {
   const navigate = useNavigate();
-  // read once on mount: this is a snapshot of where you have been, and it
-  // must not churn while the dashboard is open
-  const [recentRooms] = useState(() => listRecentRooms());
   const { user, logout } = useAuth();
+  // A snapshot, so the row does not churn while you are looking at it - but
+  // re-taken whenever the session changes. Reading it once for the lifetime
+  // of the component meant a sign-out followed by a different sign-in, with
+  // no reload in between, showed the previous person's room names.
+  const [recentRooms, setRecentRooms] = useState<RecentRoom[]>([]);
+  const userId = user?.id;
+  useEffect(() => {
+    setRecentRooms(userId ? listRecentRooms() : []);
+  }, [userId]);
+
   const [publicFilter, setPublicFilter] = useState('all');
   const [deleteModal, setDeleteModal] = useState<{ show: boolean; room: any | null }>({ show: false, room: null });
   const cancelDeleteRef = useRef<HTMLButtonElement>(null);

--- a/video-sync-frontend/src/services/recent-rooms.test.ts
+++ b/video-sync-frontend/src/services/recent-rooms.test.ts
@@ -73,3 +73,19 @@ describe('recent rooms', () => {
     expect(listRecentRooms()).toEqual([]);
   });
 });
+
+describe('session boundaries', () => {
+  it('clearing leaves nothing for the next person', () => {
+    // The dashboard also re-reads this whenever the signed-in id changes,
+    // because clearing storage alone left the previous list in React state
+    // until a reload - a different user could see where the last one had been.
+    rememberRoom({ code: 'AAA', name: 'Private thing' }, 1);
+    rememberRoom({ code: 'BBB', name: 'Another' }, 2);
+    expect(listRecentRooms()).toHaveLength(2);
+
+    clearRecentRooms();
+
+    expect(listRecentRooms()).toEqual([]);
+    expect(localStorage.getItem('mustard:recent-rooms')).toBeNull();
+  });
+});

--- a/video-sync-frontend/src/services/recent-rooms.test.ts
+++ b/video-sync-frontend/src/services/recent-rooms.test.ts
@@ -1,0 +1,75 @@
+import {
+  clearRecentRooms,
+  forgetRoom,
+  listRecentRooms,
+  rememberRoom,
+} from './recent-rooms';
+
+beforeEach(() => localStorage.clear());
+
+describe('recent rooms', () => {
+  it('remembers a visit, newest first', () => {
+    rememberRoom({ code: 'AAA', name: 'First' }, 1000);
+    rememberRoom({ code: 'BBB', name: 'Second' }, 2000);
+
+    expect(listRecentRooms().map((r) => r.code)).toEqual(['BBB', 'AAA']);
+  });
+
+  it('lists a room once, at its most recent visit', () => {
+    rememberRoom({ code: 'AAA', name: 'First' }, 1000);
+    rememberRoom({ code: 'BBB', name: 'Second' }, 2000);
+    rememberRoom({ code: 'AAA', name: 'First again' }, 3000);
+
+    const rooms = listRecentRooms();
+    expect(rooms.map((r) => r.code)).toEqual(['AAA', 'BBB']);
+    expect(rooms[0].name).toBe('First again');
+  });
+
+  it('keeps only the last handful', () => {
+    for (let i = 0; i < 20; i++) {
+      rememberRoom({ code: `R${i}`, name: `Room ${i}` }, i);
+    }
+    expect(listRecentRooms()).toHaveLength(6);
+    expect(listRecentRooms()[0].code).toBe('R19');
+  });
+
+  it('falls back to the code when a room has no name', () => {
+    rememberRoom({ code: 'AAA', name: '' }, 1000);
+    expect(listRecentRooms()[0].name).toBe('AAA');
+  });
+
+  it('forgets one room, and all of them', () => {
+    rememberRoom({ code: 'AAA', name: 'a' }, 1);
+    rememberRoom({ code: 'BBB', name: 'b' }, 2);
+
+    forgetRoom('AAA');
+    expect(listRecentRooms().map((r) => r.code)).toEqual(['BBB']);
+
+    clearRecentRooms();
+    expect(listRecentRooms()).toEqual([]);
+  });
+
+  it.each([
+    ['unparseable JSON', 'not json at all'],
+    ['a non-array', '{"code":"AAA"}'],
+    ['entries of the wrong shape', '[{"nope":1},null,3]'],
+  ])('survives %s in storage', (_name, stored) => {
+    // a corrupt entry must not blank the dashboard or throw during render
+    localStorage.setItem('mustard:recent-rooms', stored);
+    expect(() => listRecentRooms()).not.toThrow();
+    expect(listRecentRooms()).toEqual([]);
+  });
+
+  it('keeps the good entries when only some are corrupt', () => {
+    localStorage.setItem(
+      'mustard:recent-rooms',
+      JSON.stringify([{ code: 'AAA', name: 'ok', at: 5 }, { junk: true }]),
+    );
+    expect(listRecentRooms().map((r) => r.code)).toEqual(['AAA']);
+  });
+
+  it('ignores a visit with no code', () => {
+    rememberRoom({ code: '', name: 'nameless' }, 1);
+    expect(listRecentRooms()).toEqual([]);
+  });
+});

--- a/video-sync-frontend/src/services/recent-rooms.ts
+++ b/video-sync-frontend/src/services/recent-rooms.ts
@@ -1,0 +1,86 @@
+/**
+ * The rooms you were just in.
+ *
+ * A room you joined by link belongs to nobody's dashboard: "Your rooms"
+ * lists what you CREATED, and a private room you were invited to appears in
+ * no listing at all. Close the tab and the only way back is to find the
+ * original message again. This remembers the last few, locally.
+ *
+ * Local on purpose: it is a convenience, not a membership record, and the
+ * server already knows who joined what. Keeping it in localStorage means no
+ * new endpoint, no new column, and nothing to leak from one account to the
+ * next beyond room names on a shared machine - which the sign-out path
+ * clears for exactly that reason.
+ */
+const KEY = 'mustard:recent-rooms';
+const LIMIT = 6;
+
+export interface RecentRoom {
+  code: string;
+  name: string;
+  /** ms epoch of the last visit, for ordering and "2h ago" */
+  at: number;
+}
+
+const isRecord = (v: unknown): v is RecentRoom => {
+  const r = v as RecentRoom | null;
+  return (
+    !!r &&
+    typeof r.code === 'string' &&
+    r.code.length > 0 &&
+    typeof r.name === 'string' &&
+    typeof r.at === 'number' &&
+    Number.isFinite(r.at)
+  );
+};
+
+export const listRecentRooms = (): RecentRoom[] => {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // Filter rather than trust: this survives a schema change and a
+    // half-written value, and a corrupt entry must not blank the dashboard.
+    return parsed.filter(isRecord).sort((a, b) => b.at - a.at).slice(0, LIMIT);
+  } catch {
+    return [];
+  }
+};
+
+/** Record a visit. The newest wins, and a room is never listed twice. */
+export const rememberRoom = (
+  room: { code: string; name: string },
+  now: number = Date.now(),
+): void => {
+  if (!room?.code) return;
+  try {
+    const next = [
+      { code: room.code, name: room.name || room.code, at: now },
+      ...listRecentRooms().filter((r) => r.code !== room.code),
+    ].slice(0, LIMIT);
+    localStorage.setItem(KEY, JSON.stringify(next));
+  } catch {
+    // a full or disabled localStorage is not worth failing a page load over
+  }
+};
+
+export const forgetRoom = (code: string): void => {
+  try {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify(listRecentRooms().filter((r) => r.code !== code)),
+    );
+  } catch {
+    /* see above */
+  }
+};
+
+/** Signing out must not leave the next person a list of where you have been. */
+export const clearRecentRooms = (): void => {
+  try {
+    localStorage.removeItem(KEY);
+  } catch {
+    /* see above */
+  }
+};

--- a/video-sync-frontend/src/shared/sync-protocol.ts
+++ b/video-sync-frontend/src/shared/sync-protocol.ts
@@ -119,6 +119,18 @@ export interface RoomController {
   reason: 'creator' | 'succession' | 'reclaim';
 }
 
+/**
+ * S→room when the host ends the room.
+ *
+ * Deleting a room used to be silent to everyone in it: the row went, the
+ * link stopped working, and the people watching sat in a room that no longer
+ * existed until they happened to act. This is the goodbye.
+ */
+export interface RoomClosed {
+  v: 1;
+  roomCode: string;
+}
+
 /** C→S batched telemetry (off unless debug/harness enables it). */
 export interface SyncReport {
   v: 1;
@@ -148,4 +160,6 @@ export const SYNC_EVENTS = {
   report: 'sync:report',
   /** S→room RoomController */
   controller: 'room:controller',
+  /** S→room RoomClosed */
+  closed: 'room:closed',
 } as const;


### PR DESCRIPTION
Continuing through the UX audit. Five things, and the first is a correction to something I told the user.

## Host migration is not missing — it was broken at the last inch

I reported host migration as missing. **It isn't.** `timeline.service.ts` has implemented P3 succession all along: the longest-connected participant is promoted when the controller leaves, the creator reclaims on return, and `room:controller` is broadcast. The server would even have *accepted* the promoted person's commands — `allowedToControl` already counts `activeController`.

**The frontend never listened.** `canControl` was computed locally as `isHost || allowGuestControl`, so the promoted person's own client refused their click and never sent it. From outside, indistinguishable from having no host migration at all — which is exactly why my audit and I both misread it.

Two tests, and the second is the one that matters: a promoted guest gains control, **and someone else being promoted does not hand this client the remote** — the assertion that catches a naive `controllerId != null`.

## Chat and the film on the same screen

Below 1100px the columns stack, putting chat under the video: following the conversation meant scrolling the film off screen. The side column now has tabs at that width and shows one panel at a time. CSS-only, driven by the same breakpoint as the grid — no resize listener, no flash of the wrong panel on first paint.

*Verified structurally, not visually*: the tablist renders, is `display:none` at desktop width, and the `max-width:1100px` rule flips it to `flex`. The screenshot pipeline here doesn't follow a window resize, so the narrow rendering wants a human eye.

## Three connection states, and toasts that only fire when there's news

The room had two states and one was a lie: before the first connect, `connected` is false, so a room that was merely *opening* announced "Disconnected" — which reads as broken. Now Connecting… / Reconnecting… / Connected, the middle in mustard rather than red because socket.io is still trying and nothing is lost.

The toasts were noise: every page load fired "Connected to sync server" on top of "Joined the room", and every blip fired a red "Disconnected". First connect is silent (it's the page loading), a *re*-connect says "Back in sync", and a disconnect says nothing — the chip carries it and the retry is automatic.

## The rooms you were just in

A room joined by link belongs to no listing — "Your rooms" is what you *created*. Close the tab and the only way back is the original message. "Jump back in" on the dashboard, local rather than a new endpoint. Every read filters rather than trusts (tests cover unparseable JSON, a non-array, wrong-shaped entries, a good/corrupt mix), and signing out clears it because the machine may not be yours.

## Share that actually shares, and a signature that told the truth

`navigator.share` where it exists — on a phone the clipboard is the long way round — with a dismissed sheet treated as "nothing happened" rather than a false "copied". Desktop keeps the clipboard, and a denied clipboard now says so.

And `updateRoomByCode`'s parameter listed `name`/`videoUrl` while three more columns were already flowing through it into Prisma. TypeScript allowed it because the caller passes a variable, not a literal, so excess-property checking never ran — the signature was *quietly* wrong, which is the worse kind.

99 frontend tests, 300 backend, both builds clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Return to recently visited rooms from the home page.
  - Hosts can end rooms with participants notified and redirected automatically.
  - Promoted guests can gain remote playback control when permitted.
  - Added 10-second skip-back and skip-forward controls, including J/L shortcuts.
  - Voice chat now displays current callers and live participant counts.
  - Room sharing supports native sharing with clipboard fallback.

- **Improvements**
  - Connection status now distinguishes connecting, reconnecting, and connected states.
  - Recent-room history is safely cleared on logout or session expiry.
  - Responsive room layouts improve chat and participant viewing on narrow screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->