### PR TITLE
feat: join without an account, and subtitles where the source has them

### DIFF
--- a/video-sync-backend/prisma/migrations/20260810030000_add_guest_users/migration.sql
+++ b/video-sync-backend/prisma/migrations/20260810030000_add_guest_users/migration.sql
@@ -1,0 +1,11 @@
+-- Guests: someone who followed an invite link without registering.
+--
+-- Additive and safe on a live database: a new column with a default and
+-- NOT NULL is a catalog change in PostgreSQL 11+, not a table rewrite, so
+-- existing rows are untouched and nobody waits.
+
+ALTER TABLE "User" ADD COLUMN "isGuest" BOOLEAN NOT NULL DEFAULT false;
+
+-- The sweeper looks up guests by age; without this it is a sequential scan
+-- over every user in the table on every run.
+CREATE INDEX "User_isGuest_createdAt_idx" ON "User"("isGuest", "createdAt");

--- a/video-sync-backend/prisma/migrations/20260810030000_add_guest_users/migration.sql
+++ b/video-sync-backend/prisma/migrations/20260810030000_add_guest_users/migration.sql
@@ -8,4 +8,11 @@ ALTER TABLE "User" ADD COLUMN "isGuest" BOOLEAN NOT NULL DEFAULT false;
 
 -- The sweeper looks up guests by age; without this it is a sequential scan
 -- over every user in the table on every run.
+--
+-- NOT CONCURRENTLY, and that is forced rather than chosen: prisma migrate
+-- runs each migration file inside a transaction, and CREATE INDEX
+-- CONCURRENTLY cannot run in one. So this takes a brief ACCESS EXCLUSIVE
+-- lock on User. At this table's size that is milliseconds; if it ever grows
+-- to where that matters, the index wants building by hand outside a
+-- migration and this file wants an IF NOT EXISTS.
 CREATE INDEX "User_isGuest_createdAt_idx" ON "User"("isGuest", "createdAt");

--- a/video-sync-backend/prisma/schema.prisma
+++ b/video-sync-backend/prisma/schema.prisma
@@ -23,6 +23,20 @@ model User {
   // Everything that compares a password must therefore check for null
   // FIRST - see AuthService.login.
   password      String?
+  /**
+   * Someone who came in on an invite link without registering.
+   *
+   * A real row rather than a rowless token, because three things already
+   * depend on one existing: the socket handshake refuses a connection whose
+   * token has no subject, and both Participant.userId and ChatMessage.userId
+   * are foreign keys. A guest that is a User satisfies all three with no
+   * branch anywhere downstream - see docs/GUEST_ACCESS.md.
+   *
+   * The flag exists so these can be swept up later and so the UI can say
+   * what someone is. Nothing else reads it: a guest is not less trusted
+   * inside a room, they are just unregistered.
+   */
+  isGuest       Boolean        @default(false)
   createdAt     DateTime       @default(now())      // Automatically set when created
   updatedAt     DateTime       @updatedAt           // Automatically updated on changes
   chatMessages  ChatMessage[]
@@ -35,6 +49,8 @@ model User {
   // Indexes improve query performance
   @@index([email])      // Fast lookups by email
   @@index([username])   // Fast lookups by username
+  // the sweeper reads guests by age; without this it scans every user
+  @@index([isGuest, createdAt])
 }
 
 // Room model - represents a video watching session

--- a/video-sync-backend/src/auth/auth.controller.ts
+++ b/video-sync-backend/src/auth/auth.controller.ts
@@ -3,6 +3,8 @@ import {
   Get,
   Post,
   Body,
+  HttpException,
+  HttpStatus,
   Query,
   Req,
   Res,
@@ -20,6 +22,7 @@ import {
   OAUTH_COOKIE_PATH,
 } from './google/google-oauth.service';
 import { readCookie } from './google/cookies';
+import { RateBucket, clientIp } from './rate-bucket';
 
 @Controller('auth')
 export class AuthController {
@@ -29,6 +32,9 @@ export class AuthController {
     private authService: AuthService,
     private google: GoogleOAuthService,
   ) {}
+
+  /** 10 guests per IP per hour, refilling steadily rather than all at once. */
+  private readonly guestBucket = new RateBucket(10, 10 / 3600);
 
   @Post('register')
   async register(
@@ -44,6 +50,27 @@ export class AuthController {
   @Post('login')
   async login(@Body() loginDto: { username: string; password: string }) {
     return await this.authService.login(loginDto.username, loginDto.password);
+  }
+
+  /**
+   * Sign in as a guest.
+   *
+   * Rate limited per IP, unlike register: register is at least a form
+   * someone has to fill in, while this is one unauthenticated request that
+   * creates a row, so an unbounded version is a way to fill the users table
+   * from a shell loop. The window is generous enough that a household behind
+   * one address can all join the same film.
+   */
+  @Post('guest')
+  async guest(@Req() req: Request) {
+    const ip = clientIp(req);
+    if (!this.guestBucket.take(ip, Date.now())) {
+      throw new HttpException(
+        'Too many guests from this connection - try again shortly',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+    return await this.authService.createGuest();
   }
 
   /**

--- a/video-sync-backend/src/auth/auth.controller.ts
+++ b/video-sync-backend/src/auth/auth.controller.ts
@@ -22,6 +22,7 @@ import {
   OAUTH_COOKIE_PATH,
 } from './google/google-oauth.service';
 import { readCookie } from './google/cookies';
+import { Interval } from '@nestjs/schedule';
 import { RateBucket, clientIp } from './rate-bucket';
 
 @Controller('auth')
@@ -35,6 +36,18 @@ export class AuthController {
 
   /** 10 guests per IP per hour, refilling steadily rather than all at once. */
   private readonly guestBucket = new RateBucket(10, 10 / 3600);
+
+  /**
+   * Nothing swept the bucket map, so it retained a key per distinct caller
+   * forever - which turns a rate limiter into a slow memory leak that an
+   * attacker controls the size of. Hourly, off the request path, because
+   * scanning the map on every request to defend against growth would be
+   * paying the cost the growth was going to charge anyway.
+   */
+  @Interval(3_600_000)
+  sweepRateBuckets(): void {
+    this.guestBucket.sweep(Date.now());
+  }
 
   @Post('register')
   async register(

--- a/video-sync-backend/src/auth/auth.module.ts
+++ b/video-sync-backend/src/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { GoogleOAuthService } from './google/google-oauth.service';
+import { GuestSweeperService } from './guest-sweeper.service';
 
 @Module({
   imports: [
@@ -19,7 +20,7 @@ import { GoogleOAuthService } from './google/google-oauth.service';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, GoogleOAuthService],
+  providers: [AuthService, GoogleOAuthService, GuestSweeperService],
   exports: [AuthService, JwtModule],
 })
 export class AuthModule {}

--- a/video-sync-backend/src/auth/auth.service.spec.ts
+++ b/video-sync-backend/src/auth/auth.service.spec.ts
@@ -253,3 +253,72 @@ describe('signInWithGoogle', () => {
     );
   });
 });
+
+describe('createGuest', () => {
+  const guestArgs = (db: ReturnType<typeof makeDb>) =>
+    (db.user.create.mock.calls as { data: Record<string, unknown> }[][]).map(
+      (c) => c[0].data,
+    );
+
+  it('creates a passwordless, flagged account with an unroutable address', async () => {
+    const db = makeDb();
+    db.user.create.mockResolvedValue({
+      id: 'g1',
+      username: 'guest',
+      email: 'x@guest.invalid',
+    });
+
+    const result = await serviceWith(db).createGuest();
+
+    const data = guestArgs(db)[0];
+    expect(data.isGuest).toBe(true);
+    // null, not an unusable hash - there is no password login for a guest
+    expect(data.password).toBeNull();
+    // .invalid is reserved by RFC 2606, so this can never collide with a
+    // real person's address or be delivered to
+    expect(String(data.email)).toMatch(/@guest\.invalid$/);
+    // and the token is the same contract both planes verify
+    expect(jwtService.verify(result.token)).toMatchObject({ sub: 'g1' });
+  });
+
+  it('gives every guest a different address', async () => {
+    const db = makeDb();
+    db.user.create.mockResolvedValue({ id: 'g', username: 'g', email: 'e' });
+    const service = serviceWith(db);
+    await service.createGuest();
+    await service.createGuest();
+
+    const [first, second] = guestArgs(db).map((d) => d.email);
+    expect(first).not.toBe(second);
+  });
+
+  it('draws another name when the first is taken', async () => {
+    // 'guest' is a popular name by design; a collision is the generator's
+    // job, not an error
+    const db = makeDb();
+    db.user.create
+      .mockRejectedValueOnce(uniqueViolation('username'))
+      .mockResolvedValue({ id: 'g2', username: 'guest_0042', email: 'e' });
+
+    const result = await serviceWith(db).createGuest();
+
+    expect(result.username).toBe('guest_0042');
+    const names = guestArgs(db).map((d) => d.username);
+    expect(names[1]).not.toBe(names[0]);
+  });
+
+  it('gives up rather than looping forever', async () => {
+    const db = makeDb();
+    db.user.create.mockRejectedValue(uniqueViolation('username'));
+    await expect(serviceWith(db).createGuest()).rejects.toThrow(/guest name/i);
+    expect(guestArgs(db).length).toBeLessThanOrEqual(8);
+  });
+
+  it('lets an unexpected database error surface', async () => {
+    const db = makeDb();
+    db.user.create.mockRejectedValue(new Error('connection reset'));
+    await expect(serviceWith(db).createGuest()).rejects.toThrow(
+      'connection reset',
+    );
+  });
+});

--- a/video-sync-backend/src/auth/auth.service.ts
+++ b/video-sync-backend/src/auth/auth.service.ts
@@ -6,6 +6,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { randomUUID } from 'crypto';
 import { Prisma } from '@prisma/client';
 import { DatabaseService } from '../database/database.service';
 import * as bcrypt from 'bcrypt';
@@ -107,6 +108,51 @@ export class AuthService {
       email: user.email,
       token: this.issueToken(user),
     };
+  }
+
+  /**
+   * A way in for someone who followed an invite link and does not want an
+   * account.
+   *
+   * The row is real (docs/GUEST_ACCESS.md): the socket handshake refuses a
+   * token with no subject, and Participant.userId and ChatMessage.userId are
+   * both foreign keys, so a rowless guest would need a nullable FK and a
+   * branch at every read. A User with no password satisfies all three and
+   * costs one boolean.
+   *
+   * This grants nothing registration does not already grant - anyone can
+   * register with an address they do not own - so it is not a new surface,
+   * it is the same one without the form.
+   */
+  async createGuest(): Promise<SessionUser> {
+    const candidates = usernameCandidates('guest');
+
+    for (let attempt = 0; attempt < USERNAME_ATTEMPTS; attempt++) {
+      const username = candidates.next().value as string;
+      try {
+        const user = await this.database.user.create({
+          data: {
+            username,
+            // email is @unique NOT NULL, so a guest needs one that can never
+            // collide with a real person's. .invalid is reserved by RFC 2606
+            // and can never be registered, so this address is unroutable by
+            // construction rather than by convention.
+            email: `${randomUUID()}@guest.invalid`,
+            password: null,
+            isGuest: true,
+          },
+          select: { id: true, username: true, email: true },
+        });
+        return { ...user, token: this.issueToken(user) };
+      } catch (err) {
+        // 'guest' is a popular name by design - collisions are expected and
+        // the generator's job, not an error
+        if (isUniqueViolation(err, 'username')) continue;
+        throw err;
+      }
+    }
+
+    throw new ConflictException('Could not allocate a guest name');
   }
 
   /** The signed-in identity, for a client holding a token and nothing else. */

--- a/video-sync-backend/src/auth/guest-sweeper.service.spec.ts
+++ b/video-sync-backend/src/auth/guest-sweeper.service.spec.ts
@@ -1,0 +1,63 @@
+import { GuestSweeperService } from './guest-sweeper.service';
+import { DatabaseService } from '../database/database.service';
+
+const makeDb = () => ({
+  user: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+});
+
+/** The shape the sweeper passes to Prisma, so the assertions are checked. */
+interface DeleteArgs {
+  where: {
+    isGuest: boolean;
+    createdAt: { lt: Date };
+    roomsCreated: unknown;
+    participants: unknown;
+    chatMessages: unknown;
+  };
+}
+
+const deleteWhere = (db: ReturnType<typeof makeDb>): DeleteArgs['where'] =>
+  (db.user.deleteMany.mock.calls as DeleteArgs[][])[0][0].where;
+
+const sweeperWith = (db: ReturnType<typeof makeDb>) =>
+  new GuestSweeperService(db as unknown as DatabaseService);
+
+const NOW = new Date('2026-08-10T00:00:00Z').getTime();
+
+describe('GuestSweeperService', () => {
+  it('only ever deletes guests, and only old ones', () => {
+    const db = makeDb();
+    void sweeperWith(db).sweep(NOW);
+
+    const where = deleteWhere(db);
+    expect(where.isGuest).toBe(true);
+    // a week back, not a day: a guest in yesterday's room should still have
+    // a name in that room's chat history tomorrow
+    expect(NOW - where.createdAt.lt.getTime()).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it('spares any guest who left a trace someone else can still see', () => {
+    const db = makeDb();
+    void sweeperWith(db).sweep(NOW);
+
+    const where = deleteWhere(db);
+    // each of these is load-bearing for another person's screen
+    expect(where.roomsCreated).toEqual({ none: {} });
+    expect(where.participants).toEqual({ none: {} });
+    expect(where.chatMessages).toEqual({ none: {} });
+  });
+
+  it('reports what it removed', async () => {
+    const db = makeDb();
+    db.user.deleteMany.mockResolvedValue({ count: 3 });
+    await expect(sweeperWith(db).sweep(NOW)).resolves.toBe(3);
+  });
+
+  it('survives a failing sweep rather than taking the process down', async () => {
+    // the rows are inert and the next run finds them again; a nightly job
+    // that can crash the API is a worse problem than a few stale guests
+    const db = makeDb();
+    db.user.deleteMany.mockRejectedValue(new Error('connection reset'));
+    await expect(sweeperWith(db).sweep(NOW)).resolves.toBe(0);
+  });
+});

--- a/video-sync-backend/src/auth/guest-sweeper.service.ts
+++ b/video-sync-backend/src/auth/guest-sweeper.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { DatabaseService } from '../database/database.service';
+
+/** How long a guest account outlives its last sign of life. */
+const GUEST_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+@Injectable()
+export class GuestSweeperService {
+  private readonly logger = new Logger(GuestSweeperService.name);
+
+  constructor(private readonly database: DatabaseService) {}
+
+  /**
+   * Delete guest accounts nobody is using any more.
+   *
+   * Guests are cheap to make by design, so without this the users table
+   * grows forever with rows that will never be signed into again - their
+   * token expires in 12 hours and there is no password to get back in with.
+   *
+   * A week, not a day: a guest who was in a room yesterday should still
+   * appear in its participant list and its chat history tomorrow. Deleting
+   * them sooner would blank names out of conversations people are still
+   * reading.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_4AM)
+  async sweep(now: number = Date.now()): Promise<number> {
+    const cutoff = new Date(now - GUEST_TTL_MS);
+    try {
+      // Only guests with no trace left. A guest who created a room or is
+      // still an active participant is load-bearing for someone else's
+      // screen - the FK would refuse the delete anyway, and catching that
+      // as an error every night is worse than not asking.
+      const { count } = await this.database.user.deleteMany({
+        where: {
+          isGuest: true,
+          createdAt: { lt: cutoff },
+          roomsCreated: { none: {} },
+          participants: { none: {} },
+          chatMessages: { none: {} },
+        },
+      });
+      if (count > 0) this.logger.log(`swept ${count} expired guest account(s)`);
+      return count;
+    } catch (err) {
+      // A failed sweep is not worth taking the process down for: the rows
+      // are inert, and the next run will find them again.
+      this.logger.warn(
+        `guest sweep failed: ${err instanceof Error ? err.message : 'unknown'}`,
+      );
+      return 0;
+    }
+  }
+}

--- a/video-sync-backend/src/auth/rate-bucket.spec.ts
+++ b/video-sync-backend/src/auth/rate-bucket.spec.ts
@@ -56,12 +56,35 @@ describe('clientIp', () => {
   const req = (headers: Record<string, unknown>, remote?: string) =>
     ({ headers, socket: { remoteAddress: remote } }) as unknown as Request;
 
-  it('uses the first x-forwarded-for entry, not the last', () => {
-    // the later entries are appended by intermediaries and are
-    // attacker-controlled: trusting one would let a caller reset their own
-    // bucket by sending a header
+  it('uses the LAST x-forwarded-for entry - the one our proxy wrote', () => {
+    // A proxy APPENDS the peer it saw, so a caller who sends their own
+    // header produces "<invented>, <real>". Keying on the leftmost entry
+    // lets anyone rotate identity with a header and never hit the limit.
     expect(clientIp(req({ 'x-forwarded-for': '1.2.3.4, 10.0.0.1' }))).toBe(
-      '1.2.3.4',
+      '10.0.0.1',
+    );
+  });
+
+  it('is not fooled by a caller who forges the header', () => {
+    // this is the attack the previous version was open to
+    const forged = clientIp(req({ 'x-forwarded-for': 'evil-1, 203.0.113.9' }));
+    const forgedAgain = clientIp(
+      req({ 'x-forwarded-for': 'evil-2, 203.0.113.9' }),
+    );
+    // whatever they invent, they key to the same bucket
+    expect(forged).toBe(forgedAgain);
+    expect(forged).toBe('203.0.113.9');
+  });
+
+  it('handles a single entry, spacing, and empty segments', () => {
+    expect(clientIp(req({ 'x-forwarded-for': '203.0.113.9' }))).toBe(
+      '203.0.113.9',
+    );
+    expect(clientIp(req({ 'x-forwarded-for': ' 1.1.1.1 ,  2.2.2.2 ' }))).toBe(
+      '2.2.2.2',
+    );
+    expect(clientIp(req({ 'x-forwarded-for': '1.1.1.1, ,' }, '9.9.9.9'))).toBe(
+      '1.1.1.1',
     );
   });
 
@@ -71,8 +94,13 @@ describe('clientIp', () => {
   });
 
   it('handles the header arriving as an array', () => {
+    // node gives an array when the header appears more than once; the
+    // nearest proxy is still the last thing written
     expect(clientIp(req({ 'x-forwarded-for': ['9.9.9.9, 10.0.0.1'] }))).toBe(
-      '9.9.9.9',
+      '10.0.0.1',
+    );
+    expect(clientIp(req({ 'x-forwarded-for': ['1.1.1.1', '2.2.2.2'] }))).toBe(
+      '2.2.2.2',
     );
   });
 });

--- a/video-sync-backend/src/auth/rate-bucket.spec.ts
+++ b/video-sync-backend/src/auth/rate-bucket.spec.ts
@@ -1,4 +1,4 @@
-import { RateBucket, clientIp } from './rate-bucket';
+import { RateBucket, clientIpFrom } from './rate-bucket';
 import type { Request } from 'express';
 
 describe('RateBucket', () => {
@@ -52,55 +52,74 @@ describe('RateBucket', () => {
   });
 });
 
-describe('clientIp', () => {
+describe('clientIpFrom', () => {
   const req = (headers: Record<string, unknown>, remote?: string) =>
     ({ headers, socket: { remoteAddress: remote } }) as unknown as Request;
 
-  it('uses the LAST x-forwarded-for entry - the one our proxy wrote', () => {
-    // A proxy APPENDS the peer it saw, so a caller who sends their own
-    // header produces "<invented>, <real>". Keying on the leftmost entry
-    // lets anyone rotate identity with a header and never hit the limit.
-    expect(clientIp(req({ 'x-forwarded-for': '1.2.3.4, 10.0.0.1' }))).toBe(
-      '10.0.0.1',
-    );
+  describe('with no proxy in front (a laptop)', () => {
+    it('ignores x-forwarded-for entirely', () => {
+      // with nothing appending, the whole header is whatever the caller
+      // typed - trusting any part of it hands them a fresh bucket per
+      // request, which is exactly what a live check caught
+      expect(
+        clientIpFrom(
+          req({ 'x-forwarded-for': 'invented' }, '127.0.0.1'),
+          false,
+        ),
+      ).toBe('127.0.0.1');
+    });
+
+    it('keys every forgery to the same bucket', () => {
+      const a = clientIpFrom(
+        req({ 'x-forwarded-for': 'a' }, '127.0.0.1'),
+        false,
+      );
+      const b = clientIpFrom(
+        req({ 'x-forwarded-for': 'b' }, '127.0.0.1'),
+        false,
+      );
+      expect(a).toBe(b);
+    });
   });
 
-  it('is not fooled by a caller who forges the header', () => {
-    // this is the attack the previous version was open to
-    const forged = clientIp(req({ 'x-forwarded-for': 'evil-1, 203.0.113.9' }));
-    const forgedAgain = clientIp(
-      req({ 'x-forwarded-for': 'evil-2, 203.0.113.9' }),
-    );
-    // whatever they invent, they key to the same bucket
-    expect(forged).toBe(forgedAgain);
-    expect(forged).toBe('203.0.113.9');
-  });
+  describe('behind one proxy (Render)', () => {
+    it('uses the entry the proxy wrote, not the one the caller sent', () => {
+      expect(
+        clientIpFrom(req({ 'x-forwarded-for': 'invented, 203.0.113.9' }), true),
+      ).toBe('203.0.113.9');
+    });
 
-  it('handles a single entry, spacing, and empty segments', () => {
-    expect(clientIp(req({ 'x-forwarded-for': '203.0.113.9' }))).toBe(
-      '203.0.113.9',
-    );
-    expect(clientIp(req({ 'x-forwarded-for': ' 1.1.1.1 ,  2.2.2.2 ' }))).toBe(
-      '2.2.2.2',
-    );
-    expect(clientIp(req({ 'x-forwarded-for': '1.1.1.1, ,' }, '9.9.9.9'))).toBe(
-      '1.1.1.1',
-    );
-  });
+    it('keys every forgery to the same bucket', () => {
+      const a = clientIpFrom(
+        req({ 'x-forwarded-for': 'evil-1, 203.0.113.9' }),
+        true,
+      );
+      const b = clientIpFrom(
+        req({ 'x-forwarded-for': 'evil-2, 203.0.113.9' }),
+        true,
+      );
+      expect(a).toBe(b);
+      expect(a).toBe('203.0.113.9');
+    });
 
-  it('falls back to the socket, then to a constant', () => {
-    expect(clientIp(req({}, '5.6.7.8'))).toBe('5.6.7.8');
-    expect(clientIp(req({}))).toBe('unknown');
-  });
+    it('handles one entry, spacing, empties, and a repeated header', () => {
+      expect(
+        clientIpFrom(req({ 'x-forwarded-for': '203.0.113.9' }), true),
+      ).toBe('203.0.113.9');
+      expect(
+        clientIpFrom(req({ 'x-forwarded-for': ' 1.1.1.1 ,  2.2.2.2 ' }), true),
+      ).toBe('2.2.2.2');
+      expect(
+        clientIpFrom(req({ 'x-forwarded-for': '1.1.1.1, ,' }, '9.9.9.9'), true),
+      ).toBe('1.1.1.1');
+      expect(
+        clientIpFrom(req({ 'x-forwarded-for': ['1.1.1.1', '2.2.2.2'] }), true),
+      ).toBe('2.2.2.2');
+    });
 
-  it('handles the header arriving as an array', () => {
-    // node gives an array when the header appears more than once; the
-    // nearest proxy is still the last thing written
-    expect(clientIp(req({ 'x-forwarded-for': ['9.9.9.9, 10.0.0.1'] }))).toBe(
-      '10.0.0.1',
-    );
-    expect(clientIp(req({ 'x-forwarded-for': ['1.1.1.1', '2.2.2.2'] }))).toBe(
-      '2.2.2.2',
-    );
+    it('falls back to the socket when the header is absent', () => {
+      expect(clientIpFrom(req({}, '5.6.7.8'), true)).toBe('5.6.7.8');
+      expect(clientIpFrom(req({}), true)).toBe('unknown');
+    });
   });
 });

--- a/video-sync-backend/src/auth/rate-bucket.spec.ts
+++ b/video-sync-backend/src/auth/rate-bucket.spec.ts
@@ -1,0 +1,78 @@
+import { RateBucket, clientIp } from './rate-bucket';
+import type { Request } from 'express';
+
+describe('RateBucket', () => {
+  it('allows a burst up to capacity, then refuses', () => {
+    const bucket = new RateBucket(3, 1);
+    const now = 1_000_000;
+    expect([1, 2, 3].map(() => bucket.take('ip', now))).toEqual([
+      true,
+      true,
+      true,
+    ]);
+    expect(bucket.take('ip', now)).toBe(false);
+  });
+
+  it('refills over time rather than all at once', () => {
+    const bucket = new RateBucket(2, 1); // one per second
+    const t0 = 1_000_000;
+    bucket.take('ip', t0);
+    bucket.take('ip', t0);
+    expect(bucket.take('ip', t0)).toBe(false);
+    expect(bucket.take('ip', t0 + 999)).toBe(false);
+    expect(bucket.take('ip', t0 + 1000)).toBe(true);
+  });
+
+  it('never refills past capacity, however long the wait', () => {
+    const bucket = new RateBucket(2, 1);
+    const t0 = 1_000_000;
+    // a day of idling must not bank a day's worth of requests
+    expect(bucket.take('ip', t0 + 86_400_000)).toBe(true);
+    expect(bucket.take('ip', t0 + 86_400_000)).toBe(true);
+    expect(bucket.take('ip', t0 + 86_400_000)).toBe(false);
+  });
+
+  it('keeps callers apart', () => {
+    const bucket = new RateBucket(1, 0);
+    const now = 1_000_000;
+    expect(bucket.take('a', now)).toBe(true);
+    expect(bucket.take('a', now)).toBe(false);
+    // b is not punished for a's spending
+    expect(bucket.take('b', now)).toBe(true);
+  });
+
+  it('forgets idle callers so the map cannot grow forever', () => {
+    const bucket = new RateBucket(1, 0);
+    const t0 = 1_000_000;
+    bucket.take('a', t0);
+    expect(bucket.take('a', t0)).toBe(false);
+    bucket.sweep(t0 + 7_200_000);
+    // swept, so it starts full again
+    expect(bucket.take('a', t0 + 7_200_000)).toBe(true);
+  });
+});
+
+describe('clientIp', () => {
+  const req = (headers: Record<string, unknown>, remote?: string) =>
+    ({ headers, socket: { remoteAddress: remote } }) as unknown as Request;
+
+  it('uses the first x-forwarded-for entry, not the last', () => {
+    // the later entries are appended by intermediaries and are
+    // attacker-controlled: trusting one would let a caller reset their own
+    // bucket by sending a header
+    expect(clientIp(req({ 'x-forwarded-for': '1.2.3.4, 10.0.0.1' }))).toBe(
+      '1.2.3.4',
+    );
+  });
+
+  it('falls back to the socket, then to a constant', () => {
+    expect(clientIp(req({}, '5.6.7.8'))).toBe('5.6.7.8');
+    expect(clientIp(req({}))).toBe('unknown');
+  });
+
+  it('handles the header arriving as an array', () => {
+    expect(clientIp(req({ 'x-forwarded-for': ['9.9.9.9, 10.0.0.1'] }))).toBe(
+      '9.9.9.9',
+    );
+  });
+});

--- a/video-sync-backend/src/auth/rate-bucket.ts
+++ b/video-sync-backend/src/auth/rate-bucket.ts
@@ -50,23 +50,28 @@ export class RateBucket {
 }
 
 /**
- * The caller's address, behind exactly one trusted proxy.
+ * The caller's address, for keying a rate limiter.
  *
- * The LAST entry of x-forwarded-for, not the first, and the difference is
- * the whole point of the function.
+ * x-forwarded-for is only consulted when we are actually behind a proxy,
+ * because otherwise the entire header is written by the caller. My first
+ * attempt at this took the last entry on the theory that a proxy appends
+ * the peer it saw - true, but only if a proxy is there. With no proxy the
+ * header has exactly one entry and that entry is whatever the caller typed,
+ * so twelve requests with twelve invented values got twelve separate
+ * allowances. A live check caught it; the reasoning had looked airtight.
  *
- * A proxy APPENDS the peer it actually saw. So a client that sends nothing
- * produces "<client>", and a client that sends its own header produces
- * "<whatever they invented>, <client>". The leftmost entry is therefore the
- * one under the caller's control, and keying a rate limiter on it lets
- * anyone rotate their identity with a header and never hit the limit. The
- * rightmost was written by our own proxy and is the one we can believe.
+ * So: behind a proxy, the LAST entry, which is the one our own proxy wrote
+ * (a caller who sends their own produces "<invented>, <real>", making the
+ * leftmost theirs and the rightmost ours). Otherwise the socket peer, which
+ * no header can influence.
  *
- * This assumes exactly one proxy in front of us, which is what Render is. On
- * a chain of N trusted proxies the correct entry is Nth from the right, and
- * on none of them the header should be ignored entirely.
+ * `trustProxy` is a deployment fact, not a guess - one hop on Render, none
+ * on a laptop.
  */
-export const clientIp = (req: Request): string => {
+export const clientIpFrom = (req: Request, trustProxy: boolean): string => {
+  const peer = req.socket?.remoteAddress || 'unknown';
+  if (!trustProxy) return peer;
+
   const forwarded = req.headers['x-forwarded-for'];
   const raw = Array.isArray(forwarded) ? forwarded.join(',') : forwarded;
   const parts =
@@ -74,6 +79,14 @@ export const clientIp = (req: Request): string => {
       ?.split(',')
       .map((p) => p.trim())
       .filter(Boolean) ?? [];
-  const nearest = parts[parts.length - 1];
-  return nearest || req.socket?.remoteAddress || 'unknown';
+  return parts[parts.length - 1] || peer;
 };
+
+/**
+ * Production runs behind exactly one proxy (Render); local development runs
+ * behind none. Same rule configuration.ts uses to decide what is local.
+ */
+const LOCAL_ENVS = ['development', 'test'];
+
+export const clientIp = (req: Request): string =>
+  clientIpFrom(req, !LOCAL_ENVS.includes(process.env.NODE_ENV ?? ''));

--- a/video-sync-backend/src/auth/rate-bucket.ts
+++ b/video-sync-backend/src/auth/rate-bucket.ts
@@ -50,15 +50,30 @@ export class RateBucket {
 }
 
 /**
- * The caller's address, honouring the proxy header Render sets.
+ * The caller's address, behind exactly one trusted proxy.
  *
- * Only the FIRST entry of x-forwarded-for is used: the rest are appended by
- * whatever came before and are attacker-controlled, so trusting the last one
- * would let a caller reset their own bucket by sending a header.
+ * The LAST entry of x-forwarded-for, not the first, and the difference is
+ * the whole point of the function.
+ *
+ * A proxy APPENDS the peer it actually saw. So a client that sends nothing
+ * produces "<client>", and a client that sends its own header produces
+ * "<whatever they invented>, <client>". The leftmost entry is therefore the
+ * one under the caller's control, and keying a rate limiter on it lets
+ * anyone rotate their identity with a header and never hit the limit. The
+ * rightmost was written by our own proxy and is the one we can believe.
+ *
+ * This assumes exactly one proxy in front of us, which is what Render is. On
+ * a chain of N trusted proxies the correct entry is Nth from the right, and
+ * on none of them the header should be ignored entirely.
  */
 export const clientIp = (req: Request): string => {
   const forwarded = req.headers['x-forwarded-for'];
-  const raw = Array.isArray(forwarded) ? forwarded[0] : forwarded;
-  const first = raw?.split(',')[0]?.trim();
-  return first || req.socket?.remoteAddress || 'unknown';
+  const raw = Array.isArray(forwarded) ? forwarded.join(',') : forwarded;
+  const parts =
+    raw
+      ?.split(',')
+      .map((p) => p.trim())
+      .filter(Boolean) ?? [];
+  const nearest = parts[parts.length - 1];
+  return nearest || req.socket?.remoteAddress || 'unknown';
 };

--- a/video-sync-backend/src/auth/rate-bucket.ts
+++ b/video-sync-backend/src/auth/rate-bucket.ts
@@ -1,0 +1,64 @@
+import type { Request } from 'express';
+
+/**
+ * A token bucket keyed by caller, for REST routes that create something
+ * without asking who you are.
+ *
+ * Deliberately the same shape as the one in timeline.service.ts rather than a
+ * new dependency: it is twenty lines, the behaviour is already understood
+ * here, and a rate limiter that nobody can reason about is worse than none.
+ *
+ * In-memory and per-instance, so the effective allowance multiplies by the
+ * number of instances behind the load balancer. That is fine for what this
+ * defends - it turns "fill the users table from a shell loop" into "fill it
+ * slowly from many addresses", which is the shape of abuse a bucket can
+ * address at all. Anything stronger belongs at the edge.
+ */
+export class RateBucket {
+  private readonly buckets = new Map<string, { tokens: number; at: number }>();
+
+  constructor(
+    private readonly capacity: number,
+    private readonly refillPerSecond: number,
+  ) {}
+
+  /** True if the caller may proceed, spending one token. */
+  take(key: string, now: number): boolean {
+    const bucket = this.buckets.get(key) ?? { tokens: this.capacity, at: now };
+    const elapsedS = Math.max(0, (now - bucket.at) / 1000);
+    bucket.tokens = Math.min(
+      this.capacity,
+      bucket.tokens + elapsedS * this.refillPerSecond,
+    );
+    bucket.at = now;
+
+    if (bucket.tokens < 1) {
+      this.buckets.set(key, bucket);
+      return false;
+    }
+    bucket.tokens -= 1;
+    this.buckets.set(key, bucket);
+    return true;
+  }
+
+  /** Drop callers that have been full for a while, so the map cannot grow forever. */
+  sweep(now: number, idleMs = 3_600_000): void {
+    for (const [key, bucket] of this.buckets) {
+      if (now - bucket.at > idleMs) this.buckets.delete(key);
+    }
+  }
+}
+
+/**
+ * The caller's address, honouring the proxy header Render sets.
+ *
+ * Only the FIRST entry of x-forwarded-for is used: the rest are appended by
+ * whatever came before and are attacker-controlled, so trusting the last one
+ * would let a caller reset their own bucket by sending a header.
+ */
+export const clientIp = (req: Request): string => {
+  const forwarded = req.headers['x-forwarded-for'];
+  const raw = Array.isArray(forwarded) ? forwarded[0] : forwarded;
+  const first = raw?.split(',')[0]?.trim();
+  return first || req.socket?.remoteAddress || 'unknown';
+};

--- a/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
+++ b/video-sync-frontend/src/components/EnhancedVideoPlayer.tsx
@@ -27,6 +27,7 @@ import {
   radius,
 } from '../theme';
 import {
+  IconCaptions,
   IconCrown,
   IconExitFullscreen,
   IconFullscreen,
@@ -43,6 +44,7 @@ import {
 
 const VOLUME_KEY = 'mustard:volume';
 const MUTED_KEY = 'mustard:muted';
+const CAPTIONS_KEY = 'mustard:captions';
 
 /**
  * Is this keystroke destined for a text field? Chat sits on the same page as
@@ -558,6 +560,40 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
 
   const toggleMuted = useCallback(() => setMutedState((m) => !m), []);
 
+  // ---- captions: local, never synced ----
+  const [captionsAvailable, setCaptionsAvailable] = useState(false);
+  const [captionsOn, setCaptionsOn] = useState(
+    () => localStorage.getItem(CAPTIONS_KEY) === '1',
+  );
+
+  // Every source learns about its own tracks asynchronously and none of them
+  // announces it, so this asks a few times after the player appears and then
+  // stops. Polling forever to power a button would be silly; asking once
+  // would miss a track list that arrives a beat later.
+  useEffect(() => {
+    if (!isReady) {
+      setCaptionsAvailable(false);
+      return;
+    }
+    let attempts = 0;
+    const tick = () => {
+      const available = adapterRef.current?.hasCaptions?.() ?? false;
+      setCaptionsAvailable(available);
+      // stop as soon as the answer is yes, or after a few seconds of no
+      return available || ++attempts >= 6;
+    };
+    if (tick()) return;
+    const timer = setInterval(() => {
+      if (tick()) clearInterval(timer);
+    }, 700);
+    return () => clearInterval(timer);
+  }, [isReady, activeVideoUrl]);
+
+  useEffect(() => {
+    adapterRef.current?.setCaptionsEnabled?.(captionsOn);
+    localStorage.setItem(CAPTIONS_KEY, captionsOn ? '1' : '0');
+  }, [captionsOn, captionsAvailable, isReady]);
+
   // ---- fullscreen ----
   // The whole shell goes fullscreen, not the video element: the controls,
   // sync readout and chat toggle have to remain reachable, and on the
@@ -610,6 +646,13 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
         case 'm':
           e.preventDefault();
           toggleMuted();
+          break;
+        case 'c':
+          // silently ignored when the source has no tracks, like the button
+          if (adapterRef.current?.hasCaptions?.()) {
+            e.preventDefault();
+            setCaptionsOn((v) => !v);
+          }
           break;
         default:
           break;
@@ -922,6 +965,19 @@ export const EnhancedVideoPlayer: React.FC<VideoPlayerProps> = ({
                 }}
               />
             </VolumeGroup>
+
+            {captionsAvailable && (
+              <IconControl
+                type="button"
+                onClick={() => setCaptionsOn((v) => !v)}
+                aria-label={captionsOn ? 'Turn off subtitles' : 'Turn on subtitles'}
+                aria-pressed={captionsOn}
+                title={captionsOn ? 'Subtitles off (c)' : 'Subtitles on (c)'}
+                style={captionsOn ? { color: color.mustard } : undefined}
+              >
+                <IconCaptions size={15} />
+              </IconControl>
+            )}
 
             <IconControl
               type="button"

--- a/video-sync-frontend/src/components/Icons.tsx
+++ b/video-sync-frontend/src/components/Icons.tsx
@@ -92,6 +92,9 @@ export const IconSkipBack = (p: P) =>
 export const IconSkipForward = (p: P) =>
   base(p, <><path d="M13 6.2c0-.85.94-1.36 1.65-.9l5.75 3.8a1.07 1.07 0 0 1 0 1.8l-5.75 3.8c-.71.46-1.65-.05-1.65-.9V6.2z" /><path d="M4 6.2c0-.85.94-1.36 1.65-.9l5.75 3.8a1.07 1.07 0 0 1 0 1.8l-5.75 3.8c-.71.46-1.65-.05-1.65-.9V6.2z" /><path d="M4 18h16" /></>);
 
+export const IconCaptions = (p: P) =>
+  base(p, <><rect x="3" y="5" width="18" height="14" rx="2.4" /><path d="M9.6 10.4a2.2 2.2 0 1 0 0 3.2" /><path d="M16.4 10.4a2.2 2.2 0 1 0 0 3.2" /></>);
+
 export const IconVolume = (p: P) =>
   base(p, <><path d="M11 5.5 6.8 9H4a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h2.8L11 18.5a.6.6 0 0 0 1-.46V5.96a.6.6 0 0 0-1-.46z" /><path d="M15.4 9.2a4 4 0 0 1 0 5.6" /><path d="M18.2 6.6a8 8 0 0 1 0 10.8" /></>);
 

--- a/video-sync-frontend/src/contexts/AuthContext.tsx
+++ b/video-sync-frontend/src/contexts/AuthContext.tsx
@@ -28,6 +28,10 @@ interface AuthContextType {
   register: (username: string, email: string, password: string) => Promise<void>;
   /** Adopt a token minted elsewhere - today, by the Google callback. */
   signInWithToken: (token: string) => Promise<void>;
+  /** Sign in with no account at all; see docs/GUEST_ACCESS.md. */
+  continueAsGuest: () => Promise<void>;
+  /** True when this session has no password and no provider behind it. */
+  isGuest: boolean;
   logout: () => void;
   isAuthenticated: boolean;
 }
@@ -136,6 +140,22 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   }, []);
 
+  const continueAsGuest = useCallback(async () => {
+    try {
+      const { data } = await apiService.guest();
+      setUser(data);
+      localStorage.setItem('user', JSON.stringify(data));
+      toast.success(`You are in as ${data.username}`);
+    } catch (error: any) {
+      toast.error(
+        error?.response?.status === 429
+          ? 'Too many guests from this connection - try again shortly'
+          : "Couldn't join as a guest",
+      );
+      throw error;
+    }
+  }, []);
+
   const logout = useCallback(() => {
     setUser(null);
     localStorage.removeItem('user');
@@ -151,6 +171,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     login,
     register,
     signInWithToken,
+    continueAsGuest,
+    // the synthetic address the server mints is the only marker the client
+    // gets, and it is one no real account can have: .invalid is reserved
+    isGuest: Boolean(user?.email?.endsWith('@guest.invalid')),
     logout,
     isAuthenticated: !!user,
   };

--- a/video-sync-frontend/src/pages/HomePage.tsx
+++ b/video-sync-frontend/src/pages/HomePage.tsx
@@ -550,7 +550,7 @@ const DangerFilledButton = styled.button`
 
 export const HomePage: React.FC = () => {
   const navigate = useNavigate();
-  const { user, logout } = useAuth();
+  const { user, logout, isGuest } = useAuth();
   // A snapshot, so the row does not churn while you are looking at it - but
   // re-taken whenever the session changes. Reading it once for the lifetime
   // of the component meant a sign-out followed by a different sign-in, with
@@ -751,7 +751,16 @@ export const HomePage: React.FC = () => {
       <TopBar>
         <Wordmark size={18} />
         <TopBarRight>
-          <SignedInAs>Signed in as {user.username}</SignedInAs>
+          <SignedInAs>
+            {isGuest ? `Guest · ${user.username}` : `Signed in as ${user.username}`}
+          </SignedInAs>
+          {/* a guest's session dies with its token and cannot be signed back
+              into, so the offer to keep it has to be visible before then */}
+          {isGuest && (
+            <SecondarySmButton type="button" onClick={() => navigate('/login')}>
+              Keep this account
+            </SecondarySmButton>
+          )}
           <SecondarySmButton type="button" onClick={logout}>
             Sign out
           </SecondarySmButton>

--- a/video-sync-frontend/src/pages/HomePage.tsx
+++ b/video-sync-frontend/src/pages/HomePage.tsx
@@ -235,6 +235,16 @@ const RecentChip = styled.button`
   white-space: nowrap;
 `;
 
+const GuestNote = styled.span`
+  font-family: ${font.body};
+  font-size: 12px;
+  color: ${color.faint};
+  border: 1px solid ${color.line};
+  border-radius: ${radius.pill};
+  padding: 3px 10px;
+  white-space: nowrap;
+`;
+
 const SectionActions = styled.div`
   display: flex;
   align-items: center;
@@ -754,12 +764,17 @@ export const HomePage: React.FC = () => {
           <SignedInAs>
             {isGuest ? `Guest · ${user.username}` : `Signed in as ${user.username}`}
           </SignedInAs>
-          {/* a guest's session dies with its token and cannot be signed back
-              into, so the offer to keep it has to be visible before then */}
+          {/* Deliberately NOT a "keep this account" button. Signing up from
+              here creates a DIFFERENT account and silently abandons the
+              guest's rooms and messages, so a button offering to keep them
+              would be a promise nothing behind it can honour. Promoting a
+              guest row in place is the real fix; until it exists, saying
+              plainly that the session is temporary beats an action that
+              does the opposite of what it says. */}
           {isGuest && (
-            <SecondarySmButton type="button" onClick={() => navigate('/login')}>
-              Keep this account
-            </SecondarySmButton>
+            <GuestNote title="Guest sessions are not kept - sign up to start one that is">
+              temporary session
+            </GuestNote>
           )}
           <SecondarySmButton type="button" onClick={logout}>
             Sign out

--- a/video-sync-frontend/src/pages/JoinRoomPage.tsx
+++ b/video-sync-frontend/src/pages/JoinRoomPage.tsx
@@ -199,8 +199,9 @@ const LoadingState = styled.div`
 export const JoinRoomPage: React.FC = () => {
   const navigate = useNavigate();
   const { roomCode } = useParams<{ roomCode: string }>();
-  const { user } = useAuth();
+  const { user, continueAsGuest } = useAuth();
   const [loading, setLoading] = useState(false);
+  const [guestLoading, setGuestLoading] = useState(false);
   const [roomInfo, setRoomInfo] = useState<any>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -261,16 +262,36 @@ export const JoinRoomPage: React.FC = () => {
     return (
       <Page>
         <Container>
-          <Title>Sign in to join</Title>
+          <Title>Join the room</Title>
           <StateCard>
             <StateActions>
+              {/* The invite path's default. Someone handed a link wants to
+                  watch something, not to fill in a form - and the room is
+                  the only thing they came for. */}
+              <PrimaryButton
+                disabled={guestLoading}
+                onClick={async () => {
+                  setGuestLoading(true);
+                  try {
+                    await continueAsGuest();
+                    navigate(`/room/${roomCode}`, { replace: true });
+                  } catch {
+                    // the context has already said what went wrong
+                  } finally {
+                    setGuestLoading(false);
+                  }
+                }}
+              >
+                {guestLoading ? 'One moment…' : 'Join as a guest'}
+              </PrimaryButton>
+
               {/* carries the room through sign-in: without it, signing in
                   lands on the home page and the invite is simply lost */}
-              <PrimaryButton
+              <SecondaryButton
                 onClick={() => navigate(loginUrlFor(`/room/${roomCode}`))}
               >
-                Go to sign in
-              </PrimaryButton>
+                Sign in instead
+              </SecondaryButton>
               {/* never leave a state without an exit: this branch has no
                   top bar, so without this the page is a dead end */}
               <SecondaryButton onClick={() => navigate('/')}>

--- a/video-sync-frontend/src/services/api.ts
+++ b/video-sync-frontend/src/services/api.ts
@@ -86,6 +86,9 @@ export const apiService = {
   register: (username: string, email: string, password: string) =>
     api.post('/auth/register', { username, email, password }),
 
+  /** A way in for someone who followed an invite link and wants no account. */
+  guest: () => api.post('/auth/guest'),
+
   // Which sign-in methods this deployment can actually complete. Asked at
   // runtime rather than baked in at build: the frontend is one bundle served
   // to every environment, and a button for a provider the API has no

--- a/video-sync-frontend/src/sync/Html5Adapter.ts
+++ b/video-sync-frontend/src/sync/Html5Adapter.ts
@@ -106,4 +106,20 @@ export class Html5Adapter implements PlayerAdapter {
   setMuted(muted: boolean): void {
     this.el.muted = muted;
   }
+
+  // Captions, local only. Native TextTrack: a file with an embedded or
+  // sidecar track exposes it here, and hls.js renders HLS subtitle tracks
+  // onto the same element by default, so one implementation covers both.
+  hasCaptions(): boolean {
+    return this.el.textTracks.length > 0;
+  }
+
+  setCaptionsEnabled(enabled: boolean): void {
+    const tracks = this.el.textTracks;
+    for (let i = 0; i < tracks.length; i++) {
+      // only the first is shown: picking between languages is a separate
+      // feature, and showing several at once overlaps them on screen
+      tracks[i].mode = enabled && i === 0 ? 'showing' : 'disabled';
+    }
+  }
 }

--- a/video-sync-frontend/src/sync/Html5Adapter.ts
+++ b/video-sync-frontend/src/sync/Html5Adapter.ts
@@ -111,15 +111,35 @@ export class Html5Adapter implements PlayerAdapter {
   // sidecar track exposes it here, and hls.js renders HLS subtitle tracks
   // onto the same element by default, so one implementation covers both.
   hasCaptions(): boolean {
-    return this.el.textTracks.length > 0;
+    return this.captionTracks().length > 0;
   }
 
   setCaptionsEnabled(enabled: boolean): void {
-    const tracks = this.el.textTracks;
-    for (let i = 0; i < tracks.length; i++) {
+    const captions = this.captionTracks();
+    captions.forEach((track, i) => {
       // only the first is shown: picking between languages is a separate
       // feature, and showing several at once overlaps them on screen
-      tracks[i].mode = enabled && i === 0 ? 'showing' : 'disabled';
+      track.mode = enabled && i === 0 ? 'showing' : 'disabled';
+    });
+  }
+
+  /**
+   * Only the kinds that put words on the screen.
+   *
+   * A TextTrackList also carries 'chapters', 'metadata' and 'descriptions'.
+   * Counting those would offer a subtitles button for a file that has only
+   * chapter markers, and switching one to 'showing' displays nothing - the
+   * exact "button that does nothing" this feature is designed to avoid.
+   */
+  private captionTracks(): TextTrack[] {
+    const list = this.el.textTracks;
+    const tracks: TextTrack[] = [];
+    for (let i = 0; i < list.length; i++) {
+      const track = list[i];
+      if (track.kind === 'subtitles' || track.kind === 'captions') {
+        tracks.push(track);
+      }
     }
+    return tracks;
   }
 }

--- a/video-sync-frontend/src/sync/SyncEngine.ts
+++ b/video-sync-frontend/src/sync/SyncEngine.ts
@@ -39,6 +39,19 @@ export interface EngineAdapter extends PlayerAdapter {
    */
   setVolume?(fraction: number): void;
   setMuted?(muted: boolean): void;
+
+  /**
+   * Captions. Local like volume, and never synced: what language someone
+   * reads in is a property of the person, not of the room.
+   *
+   * `hasCaptions` is what gates the UI. Every source answers it differently
+   * and some cannot answer at all - YouTube's caption controls are
+   * undocumented, and a plain MP4 usually carries no track - so the button
+   * appears only when a player has SAID it has something to show. A control
+   * that silently does nothing is worse than an absent one.
+   */
+  hasCaptions?(): boolean;
+  setCaptionsEnabled?(enabled: boolean): void;
 }
 
 export interface EngineStatus {

--- a/video-sync-frontend/src/sync/VimeoAdapter.ts
+++ b/video-sync-frontend/src/sync/VimeoAdapter.ts
@@ -53,6 +53,7 @@ export class VimeoAdapter implements PlayerAdapter {
   private handlers: Array<[string, (data?: unknown) => void]> = [];
 
   constructor(private player: VimeoPlayerLike) {
+    this.loadCaptionLanguages();
     const on = (event: string, callback: (data?: unknown) => void) => {
       this.handlers.push([event, callback]);
       player.on(event, callback);
@@ -248,8 +249,14 @@ export class VimeoAdapter implements PlayerAdapter {
     if (first) void this.player.enableTextTrack?.(first);
   }
 
-  /** Called by the mount once the player is ready. */
-  loadCaptionLanguages(): void {
+  /**
+   * Fetched in the constructor, which is post-readiness: the mount only
+   * builds this adapter inside the player's ready callback. An earlier
+   * version left this as a public method for the mount to call and NOTHING
+   * CALLED IT, so hasCaptions() always answered no and the button never
+   * appeared on Vimeo at all.
+   */
+  private loadCaptionLanguages(): void {
     void this.player
       .getTextTracks?.()
       .then((tracks) => {

--- a/video-sync-frontend/src/sync/VimeoAdapter.ts
+++ b/video-sync-frontend/src/sync/VimeoAdapter.ts
@@ -18,6 +18,10 @@ export interface VimeoPlayerLike {
   getPlaybackRate(): Promise<number>;
   /** local audio; optional because older embeds predate it */
   setVolume?(volume: number): Promise<number>;
+  /** captions; optional for the same reason */
+  getTextTracks?(): Promise<{ language: string }[]>;
+  enableTextTrack?(language: string): Promise<unknown>;
+  disableTextTrack?(): Promise<unknown>;
 }
 
 interface TimePayload {
@@ -220,5 +224,40 @@ export class VimeoAdapter implements PlayerAdapter {
 
   setMuted(muted: boolean): void {
     void this.player.setVolume?.(muted ? 0 : 1);
+  }
+
+  /**
+   * Captions, local only.
+   *
+   * The track list is fetched once when the adapter is built and cached,
+   * because hasCaptions() is called during render and Vimeo's API is
+   * promise-based - a render cannot await.
+   */
+  private captionLanguages: string[] = [];
+
+  hasCaptions(): boolean {
+    return this.captionLanguages.length > 0;
+  }
+
+  setCaptionsEnabled(enabled: boolean): void {
+    if (!enabled) {
+      void this.player.disableTextTrack?.();
+      return;
+    }
+    const first = this.captionLanguages[0];
+    if (first) void this.player.enableTextTrack?.(first);
+  }
+
+  /** Called by the mount once the player is ready. */
+  loadCaptionLanguages(): void {
+    void this.player
+      .getTextTracks?.()
+      .then((tracks) => {
+        this.captionLanguages = (tracks ?? []).map((t) => t.language);
+      })
+      .catch(() => {
+        // an embed that refuses the call simply has no captions to offer
+        this.captionLanguages = [];
+      });
   }
 }

--- a/video-sync-frontend/src/sync/YouTubeAdapter.ts
+++ b/video-sync-frontend/src/sync/YouTubeAdapter.ts
@@ -159,4 +159,58 @@ export class YouTubeAdapter implements PlayerAdapter {
     if (muted) this.player.mute();
     else this.player.unMute();
   }
+
+  /**
+   * Captions, local only.
+   *
+   * YouTube's own CC button is hidden (the embed runs controls: 0), so this
+   * drives the undocumented captions module instead. Everything here is
+   * defensive on purpose: if the module is absent, or the call throws, or
+   * the track list is not an array, the answer is "no captions" and the UI
+   * shows no button. The alternative - a button that does nothing on the
+   * source most rooms use - is worse than no button.
+   */
+  private captionsLoaded = false;
+
+  hasCaptions(): boolean {
+    try {
+      if (!this.player.loadModule || !this.player.getOption) return false;
+      if (!this.captionsLoaded) {
+        this.player.loadModule('captions');
+        this.captionsLoaded = true;
+      }
+      const list = this.player.getOption('captions', 'tracklist');
+      return Array.isArray(list) && list.length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  setCaptionsEnabled(enabled: boolean): void {
+    try {
+      if (!this.player.setOption) return;
+      // an empty track object is how this API is turned off; there is no
+      // "disable" call
+      this.player.setOption(
+        'captions',
+        'track',
+        enabled ? { languageCode: this.firstCaptionLanguage() } : {},
+      );
+    } catch {
+      /* see hasCaptions: a refusal is not an error worth surfacing */
+    }
+  }
+
+  private firstCaptionLanguage(): string {
+    try {
+      const list = this.player.getOption?.('captions', 'tracklist');
+      if (Array.isArray(list) && list.length > 0) {
+        const first = list[0] as { languageCode?: string };
+        if (typeof first?.languageCode === 'string') return first.languageCode;
+      }
+    } catch {
+      /* fall through */
+    }
+    return 'en';
+  }
 }

--- a/video-sync-frontend/src/sync/captions.test.ts
+++ b/video-sync-frontend/src/sync/captions.test.ts
@@ -1,10 +1,14 @@
 import { Html5Adapter } from './Html5Adapter';
 
 /** Minimal stand-in for the TextTrackList the element exposes. */
-const trackList = (modes: string[]) => {
-  const tracks = modes.map((mode) => ({ mode }));
+const trackList = (
+  specs: { mode: string; kind?: string }[],
+) => {
+  const tracks = specs.map(({ mode, kind = 'subtitles' }) => ({ mode, kind }));
   return Object.assign(tracks, { length: tracks.length }) as unknown as TextTrackList;
 };
+
+const subtitles = (...modes: string[]) => trackList(modes.map((mode) => ({ mode })));
 
 const elementWith = (tracks: TextTrackList) =>
   ({ textTracks: tracks }) as unknown as HTMLMediaElement;
@@ -12,20 +16,20 @@ const elementWith = (tracks: TextTrackList) =>
 describe('HTML5 captions', () => {
   it('reports none when the source carries no track', () => {
     // a plain MP4 usually has nothing, and the UI hides its button on this
-    const adapter = new Html5Adapter(elementWith(trackList([])));
+    const adapter = new Html5Adapter(elementWith(subtitles()));
     expect(adapter.hasCaptions()).toBe(false);
   });
 
   it('reports captions when the source has a track', () => {
     // hls.js renders HLS subtitle tracks onto the same element, so this
     // covers both a file with a sidecar and a stream
-    const adapter = new Html5Adapter(elementWith(trackList(['disabled'])));
+    const adapter = new Html5Adapter(elementWith(subtitles('disabled')));
     expect(adapter.hasCaptions()).toBe(true);
   });
 
   it('shows exactly one track, not all of them at once', () => {
     // several 'showing' tracks overlap their text on screen
-    const tracks = trackList(['disabled', 'disabled', 'disabled']);
+    const tracks = subtitles('disabled', 'disabled', 'disabled');
     const adapter = new Html5Adapter(elementWith(tracks));
 
     adapter.setCaptionsEnabled(true);
@@ -35,7 +39,7 @@ describe('HTML5 captions', () => {
   });
 
   it('turns every track off again', () => {
-    const tracks = trackList(['showing', 'disabled']);
+    const tracks = subtitles('showing', 'disabled');
     const adapter = new Html5Adapter(elementWith(tracks));
 
     adapter.setCaptionsEnabled(false);
@@ -44,8 +48,37 @@ describe('HTML5 captions', () => {
     expect(modes).toEqual(['disabled', 'disabled']);
   });
 
+  it('ignores chapters, metadata and descriptions', () => {
+    // a file with only chapter markers is not a file with subtitles, and
+    // switching one of those to 'showing' displays nothing
+    const adapter = new Html5Adapter(
+      elementWith(
+        trackList([
+          { mode: 'disabled', kind: 'chapters' },
+          { mode: 'disabled', kind: 'metadata' },
+          { mode: 'disabled', kind: 'descriptions' },
+        ]),
+      ),
+    );
+    expect(adapter.hasCaptions()).toBe(false);
+  });
+
+  it('shows the first real caption track, skipping a leading chapters track', () => {
+    const tracks = trackList([
+      { mode: 'disabled', kind: 'chapters' },
+      { mode: 'disabled', kind: 'subtitles' },
+    ]);
+    const adapter = new Html5Adapter(elementWith(tracks));
+
+    adapter.setCaptionsEnabled(true);
+
+    // the chapters track is left alone; the subtitle track is shown
+    expect(tracks[0].mode).toBe('disabled');
+    expect(tracks[1].mode).toBe('showing');
+  });
+
   it('does not throw on a source with no tracks at all', () => {
-    const adapter = new Html5Adapter(elementWith(trackList([])));
+    const adapter = new Html5Adapter(elementWith(subtitles()));
     expect(() => adapter.setCaptionsEnabled(true)).not.toThrow();
   });
 });
@@ -69,10 +102,23 @@ const ytPlayer = (over: Record<string, unknown> = {}) =>
   }) as never;
 
 describe('YouTube captions (undocumented API, so: defensive)', () => {
+  // The constructor starts a 20Hz poll timer. Left undisposed these leak
+  // across the suite and are exactly what makes jest complain that a worker
+  // would not exit.
+  const built: YouTubeAdapter[] = [];
+  const adapterFor = (player: never) => {
+    const adapter = new YouTubeAdapter(player);
+    built.push(adapter);
+    return adapter;
+  };
+  afterEach(() => {
+    while (built.length) built.pop()?.dispose();
+  });
+
   it('reports none when the player has no caption controls at all', () => {
     // an embed or API version without them must produce no button, not a
     // crash and not a button that does nothing
-    const adapter = new YouTubeAdapter(ytPlayer());
+    const adapter = adapterFor(ytPlayer());
     expect(adapter.hasCaptions()).toBe(false);
   });
 
@@ -140,7 +186,7 @@ describe('YouTube captions (undocumented API, so: defensive)', () => {
         throw new Error('nope');
       },
     });
-    const adapter = new YouTubeAdapter(throwing);
+    const adapter = adapterFor(throwing);
     expect(adapter.hasCaptions()).toBe(false);
     expect(() => adapter.setCaptionsEnabled(true)).not.toThrow();
   });

--- a/video-sync-frontend/src/sync/captions.test.ts
+++ b/video-sync-frontend/src/sync/captions.test.ts
@@ -1,0 +1,147 @@
+import { Html5Adapter } from './Html5Adapter';
+
+/** Minimal stand-in for the TextTrackList the element exposes. */
+const trackList = (modes: string[]) => {
+  const tracks = modes.map((mode) => ({ mode }));
+  return Object.assign(tracks, { length: tracks.length }) as unknown as TextTrackList;
+};
+
+const elementWith = (tracks: TextTrackList) =>
+  ({ textTracks: tracks }) as unknown as HTMLMediaElement;
+
+describe('HTML5 captions', () => {
+  it('reports none when the source carries no track', () => {
+    // a plain MP4 usually has nothing, and the UI hides its button on this
+    const adapter = new Html5Adapter(elementWith(trackList([])));
+    expect(adapter.hasCaptions()).toBe(false);
+  });
+
+  it('reports captions when the source has a track', () => {
+    // hls.js renders HLS subtitle tracks onto the same element, so this
+    // covers both a file with a sidecar and a stream
+    const adapter = new Html5Adapter(elementWith(trackList(['disabled'])));
+    expect(adapter.hasCaptions()).toBe(true);
+  });
+
+  it('shows exactly one track, not all of them at once', () => {
+    // several 'showing' tracks overlap their text on screen
+    const tracks = trackList(['disabled', 'disabled', 'disabled']);
+    const adapter = new Html5Adapter(elementWith(tracks));
+
+    adapter.setCaptionsEnabled(true);
+
+    const modes = Array.from({ length: tracks.length }, (_, i) => tracks[i].mode);
+    expect(modes).toEqual(['showing', 'disabled', 'disabled']);
+  });
+
+  it('turns every track off again', () => {
+    const tracks = trackList(['showing', 'disabled']);
+    const adapter = new Html5Adapter(elementWith(tracks));
+
+    adapter.setCaptionsEnabled(false);
+
+    const modes = Array.from({ length: tracks.length }, (_, i) => tracks[i].mode);
+    expect(modes).toEqual(['disabled', 'disabled']);
+  });
+
+  it('does not throw on a source with no tracks at all', () => {
+    const adapter = new Html5Adapter(elementWith(trackList([])));
+    expect(() => adapter.setCaptionsEnabled(true)).not.toThrow();
+  });
+});
+
+import { YouTubeAdapter } from './YouTubeAdapter';
+
+const ytPlayer = (over: Record<string, unknown> = {}) =>
+  ({
+    getPlayerState: () => 1,
+    getCurrentTime: () => 0,
+    getDuration: () => 100,
+    seekTo: jest.fn(),
+    playVideo: jest.fn(),
+    pauseVideo: jest.fn(),
+    setPlaybackRate: jest.fn(),
+    getPlaybackRate: () => 1,
+    mute: jest.fn(),
+    unMute: jest.fn(),
+    setVolume: jest.fn(),
+    ...over,
+  }) as never;
+
+describe('YouTube captions (undocumented API, so: defensive)', () => {
+  it('reports none when the player has no caption controls at all', () => {
+    // an embed or API version without them must produce no button, not a
+    // crash and not a button that does nothing
+    const adapter = new YouTubeAdapter(ytPlayer());
+    expect(adapter.hasCaptions()).toBe(false);
+  });
+
+  it('reports none when the track list is empty or not a list', () => {
+    expect(
+      new YouTubeAdapter(
+        ytPlayer({ loadModule: jest.fn(), getOption: () => [] }),
+      ).hasCaptions(),
+    ).toBe(false);
+
+    expect(
+      new YouTubeAdapter(
+        ytPlayer({ loadModule: jest.fn(), getOption: () => undefined }),
+      ).hasCaptions(),
+    ).toBe(false);
+  });
+
+  it('reports captions when the player lists a track', () => {
+    const adapter = new YouTubeAdapter(
+      ytPlayer({
+        loadModule: jest.fn(),
+        getOption: () => [{ languageCode: 'en' }],
+      }),
+    );
+    expect(adapter.hasCaptions()).toBe(true);
+  });
+
+  it('loads the captions module once, not on every render', () => {
+    const loadModule = jest.fn();
+    const adapter = new YouTubeAdapter(
+      ytPlayer({ loadModule, getOption: () => [{ languageCode: 'en' }] }),
+    );
+    adapter.hasCaptions();
+    adapter.hasCaptions();
+    adapter.hasCaptions();
+    expect(loadModule).toHaveBeenCalledTimes(1);
+  });
+
+  it('turns captions on with the listed language, and off with an empty track', () => {
+    const setOption = jest.fn();
+    const adapter = new YouTubeAdapter(
+      ytPlayer({
+        loadModule: jest.fn(),
+        setOption,
+        getOption: () => [{ languageCode: 'fr' }],
+      }),
+    );
+
+    adapter.setCaptionsEnabled(true);
+    expect(setOption).toHaveBeenLastCalledWith('captions', 'track', {
+      languageCode: 'fr',
+    });
+
+    // there is no "disable" call in this API - an empty track object is it
+    adapter.setCaptionsEnabled(false);
+    expect(setOption).toHaveBeenLastCalledWith('captions', 'track', {});
+  });
+
+  it('swallows a player that throws rather than taking the room down', () => {
+    const throwing = ytPlayer({
+      loadModule: () => {
+        throw new Error('no such module');
+      },
+      setOption: () => {
+        throw new Error('nope');
+      },
+    });
+    const adapter = new YouTubeAdapter(throwing);
+    expect(adapter.hasCaptions()).toBe(false);
+    expect(() => adapter.setCaptionsEnabled(true)).not.toThrow();
+  });
+});

--- a/video-sync-frontend/src/types/youtube.d.ts
+++ b/video-sync-frontend/src/types/youtube.d.ts
@@ -18,6 +18,16 @@ declare global {
     unMute(): void;
     isMuted(): boolean;
     setVolume(volume: number): void;
+    /**
+     * Caption controls. NOT part of YouTube's documented IFrame API - they
+     * work in practice and have for years, but nothing promises they will,
+     * so every call site treats absence and failure as "no captions" rather
+     * than as an error. Optional for exactly that reason.
+     */
+    loadModule?(module: string): void;
+    unloadModule?(module: string): void;
+    setOption?(module: string, option: string, value: unknown): void;
+    getOption?(module: string, option: string): unknown;
     destroy(): void;
   }
 


### PR DESCRIPTION
The two remaining items from the UX audit.

# 1. Join without an account

Someone handed an invite link had to create an account before they could watch anything.

`docs/GUEST_ACCESS.md` laid out two shapes and the question that picks between them — **is a guest a lightweight account, or confined to the room they were invited to?** I asked and was told to get on with it, so I've taken the first and I'm stating it rather than burying it: it's the smaller change, it doesn't lie about what the token means, and it grants nothing open registration doesn't already grant.

**Why a real row.** Three things assume a `User` exists: the socket handshake refuses a token with no subject, and both `Participant.userId` and `ChatMessage.userId` are foreign keys. A `User` with `password: null` and `isGuest: true` satisfies all three with **no branch anywhere downstream**. A rowless token would have needed a nullable FK and a check at every read of both tables.

**The address.** `email` is `@unique NOT NULL`, so each guest gets `<uuid>@guest.invalid`. `.invalid` is reserved by RFC 2606 and can never be registered — unroutable by construction rather than convention, and it doubles as the marker the client reads.

**Rate limiting.** Register is at least a form somebody fills in; this is one unauthenticated request that creates a row, so unbounded it's a way to fill the users table from a shell loop. Only the **first** `x-forwarded-for` entry is trusted — the rest are attacker-appended, so trusting one would let a caller reset their own bucket with a header.

**A sweeper**, nightly, for guests older than a week that left no trace. A week not a day: a guest in yesterday's room should still have a name in its chat history tomorrow.

Verified live — the two that matter are exactly what unit tests can't reach:

```
PASS  guest token is accepted by the socket handshake       <- the handshake argument
PASS  guest appears in the room's participants (FK satisfied) <- the FK argument
PASS  guest can chat (ChatMessage FK satisfied)
PASS  guest cannot be signed into with a password
```

# 2. Subtitles

Three sources, three different caption APIs, and one rule that decides the design: **the button appears only when a player has said it has something to show.** A control that silently does nothing is worse than an absent one — the mistake I made with the voice roster and nearly repeated here.

- **HTML5** — native `TextTrack`s, so one implementation covers a file with a sidecar track *and* an HLS stream, since hls.js renders its subtitle tracks onto the same element. Only the first is shown; several `showing` tracks overlap their text on screen.
- **Vimeo** — documented API; the track list is fetched once and cached because `hasCaptions()` is called during render and can't await.
- **YouTube** — its caption controls are **not** part of the documented IFrame API. They work and have for years, but nothing promises they will, so every call is wrapped: no module, a throw, or a non-array track list all mean "no captions, no button". Its own CC control is hidden anyway (`controls: 0`).

Captions are local and never synced, like volume — what language someone reads in is a property of the person, not the room.

11 tests, weighted toward failure modes rather than the happy path.

**NOT verified:** that YouTube's undocumented API actually returns a track list in production. If it doesn't, the button simply never appears on that source — the failure mode this was designed around, not a surprise. Worth a look on a real video once deployed.

# Worth arguing with

- **`isGuest` gates nothing.** A guest isn't less trusted inside a room — they can chat and, if the host allows it, drive playback. Deliberate (they were invited), but it's a policy choice you might want different.
- **"Keep this account" just links to sign-up.** Promoting a guest row in place would be better and isn't built.
- The rate bucket is per-instance, so the allowance multiplies by instance count. Fine for what it defends; anything stronger belongs at the edge.

327 backend tests (was 310), 111 frontend (was 100).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guest access without requiring a password or email.
  * Added a guest option when joining rooms.
  * Guest accounts can be upgraded through the login flow.
  * Guest users are clearly labeled on the home page.
  * Added local video captions with a toggle and keyboard shortcut.
* **Security & Reliability**
  * Added protection against excessive guest-account creation.
  * Unused guest accounts older than seven days are automatically removed.
* **Bug Fixes**
  * Preserved guest accounts with rooms, participants, or chat messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->