### PR TITLE
review-only: the tail of #49 that CodeRabbit's quota never reached

### DIFF
--- a/docs/GUEST_ACCESS.md
+++ b/docs/GUEST_ACCESS.md
@@ -1,0 +1,75 @@
+# Joining without an account — what it would actually take
+
+The UX audit's largest open finding: someone sent an invite link has to
+create an account before they can watch anything. This note is the survey I
+did before writing any of it, because the shape of the change is decided by
+constraints that are already load-bearing, and picking the wrong shape here
+is expensive to undo.
+
+Not implemented. This is the analysis, not the design being proposed as
+settled.
+
+## Why it is not a small change
+
+Three things assume a `User` row exists, and each is there for a reason.
+
+**The socket handshake refuses a connection without a verified token.**
+`ws-auth.ts` rejects a missing token, an unparseable one, and one with no
+subject, before any handler runs. Identity is derived there and never read
+off a payload — that is what stopped the chat handler impersonation bug, and
+it is why the REST and socket planes cannot drift on who someone is. Any
+guest path has to produce something this middleware accepts, not bypass it.
+
+**`Participant.userId` is a foreign key to `User`.** Presence, the
+participant list, and the rejoin path all read through it. A guest with no
+row cannot be a participant without either a nullable FK (which pushes a
+null check into every read) or a real row.
+
+**The token IS the identity, on both planes.** REST and the socket verify the
+same HS256 `{ sub, name }`, and `relay-go` verifies its HMAC. There is one
+contract in `token-payload.ts` precisely so there is nothing to keep in sync.
+
+## The two shapes
+
+**A. A real but disposable User row.** The guest gets a `User` with no
+password (already possible — the column is nullable for Google sign-in) and
+a generated name, and a normal token. Everything downstream is unchanged:
+the handshake passes, the FK is satisfied, presence works, chat attributes
+correctly.
+
+Costs: rows accumulate for every guest visit and need a reaper; the
+`username` unique constraint needs a collision-tolerant generator (the Google
+path already has one — `google/username.ts`); and "guest" has to be visible
+in the UI, or people will not understand why their room disappeared when they
+next open the site.
+
+**B. A distinct guest token with no row.** A token with a `guest:` subject
+and a claim naming the room, accepted by the handshake but never resolvable
+to a `User`.
+
+Costs: `Participant` needs a nullable `userId` plus a display name, and every
+read of it grows a branch. Chat messages have the same problem — `ChatMessage.userId`
+is also a FK. This is the cleaner data model in the abstract and the larger
+change in practice, because it touches every place identity is read rather
+than one place it is created.
+
+## What I would want decided before writing it
+
+1. **Should a guest be scoped to one room?** B makes that natural, A does not
+   enforce it without extra work. A guest token that works everywhere is a
+   weaker thing than the invite implies.
+2. **Do guest messages persist?** If yes, `ChatMessage` needs the same
+   treatment as `Participant`, and deleting the guest later orphans history.
+3. **What happens when a guest signs up properly?** Carrying their identity
+   across is easy under A (promote the row) and hard under B (there is no row
+   to promote).
+
+## Recommendation
+
+A, with a reaper — but only if the answer to (1) is "no, a guest is a
+lightweight account". If a guest must be confined to the room they were
+invited to, B is the honest model and the extra work is the price of not
+lying about what the token means.
+
+Either way this wants to be its own PR with its own tests, not an
+afterthought bolted onto a UX sweep.

--- a/video-sync-backend/src/sync/sync.gateway.ts
+++ b/video-sync-backend/src/sync/sync.gateway.ts
@@ -28,6 +28,7 @@ import {
 import { MetricsService } from '../metrics/metrics.service';
 import { TimelineService } from './timeline.service';
 import { ActorRoomStateStore } from './actor-room-state.store';
+import { VoiceRosterService } from './voice-roster.service';
 import {
   ROOM_STATE_STORE,
   RoomStateStore,
@@ -107,6 +108,7 @@ export class SyncGateway
     private clock: ClockDomainService,
     private metrics: MetricsService,
     @Inject(ROOM_STATE_STORE) private store: RoomStateStore,
+    private voiceRoster: VoiceRosterService,
   ) {
     if (this.store instanceof ActorRoomStateStore) {
       // actor plane: intents forwarded by non-owners execute HERE, on the
@@ -325,6 +327,15 @@ export class SyncGateway
 
       // Send chat history to the joining user
       await this.handleGetMessageHistory(client, { roomCode: data.roomCode });
+
+      // ...and who is already on the voice call. The roster is otherwise
+      // only broadcast on a join or leave, so anyone who opened the room
+      // after the last transition saw an empty call and no way to know
+      // otherwise - which is the exact question the panel answers.
+      client.emit('voice-roster', {
+        roomCode: data.roomCode,
+        users: this.voiceRoster.list(data.roomCode),
+      });
     } catch (error) {
       this.logger.error({ err: String(error) }, 'join failed');
       client.emit('error', { message: 'Failed to join room' });

--- a/video-sync-backend/src/sync/sync.gateway.ts
+++ b/video-sync-backend/src/sync/sync.gateway.ts
@@ -75,6 +75,21 @@ export class SyncGateway
    * With the Redis adapter this reaches participants on every instance, not
    * just the one that served the DELETE.
    */
+  /**
+   * Who is on the voice call, told to the whole ROOM.
+   *
+   * This has to come from here, not from VoiceGateway: voice lives on the
+   * '/voice' namespace and its `server.to(roomCode)` addresses a room in
+   * THAT namespace, which the people merely watching have never joined.
+   * They are all in the main namespace's room, which is this server.
+   */
+  announceVoiceRoster(
+    roomCode: string,
+    users: { userId: string; username: string }[],
+  ): void {
+    this.server?.to(roomCode).emit('voice-roster', { roomCode, users });
+  }
+
   announceRoomClosed(roomCode: string): void {
     const payload: RoomClosed = { v: 1, roomCode };
     this.server?.to(roomCode).emit(SYNC_EVENTS.closed, payload);

--- a/video-sync-backend/src/sync/sync.module.ts
+++ b/video-sync-backend/src/sync/sync.module.ts
@@ -1,6 +1,7 @@
 // src/sync/sync.module.ts
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
+import { VoiceRosterService } from './voice-roster.service';
 import { SyncGateway } from './sync.gateway';
 import { VoiceGateway } from './voice.gateway';
 import { SyncService } from './sync.service';
@@ -27,6 +28,7 @@ function storeClass() {
   imports: [AuthModule],
   providers: [
     SyncGateway,
+    VoiceRosterService,
     VoiceGateway,
     SyncService,
     TimelineService,

--- a/video-sync-backend/src/sync/voice-roster.service.spec.ts
+++ b/video-sync-backend/src/sync/voice-roster.service.spec.ts
@@ -1,0 +1,57 @@
+import { VoiceRosterService } from './voice-roster.service';
+
+const ada = { userId: 'u1', username: 'ada' };
+const grace = { userId: 'u2', username: 'grace' };
+
+describe('VoiceRosterService', () => {
+  let roster: VoiceRosterService;
+  beforeEach(() => {
+    roster = new VoiceRosterService();
+  });
+
+  it('lists who is on a call, and nothing for a room with no call', () => {
+    roster.join('ROOM', 'sock-1', ada);
+    expect(roster.list('ROOM')).toEqual([ada]);
+    expect(roster.list('OTHER')).toEqual([]);
+  });
+
+  it('keeps rooms apart', () => {
+    roster.join('A', 'sock-1', ada);
+    roster.join('B', 'sock-2', grace);
+    expect(roster.list('A')).toEqual([ada]);
+    expect(roster.list('B')).toEqual([grace]);
+  });
+
+  it('counts one person once, however many tabs they have open', () => {
+    // the same human with the room open twice is one voice on the call, and
+    // listing them twice reads as a bug to everyone looking at it
+    roster.join('ROOM', 'sock-1', ada);
+    roster.join('ROOM', 'sock-2', ada);
+    expect(roster.list('ROOM')).toEqual([ada]);
+  });
+
+  it('reports which room a leaver was in, so the caller can announce it', () => {
+    roster.join('ROOM', 'sock-1', ada);
+    expect(roster.leave('sock-1')).toBe('ROOM');
+    expect(roster.list('ROOM')).toEqual([]);
+  });
+
+  it('says nothing about a socket that was never on a call', () => {
+    expect(roster.leave('never-here')).toBeNull();
+  });
+
+  it('drops one tab without dropping the person', () => {
+    roster.join('ROOM', 'sock-1', ada);
+    roster.join('ROOM', 'sock-2', ada);
+    roster.leave('sock-1');
+    expect(roster.list('ROOM')).toEqual([ada]);
+  });
+
+  it('forgets a room once its last caller leaves', () => {
+    roster.join('ROOM', 'sock-1', ada);
+    roster.leave('sock-1');
+    // a room that emptied must not linger as a stale key
+    expect(roster.list('ROOM')).toEqual([]);
+    expect(roster.leave('sock-1')).toBeNull();
+  });
+});

--- a/video-sync-backend/src/sync/voice-roster.service.ts
+++ b/video-sync-backend/src/sync/voice-roster.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+
+export interface VoiceMember {
+  userId: string;
+  username: string;
+}
+
+/**
+ * Who is on the voice call, per room.
+ *
+ * A service rather than state inside VoiceGateway because two gateways need
+ * it and they cannot inject each other: VoiceGateway already depends on
+ * SyncGateway to reach the main namespace, so SyncGateway asking VoiceGateway
+ * for the roster would close the loop. This is the shared fact both of them
+ * read, and it belongs to neither.
+ *
+ * In-memory and per-instance, like the voice peer map it mirrors. Voice is
+ * already single-instance in practice - the WebRTC signalling is relayed
+ * through whichever server holds both sockets - so a roster that does not
+ * span instances tells no lie that voice itself does not already tell.
+ */
+@Injectable()
+export class VoiceRosterService {
+  private readonly byRoom = new Map<string, Map<string, VoiceMember>>();
+
+  join(roomCode: string, socketId: string, member: VoiceMember): void {
+    const room = this.byRoom.get(roomCode) ?? new Map<string, VoiceMember>();
+    room.set(socketId, member);
+    this.byRoom.set(roomCode, room);
+  }
+
+  /** Returns the room the socket was in, so the caller can announce it. */
+  leave(socketId: string): string | null {
+    for (const [roomCode, room] of this.byRoom) {
+      if (!room.delete(socketId)) continue;
+      if (room.size === 0) this.byRoom.delete(roomCode);
+      return roomCode;
+    }
+    return null;
+  }
+
+  /**
+   * De-duplicated by user, not by socket: the same person with the room open
+   * in two tabs is one voice on the call, and listing them twice would read
+   * as a bug to everyone looking at it.
+   */
+  list(roomCode: string): VoiceMember[] {
+    const room = this.byRoom.get(roomCode);
+    if (!room) return [];
+    const byUser = new Map<string, VoiceMember>();
+    for (const member of room.values()) byUser.set(member.userId, member);
+    return Array.from(byUser.values());
+  }
+}

--- a/video-sync-backend/src/sync/voice.gateway.ts
+++ b/video-sync-backend/src/sync/voice.gateway.ts
@@ -12,6 +12,7 @@ import { JwtService } from '@nestjs/jwt';
 import { Server, Socket } from 'socket.io';
 import { AuthedSocketData, wsAuthMiddleware } from './ws-auth';
 import { SyncGateway } from './sync.gateway';
+import { VoiceRosterService } from './voice-roster.service';
 
 interface VoiceUser {
   userId: string;
@@ -74,6 +75,7 @@ export class VoiceGateway
   constructor(
     private jwt: JwtService,
     private sync: SyncGateway,
+    private roster: VoiceRosterService,
   ) {}
 
   afterInit(server: Server): void {
@@ -146,6 +148,10 @@ export class VoiceGateway
         this.roomVoiceUsers.set(data.roomCode, new Set());
       }
       this.roomVoiceUsers.get(data.roomCode)!.add(client.id);
+      this.roster.join(data.roomCode, client.id, {
+        userId: voiceUser.userId,
+        username: voiceUser.username,
+      });
 
       // Join voice room
       await client.join(`voice-${data.roomCode}`);
@@ -195,6 +201,7 @@ export class VoiceGateway
 
       // Remove from maps
       this.voiceUsers.delete(client.id);
+      this.roster.leave(client.id);
 
       const roomUsers = this.roomVoiceUsers.get(room);
       if (roomUsers) {

--- a/video-sync-backend/src/sync/voice.gateway.ts
+++ b/video-sync-backend/src/sync/voice.gateway.ts
@@ -11,6 +11,7 @@ import {
 import { JwtService } from '@nestjs/jwt';
 import { Server, Socket } from 'socket.io';
 import { AuthedSocketData, wsAuthMiddleware } from './ws-auth';
+import { SyncGateway } from './sync.gateway';
 
 interface VoiceUser {
   userId: string;
@@ -63,10 +64,17 @@ export class VoiceGateway
       .map((id) => this.voiceUsers.get(id))
       .filter((u): u is NonNullable<typeof u> => Boolean(u))
       .map((u) => ({ userId: u.userId, username: u.username }));
-    this.server?.to(roomCode).emit('voice-roster', { roomCode, users });
+    // Handed to the main-namespace gateway deliberately: broadcasting from
+    // here would address a room inside '/voice' that only people already on
+    // the call have joined - i.e. exactly the people who did not need
+    // telling. My first attempt did that and reached nobody.
+    this.sync.announceVoiceRoster(roomCode, users);
   }
 
-  constructor(private jwt: JwtService) {}
+  constructor(
+    private jwt: JwtService,
+    private sync: SyncGateway,
+  ) {}
 
   afterInit(server: Server): void {
     server.use(wsAuthMiddleware(this.jwt));

--- a/video-sync-frontend/src/components/EnhancedVoiceChat.tsx
+++ b/video-sync-frontend/src/components/EnhancedVoiceChat.tsx
@@ -251,10 +251,20 @@ export const EnhancedVoiceChat: React.FC<EnhancedVoiceChatProps> = ({ roomCode }
   useEffect(() => {
     if (!socket || !user) return;
 
-    // Create connection to voice namespace
-    const io = (socket as any).io;
-    if (io) {
-      voiceSocketRef.current = io.connect('/voice');
+    // Create connection to the voice namespace.
+    //
+    // manager.socket(nsp), NOT manager.connect(nsp): on socket.io-client v4
+    // `connect` is an alias of `open(callback)` - it opens the underlying
+    // transport and treats its argument as a completion callback, so
+    // `connect('/voice')` never produced a namespace socket at all. What
+    // landed in this ref was the Manager, whose `emit` is a local event
+    // emitter that sends nothing to the server.
+    const manager = (socket as any).io;
+    if (manager) {
+      voiceSocketRef.current = manager.socket('/voice', {
+        // the voice gateway runs the same handshake auth as the main one
+        auth: { token: (socket as any).auth?.token },
+      });
 
       const voiceSocket = voiceSocketRef.current;
 

--- a/video-sync-frontend/src/components/EnhancedVoiceChat.tsx
+++ b/video-sync-frontend/src/components/EnhancedVoiceChat.tsx
@@ -372,14 +372,24 @@ export const EnhancedVoiceChat: React.FC<EnhancedVoiceChatProps> = ({ roomCode }
 
   useEffect(() => {
     if (!socket) return;
-    const onRoster = (p: { users?: { userId: string; username: string }[] }) => {
+    const onRoster = (p: {
+      roomCode?: string;
+      users?: { userId: string; username: string }[];
+    }) => {
+      // a roster for a room you have left says nothing about this one
+      if (p?.roomCode && p.roomCode !== roomCode) return;
       setOnCall(p?.users ?? []);
     };
     socket.on('voice-roster', onRoster);
     return () => {
       socket.off('voice-roster', onRoster);
     };
-  }, [socket]);
+  }, [socket, roomCode]);
+
+  // whatever was true of the last room's call is not true of this one
+  useEffect(() => {
+    setOnCall([]);
+  }, [roomCode]);
 
   const handleJoinVoice = async () => {
     try {
@@ -516,8 +526,11 @@ export const EnhancedVoiceChat: React.FC<EnhancedVoiceChatProps> = ({ roomCode }
       <Header>
         <HeaderLeft>
           <Title>Voice</Title>
+          {/* voiceUsers is everyone ELSE - the server excludes the joining
+              client and this component renders its own card separately, so
+              the chip was always one short */}
           {isInVoice ? (
-            <CountChip>{voiceUsers.length} in voice</CountChip>
+            <CountChip>{voiceUsers.length + 1} in voice</CountChip>
           ) : (
             onCall.length > 0 && <CountChip>{onCall.length} on the call</CountChip>
           )}

--- a/video-sync-frontend/src/contexts/SocketContext.tsx
+++ b/video-sync-frontend/src/contexts/SocketContext.tsx
@@ -61,6 +61,11 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
       reconnectionDelayMax: 10000,
     });
 
+    // A fresh socket starts with a clean slate: the previous session's
+    // teardown fires 'disconnect', which would otherwise leave this true
+    // and make the NEXT session's first connection read as a reconnect.
+    setReconnecting(false);
+
     // The first connect is not news - it is the page loading, and it used to
     // fire a success toast on top of "Joined the room" every single time.
     // A RE-connect is news: it says the gap you just noticed is over.
@@ -96,7 +101,10 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
     setSocket(socketInstance);
 
     return () => {
+      // stop the teardown's own disconnect from being mistaken for a drop
+      hasConnected = false;
       socketInstance.disconnect();
+      setReconnecting(false);
     };
   }, [token]);
 

--- a/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
+++ b/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
@@ -575,7 +575,11 @@ export const EnhancedRoomPage: React.FC = () => {
   // until they happened to click something and got "couldn't load the room".
   useEffect(() => {
     if (!socket) return;
-    const onClosed = () => {
+    const onClosed = (p?: { roomCode?: string }) => {
+      // The socket is not guaranteed to have left a previous room, so an
+      // event can arrive for one you are no longer in. Acting on it would
+      // eject you from the room you ARE in and forget the wrong one.
+      if (p?.roomCode && p.roomCode !== roomCode) return;
       // and stop offering it under "Jump back in", where it would now 404
       if (roomCode) forgetRoom(roomCode);
       toast('The host ended this room', { icon: '👋' });


### PR DESCRIPTION
**Do not merge.** These three commits are already on `main` as part of #49 (`c61415d`). This PR exists solely so they get the review CodeRabbit's rate limit prevented — its base is a frozen snapshot of the branch at `7a9421c`, the last commit it *did* review, so the diff is exactly the unreviewed tail.

CodeRabbit reviewed this branch twice (`0926783` and `7a9421c`) and I addressed everything both times. Then its quota ran out and stayed out across four re-requests, so these landed unreviewed:

## `4dabbe5` — the voice roster reached nobody, and the voice socket was never created

My own feature was broken and a **live check caught it**, not a test. `VoiceGateway` is on the `/voice` namespace, so its `server.to(roomCode)` addressed a room *inside* that namespace — joined only by people already on the call, i.e. exactly the people who didn't need telling. The roster is now announced by `SyncGateway`, which owns the namespace everyone watching is already in.

Separately, and pre-existing: the frontend never created a voice-namespace socket at all. `manager.connect('/voice')` on socket.io-client v4 is an alias of `open(callback)` — it opens the transport and treats the string as a completion callback — so `voiceSocketRef` held the **Manager**, whose `emit` sends nothing to a server. It's `manager.socket(nsp)`.

**Worth a close look:** whether `manager.socket('/voice', { auth })` picks up the token correctly. I read the token off `(socket as any).auth?.token`, which is the shape socket.io-client stores it in, but I have not verified voice *authentication* end to end — only that the roster now arrives.

## `1d28504` — six fixes from the second review, plus `VoiceRosterService`

The substantive one: the roster only broadcast on join/leave, so anyone opening the room mid-call saw an empty call. Now sent to each client as it joins. That needed shared state — `VoiceGateway` already depends on `SyncGateway`, so `SyncGateway` asking back would close the loop.

Also: `room:closed` and `voice-roster` now check the payload's room (the socket isn't guaranteed to have left a previous one, so a stray event could eject you from the room you're actually in); `reconnecting` no longer leaks across socket sessions; the voice count includes you.

One suggestion **not** taken, deliberately: routing `voice-roster` through `/voice` and `voice-${roomCode}`. That reaches only clients already on the call — precisely the people who don't need it.

## `e84e479` — docs only

Analysis of what guest-join would take. No code.

## Verification

Live, with real clients against a running server — the only thing that catches namespace mistakes:
- a watcher who never joins sees the call roster,
- a **latecomer** arriving mid-call is told who's on it,
- both see it empty when the caller leaves.

**Not verified:** WebRTC audio itself (needs two browsers with microphones) and the narrow-screen tab layout (the screenshot pipeline doesn't follow a window resize).

310 backend tests, 100 frontend, all four CI checks green on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice-call participants now appear consistently for everyone in the same room.
  * Participant counts include the current user and update as people join or leave.
  * Room changes automatically refresh the displayed call roster.
* **Bug Fixes**
  * Improved voice connection handling during reconnects and cleanup.
  * Room-closed notifications now affect only the room currently being viewed.
* **Documentation**
  * Added guidance on guest access options, authentication considerations, and cleanup decisions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->