### PR TITLE
review-only: the rate-limit correction CodeRabbit's quota did not reach

### DIFF
--- a/video-sync-backend/src/auth/rate-bucket.spec.ts
+++ b/video-sync-backend/src/auth/rate-bucket.spec.ts
@@ -1,4 +1,4 @@
-import { RateBucket, clientIp } from './rate-bucket';
+import { RateBucket, clientIpFrom } from './rate-bucket';
 import type { Request } from 'express';
 
 describe('RateBucket', () => {
@@ -52,55 +52,74 @@ describe('RateBucket', () => {
   });
 });
 
-describe('clientIp', () => {
+describe('clientIpFrom', () => {
   const req = (headers: Record<string, unknown>, remote?: string) =>
     ({ headers, socket: { remoteAddress: remote } }) as unknown as Request;
 
-  it('uses the LAST x-forwarded-for entry - the one our proxy wrote', () => {
-    // A proxy APPENDS the peer it saw, so a caller who sends their own
-    // header produces "<invented>, <real>". Keying on the leftmost entry
-    // lets anyone rotate identity with a header and never hit the limit.
-    expect(clientIp(req({ 'x-forwarded-for': '1.2.3.4, 10.0.0.1' }))).toBe(
-      '10.0.0.1',
-    );
+  describe('with no proxy in front (a laptop)', () => {
+    it('ignores x-forwarded-for entirely', () => {
+      // with nothing appending, the whole header is whatever the caller
+      // typed - trusting any part of it hands them a fresh bucket per
+      // request, which is exactly what a live check caught
+      expect(
+        clientIpFrom(
+          req({ 'x-forwarded-for': 'invented' }, '127.0.0.1'),
+          false,
+        ),
+      ).toBe('127.0.0.1');
+    });
+
+    it('keys every forgery to the same bucket', () => {
+      const a = clientIpFrom(
+        req({ 'x-forwarded-for': 'a' }, '127.0.0.1'),
+        false,
+      );
+      const b = clientIpFrom(
+        req({ 'x-forwarded-for': 'b' }, '127.0.0.1'),
+        false,
+      );
+      expect(a).toBe(b);
+    });
   });
 
-  it('is not fooled by a caller who forges the header', () => {
-    // this is the attack the previous version was open to
-    const forged = clientIp(req({ 'x-forwarded-for': 'evil-1, 203.0.113.9' }));
-    const forgedAgain = clientIp(
-      req({ 'x-forwarded-for': 'evil-2, 203.0.113.9' }),
-    );
-    // whatever they invent, they key to the same bucket
-    expect(forged).toBe(forgedAgain);
-    expect(forged).toBe('203.0.113.9');
-  });
+  describe('behind one proxy (Render)', () => {
+    it('uses the entry the proxy wrote, not the one the caller sent', () => {
+      expect(
+        clientIpFrom(req({ 'x-forwarded-for': 'invented, 203.0.113.9' }), true),
+      ).toBe('203.0.113.9');
+    });
 
-  it('handles a single entry, spacing, and empty segments', () => {
-    expect(clientIp(req({ 'x-forwarded-for': '203.0.113.9' }))).toBe(
-      '203.0.113.9',
-    );
-    expect(clientIp(req({ 'x-forwarded-for': ' 1.1.1.1 ,  2.2.2.2 ' }))).toBe(
-      '2.2.2.2',
-    );
-    expect(clientIp(req({ 'x-forwarded-for': '1.1.1.1, ,' }, '9.9.9.9'))).toBe(
-      '1.1.1.1',
-    );
-  });
+    it('keys every forgery to the same bucket', () => {
+      const a = clientIpFrom(
+        req({ 'x-forwarded-for': 'evil-1, 203.0.113.9' }),
+        true,
+      );
+      const b = clientIpFrom(
+        req({ 'x-forwarded-for': 'evil-2, 203.0.113.9' }),
+        true,
+      );
+      expect(a).toBe(b);
+      expect(a).toBe('203.0.113.9');
+    });
 
-  it('falls back to the socket, then to a constant', () => {
-    expect(clientIp(req({}, '5.6.7.8'))).toBe('5.6.7.8');
-    expect(clientIp(req({}))).toBe('unknown');
-  });
+    it('handles one entry, spacing, empties, and a repeated header', () => {
+      expect(
+        clientIpFrom(req({ 'x-forwarded-for': '203.0.113.9' }), true),
+      ).toBe('203.0.113.9');
+      expect(
+        clientIpFrom(req({ 'x-forwarded-for': ' 1.1.1.1 ,  2.2.2.2 ' }), true),
+      ).toBe('2.2.2.2');
+      expect(
+        clientIpFrom(req({ 'x-forwarded-for': '1.1.1.1, ,' }, '9.9.9.9'), true),
+      ).toBe('1.1.1.1');
+      expect(
+        clientIpFrom(req({ 'x-forwarded-for': ['1.1.1.1', '2.2.2.2'] }), true),
+      ).toBe('2.2.2.2');
+    });
 
-  it('handles the header arriving as an array', () => {
-    // node gives an array when the header appears more than once; the
-    // nearest proxy is still the last thing written
-    expect(clientIp(req({ 'x-forwarded-for': ['9.9.9.9, 10.0.0.1'] }))).toBe(
-      '10.0.0.1',
-    );
-    expect(clientIp(req({ 'x-forwarded-for': ['1.1.1.1', '2.2.2.2'] }))).toBe(
-      '2.2.2.2',
-    );
+    it('falls back to the socket when the header is absent', () => {
+      expect(clientIpFrom(req({}, '5.6.7.8'), true)).toBe('5.6.7.8');
+      expect(clientIpFrom(req({}), true)).toBe('unknown');
+    });
   });
 });

--- a/video-sync-backend/src/auth/rate-bucket.ts
+++ b/video-sync-backend/src/auth/rate-bucket.ts
@@ -50,23 +50,28 @@ export class RateBucket {
 }
 
 /**
- * The caller's address, behind exactly one trusted proxy.
+ * The caller's address, for keying a rate limiter.
  *
- * The LAST entry of x-forwarded-for, not the first, and the difference is
- * the whole point of the function.
+ * x-forwarded-for is only consulted when we are actually behind a proxy,
+ * because otherwise the entire header is written by the caller. My first
+ * attempt at this took the last entry on the theory that a proxy appends
+ * the peer it saw - true, but only if a proxy is there. With no proxy the
+ * header has exactly one entry and that entry is whatever the caller typed,
+ * so twelve requests with twelve invented values got twelve separate
+ * allowances. A live check caught it; the reasoning had looked airtight.
  *
- * A proxy APPENDS the peer it actually saw. So a client that sends nothing
- * produces "<client>", and a client that sends its own header produces
- * "<whatever they invented>, <client>". The leftmost entry is therefore the
- * one under the caller's control, and keying a rate limiter on it lets
- * anyone rotate their identity with a header and never hit the limit. The
- * rightmost was written by our own proxy and is the one we can believe.
+ * So: behind a proxy, the LAST entry, which is the one our own proxy wrote
+ * (a caller who sends their own produces "<invented>, <real>", making the
+ * leftmost theirs and the rightmost ours). Otherwise the socket peer, which
+ * no header can influence.
  *
- * This assumes exactly one proxy in front of us, which is what Render is. On
- * a chain of N trusted proxies the correct entry is Nth from the right, and
- * on none of them the header should be ignored entirely.
+ * `trustProxy` is a deployment fact, not a guess - one hop on Render, none
+ * on a laptop.
  */
-export const clientIp = (req: Request): string => {
+export const clientIpFrom = (req: Request, trustProxy: boolean): string => {
+  const peer = req.socket?.remoteAddress || 'unknown';
+  if (!trustProxy) return peer;
+
   const forwarded = req.headers['x-forwarded-for'];
   const raw = Array.isArray(forwarded) ? forwarded.join(',') : forwarded;
   const parts =
@@ -74,6 +79,14 @@ export const clientIp = (req: Request): string => {
       ?.split(',')
       .map((p) => p.trim())
       .filter(Boolean) ?? [];
-  const nearest = parts[parts.length - 1];
-  return nearest || req.socket?.remoteAddress || 'unknown';
+  return parts[parts.length - 1] || peer;
 };
+
+/**
+ * Production runs behind exactly one proxy (Render); local development runs
+ * behind none. Same rule configuration.ts uses to decide what is local.
+ */
+const LOCAL_ENVS = ['development', 'test'];
+
+export const clientIp = (req: Request): string =>
+  clientIpFrom(req, !LOCAL_ENVS.includes(process.env.NODE_ENV ?? ''));


### PR DESCRIPTION
**Do not merge.** This commit is already on `main` as part of #51 (`088a235`). It exists here so the one change CodeRabbit's rate limit didn't reach gets read, because it is a **security fix that replaced an earlier security fix of mine that did not work**.

## What happened

CodeRabbit correctly flagged that the guest endpoint's client-IP derivation was spoofable. I "fixed" it by reading the **last** `x-forwarded-for` entry, reasoning that a proxy appends the peer it saw — so the leftmost entry is caller-controlled and the rightmost is ours.

That reasoning is true **only if a proxy is actually there.** With none, the header has exactly one entry and that entry is whatever the caller typed. I ran the attack against a live server right after committing, and it printed twelve `201`s where it should have printed a `429` — twelve invented header values, twelve separate allowances.

## The actual fix

The header is consulted only when a proxy is genuinely in front of us — one hop on Render, none on a laptop — which is a deployment fact rather than an inference. Otherwise the socket peer, which no header can influence.

Proved the same way it was disproved:

```
12 forged headers -> 201 201 201 201 201 201 201 201 201 201 429 429
```

## Worth a close look

- **The trust decision keys off `NODE_ENV`**, reusing the same `LOCAL_ENVS` rule `configuration.ts` uses. If this ever runs behind two proxies, or behind none in production, that assumption is wrong and the limiter silently returns to being bypassable. An explicit `TRUST_PROXY` setting would be more honest than inferring it — I'd take that suggestion.
- The bucket remains per-instance, so the effective allowance multiplies by instance count.
- I did **not** switch to Express's `trust proxy` / `req.ip`, which would be the conventional answer. It has the same underlying assumption and would have hidden it inside a framework setting rather than stating it where the decision is made — but that's a defensible disagreement.

330 backend tests; all four CI checks green on `main`.