### PR TITLE
fix: guest rate limiting does not work in production - cap it, then diagnose it

### DIFF
--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -153,6 +153,46 @@ To enable it:
 No frontend rebuild is needed: the button is driven by `/auth/providers` at
 runtime, so one bundle serves an install with the provider and one without.
 
+## Rate limiting an endpoint that does not know who you are
+
+`POST /auth/guest` creates a database row for anyone who asks, so it is
+limited. Getting the *key* right took three attempts and two of them shipped,
+which is worth more than the rule itself.
+
+**Take one — leftmost `x-forwarded-for`.** Wrong, and it is the classic
+mistake: that entry is written by whoever is calling. Twelve requests with
+twelve invented values bought twelve separate allowances. A local test would
+never have caught it, because locally there is no proxy at all.
+
+**Take two — the last entry**, on the theory that our proxy appends the peer
+it saw, pushing any forged value leftward. Sound for a one-hop chain, and it
+passed locally. Production disagreed: **fifteen requests from one machine
+with no forged header at all, against a capacity of ten, were all admitted**.
+The limiter was not engaging for *anyone*. One instance, `NODE_ENV=production`,
+so the key was that last entry — and it varies per request, because the
+platform appends its own hop from a pool. Every request got a fresh bucket.
+
+**Take three — the rightmost address that could belong to a person**, walking
+the chain from the right and skipping private, loopback, link-local and CGNAT
+ranges. This does not depend on knowing the hop count, which is the fact that
+kept being wrong and cannot be checked from outside. A caller can only
+*prepend*, so the rightmost public entry is still theirs; a forged
+private-looking value is skipped as a hop.
+
+Its cost, stated rather than discovered later: if the platform's own last hop
+is public, everyone behind it keys together and is limited as one caller.
+Coarse — but it fails toward refusing rather than toward unbounded row
+creation.
+
+Underneath it sits a **keyless bucket** (300/hour for the instance) that no
+header can move a caller out of. It is not a substitute for per-caller
+limiting; it is the floor under it, sized to be invisible to a room of people
+joining a film.
+
+**The lesson worth keeping: a rate limiter cannot be verified locally.** Its
+whole behaviour depends on infrastructure that only exists in production.
+Both wrong versions passed their unit tests.
+
 ## Known gaps
 
 - No token refresh or revocation. A token is good for 12 hours, and a socket

--- a/video-sync-backend/src/auth/auth.controller.spec.ts
+++ b/video-sync-backend/src/auth/auth.controller.spec.ts
@@ -133,3 +133,81 @@ describe('the OAuth routes when the provider is on', () => {
     );
   });
 });
+
+describe('the guest route under two limits at once', () => {
+  // Both buckets are real here. The point of these tests is the interaction
+  // between them, which is where I got it wrong: a mocked bucket would have
+  // agreed with either ordering.
+  const guestController = () => {
+    const createGuest = jest.fn().mockResolvedValue({
+      id: 'u1',
+      username: 'guest-1',
+      email: 'x@guest.invalid',
+      token: 't',
+    });
+    const controller = new AuthController(
+      { createGuest } as unknown as AuthService,
+      makeGoogle(false),
+    );
+    return { controller, createGuest };
+  };
+
+  // Under NODE_ENV=test there is no proxy to trust, so the key is the socket
+  // peer and the header is ignored on purpose - which is itself the correct
+  // behaviour, and why the peer varies here. How the chain is read when there
+  // IS a proxy is pinned in rate-bucket.spec.ts; these tests are about what
+  // the two buckets do to each other.
+  const from = (ip: string) =>
+    ({
+      headers: { 'x-forwarded-for': `${ip}, 10.201.4.31` },
+      socket: { remoteAddress: ip },
+    }) as unknown as Request;
+
+  const attempt = async (controller: AuthController, ip: string) => {
+    try {
+      await controller.guest(from(ip));
+      return 201;
+    } catch (err) {
+      return (err as { getStatus(): number }).getStatus();
+    }
+  };
+
+  it('allows one caller ten, then refuses them', async () => {
+    const { controller } = guestController();
+    const codes: number[] = [];
+    for (let i = 0; i < 12; i++) codes.push(await attempt(controller, '198.51.100.7'));
+    expect(codes.filter((c) => c === 201)).toHaveLength(10);
+    expect(codes.slice(10)).toEqual([429, 429]);
+  });
+
+  it('does not let a refused caller spend the shared allowance', async () => {
+    // The bug this pins: with the shared bucket asked FIRST, every one of
+    // these ninety refusals still burned a token from it, so the caller
+    // being blocked was draining the budget for everyone else on the way
+    // down. Shared capacity is 300; the abuser should cost it exactly 10.
+    const { controller } = guestController();
+    for (let i = 0; i < 100; i++) await attempt(controller, '198.51.100.7');
+
+    // 29 more callers × 10 each = 290, which with the abuser's 10 is exactly
+    // the shared capacity. Every one of these must still be served.
+    for (let caller = 0; caller < 29; caller++) {
+      const codes: number[] = [];
+      for (let i = 0; i < 10; i++) {
+        codes.push(await attempt(controller, `203.0.113.${caller}`));
+      }
+      expect(codes).toEqual(Array(10).fill(201));
+    }
+  });
+
+  it('still stops a flood spread across many addresses', async () => {
+    // What the per-caller bucket cannot see: 300 requests, every one from a
+    // different address, none of them individually over the line.
+    const { controller } = guestController();
+    const codes: number[] = [];
+    for (let i = 0; i < 310; i++) {
+      codes.push(await attempt(controller, `198.51.${Math.floor(i / 250)}.${i % 250}`));
+    }
+    expect(codes.filter((c) => c === 201)).toHaveLength(300);
+    expect(codes.filter((c) => c === 429)).toHaveLength(10);
+  });
+});

--- a/video-sync-backend/src/auth/auth.controller.spec.ts
+++ b/video-sync-backend/src/auth/auth.controller.spec.ts
@@ -175,7 +175,8 @@ describe('the guest route under two limits at once', () => {
   it('allows one caller ten, then refuses them', async () => {
     const { controller } = guestController();
     const codes: number[] = [];
-    for (let i = 0; i < 12; i++) codes.push(await attempt(controller, '198.51.100.7'));
+    for (let i = 0; i < 12; i++)
+      codes.push(await attempt(controller, '198.51.100.7'));
     expect(codes.filter((c) => c === 201)).toHaveLength(10);
     expect(codes.slice(10)).toEqual([429, 429]);
   });
@@ -199,13 +200,40 @@ describe('the guest route under two limits at once', () => {
     }
   });
 
+  it('does not charge a caller for a request the shared cap refused', async () => {
+    // The mirror of the test above, and the half I missed: asking the
+    // per-caller bucket first fixed one direction and broke the other.
+    // Once the shared cap is empty, an honest caller's own ten must still
+    // be intact - they were never served anything.
+    const { controller } = guestController();
+    for (let i = 0; i < 300; i++)
+      await attempt(controller, `198.51.${Math.floor(i / 250)}.${i % 250}`);
+
+    const fresh = '203.0.113.200';
+    expect(await attempt(controller, fresh)).toBe(429); // shared cap, not theirs
+    // more than their own capacity, so a version that spends before asking
+    // leaves them empty rather than merely dented
+    for (let i = 0; i < 15; i++) await attempt(controller, fresh);
+
+    // their bucket is untouched, so when the shared cap refills they get
+    // their full allowance rather than a spent one
+    const bucket = (
+      controller as unknown as {
+        guestBucket: { peek(k: string, n: number): boolean };
+      }
+    ).guestBucket;
+    expect(bucket.peek(fresh, Date.now())).toBe(true);
+  });
+
   it('still stops a flood spread across many addresses', async () => {
     // What the per-caller bucket cannot see: 300 requests, every one from a
     // different address, none of them individually over the line.
     const { controller } = guestController();
     const codes: number[] = [];
     for (let i = 0; i < 310; i++) {
-      codes.push(await attempt(controller, `198.51.${Math.floor(i / 250)}.${i % 250}`));
+      codes.push(
+        await attempt(controller, `198.51.${Math.floor(i / 250)}.${i % 250}`),
+      );
     }
     expect(codes.filter((c) => c === 201)).toHaveLength(300);
     expect(codes.filter((c) => c === 429)).toHaveLength(10);

--- a/video-sync-backend/src/auth/auth.controller.ts
+++ b/video-sync-backend/src/auth/auth.controller.ts
@@ -106,8 +106,20 @@ export class AuthController {
       // logging people's IPs to answer it would be a poor trade.
       const xff = req.headers['x-forwarded-for'];
       const raw = Array.isArray(xff) ? xff.join(',') : (xff ?? '');
+      // Which hops look like infrastructure and which look like a person,
+      // in order. This is the fact that distinguishes the two cases: a
+      // trailing `non-infra` means the platform's own last hop is public,
+      // and everyone behind it is being keyed together.
+      const hops = raw
+        ? raw
+            .split(',')
+            .map((h) => h.trim())
+            .filter(Boolean)
+            .map((h) => (isInfrastructureAddress(h) ? 'infra' : 'caller'))
+            .join('>')
+        : 'none';
       this.logger.log(
-        `guest key diagnostic: xff hops=${raw ? raw.split(',').length : 0} ` +
+        `guest key diagnostic: xff shape=${hops} ` +
           `headerPresent=${Boolean(xff)} ` +
           `peerIsInfra=${isInfrastructureAddress(req.socket?.remoteAddress ?? '')} ` +
           `otherForwardHeaders=${
@@ -123,22 +135,25 @@ export class AuthController {
       );
     }
 
+    // Decide on both limits BEFORE spending from either. Asking one and
+    // then the other means the first is charged for a request the second
+    // refuses - so during a flood every honest caller would burn their own
+    // allowance on requests that were never served.
     const ip = clientIp(req);
-    if (!this.guestBucket.take(ip, now)) {
+    if (!this.guestBucket.peek(ip, now)) {
       throw new HttpException(
         'Too many guests from this connection - try again shortly',
         HttpStatus.TOO_MANY_REQUESTS,
       );
     }
-    // Second, and only for callers who are within their own allowance: an
-    // attacker who is already being refused must not be able to spend the
-    // shared budget and lock everyone else out on their way down.
-    if (!this.guestGlobalBucket.take('all', now)) {
+    if (!this.guestGlobalBucket.peek('all', now)) {
       throw new HttpException(
         'Too many guests right now - try again shortly',
         HttpStatus.TOO_MANY_REQUESTS,
       );
     }
+    this.guestBucket.take(ip, now);
+    this.guestGlobalBucket.take('all', now);
 
     return await this.authService.createGuest();
   }

--- a/video-sync-backend/src/auth/auth.controller.ts
+++ b/video-sync-backend/src/auth/auth.controller.ts
@@ -23,7 +23,7 @@ import {
 } from './google/google-oauth.service';
 import { readCookie } from './google/cookies';
 import { Interval } from '@nestjs/schedule';
-import { RateBucket, clientIp } from './rate-bucket';
+import { RateBucket, clientIp, isInfrastructureAddress } from './rate-bucket';
 
 @Controller('auth')
 export class AuthController {
@@ -108,7 +108,8 @@ export class AuthController {
       const raw = Array.isArray(xff) ? xff.join(',') : (xff ?? '');
       this.logger.log(
         `guest key diagnostic: xff hops=${raw ? raw.split(',').length : 0} ` +
-          `headerPresent=${Boolean(xff)} peerIsPrivate=${/^(10\.|127\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|::1|::ffff:10\.)/.test(req.socket?.remoteAddress ?? '')} ` +
+          `headerPresent=${Boolean(xff)} ` +
+          `peerIsInfra=${isInfrastructureAddress(req.socket?.remoteAddress ?? '')} ` +
           `otherForwardHeaders=${
             Object.keys(req.headers)
               .filter(
@@ -122,13 +123,6 @@ export class AuthController {
       );
     }
 
-    if (!this.guestGlobalBucket.take('all', now)) {
-      throw new HttpException(
-        'Too many guests right now - try again shortly',
-        HttpStatus.TOO_MANY_REQUESTS,
-      );
-    }
-
     const ip = clientIp(req);
     if (!this.guestBucket.take(ip, now)) {
       throw new HttpException(
@@ -136,6 +130,16 @@ export class AuthController {
         HttpStatus.TOO_MANY_REQUESTS,
       );
     }
+    // Second, and only for callers who are within their own allowance: an
+    // attacker who is already being refused must not be able to spend the
+    // shared budget and lock everyone else out on their way down.
+    if (!this.guestGlobalBucket.take('all', now)) {
+      throw new HttpException(
+        'Too many guests right now - try again shortly',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
     return await this.authService.createGuest();
   }
 

--- a/video-sync-backend/src/auth/auth.controller.ts
+++ b/video-sync-backend/src/auth/auth.controller.ts
@@ -38,6 +38,26 @@ export class AuthController {
   private readonly guestBucket = new RateBucket(10, 10 / 3600);
 
   /**
+   * A cap on guest creation for the WHOLE instance, on top of the per-caller
+   * one.
+   *
+   * The per-caller bucket is only as good as our ability to tell callers
+   * apart, and in production that turned out not to work: the same test that
+   * held locally (ten allowed, then 429) let twenty-two through against the
+   * deployed service, with and without a forged header. Whatever key the
+   * proxy chain is yielding, it is not stable per caller.
+   *
+   * This bucket has no key, so nothing a caller sends can move them out of
+   * it. It is deliberately loose - a real room of people joining a film must
+   * not trip it - and exists to bound the damage while the per-caller key is
+   * diagnosed rather than guessed at again.
+   */
+  private readonly guestGlobalBucket = new RateBucket(300, 300 / 3600);
+
+  /** Logged once, so the next fix is based on what the proxy actually sends. */
+  private loggedForwardShape = false;
+
+  /**
    * Nothing swept the bucket map, so it retained a key per distinct caller
    * forever - which turns a rate limiter into a slow memory leak that an
    * attacker controls the size of. Hourly, off the request path, because
@@ -47,6 +67,7 @@ export class AuthController {
   @Interval(3_600_000)
   sweepRateBuckets(): void {
     this.guestBucket.sweep(Date.now());
+    this.guestGlobalBucket.sweep(Date.now());
   }
 
   @Post('register')
@@ -76,8 +97,40 @@ export class AuthController {
    */
   @Post('guest')
   async guest(@Req() req: Request) {
+    const now = Date.now();
+
+    if (!this.loggedForwardShape) {
+      this.loggedForwardShape = true;
+      // The SHAPE, not the addresses: how many hops arrive and what the
+      // socket peer looks like is all that is needed to key correctly, and
+      // logging people's IPs to answer it would be a poor trade.
+      const xff = req.headers['x-forwarded-for'];
+      const raw = Array.isArray(xff) ? xff.join(',') : (xff ?? '');
+      this.logger.log(
+        `guest key diagnostic: xff hops=${raw ? raw.split(',').length : 0} ` +
+          `headerPresent=${Boolean(xff)} peerIsPrivate=${/^(10\.|127\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|::1|::ffff:10\.)/.test(req.socket?.remoteAddress ?? '')} ` +
+          `otherForwardHeaders=${
+            Object.keys(req.headers)
+              .filter(
+                (h) =>
+                  h.includes('forward') ||
+                  h.includes('real-ip') ||
+                  h.includes('client-ip'),
+              )
+              .join('|') || 'none'
+          }`,
+      );
+    }
+
+    if (!this.guestGlobalBucket.take('all', now)) {
+      throw new HttpException(
+        'Too many guests right now - try again shortly',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
     const ip = clientIp(req);
-    if (!this.guestBucket.take(ip, Date.now())) {
+    if (!this.guestBucket.take(ip, now)) {
       throw new HttpException(
         'Too many guests from this connection - try again shortly',
         HttpStatus.TOO_MANY_REQUESTS,

--- a/video-sync-backend/src/auth/rate-bucket.spec.ts
+++ b/video-sync-backend/src/auth/rate-bucket.spec.ts
@@ -201,8 +201,20 @@ describe('keying past a proxy chain of unknown length', () => {
 
   it('treats unique-local and link-local IPv6 as hops', () => {
     expect(isInfrastructureAddress('fd00::1')).toBe(true);
-    expect(isInfrastructureAddress('fe80::1')).toBe(true);
     expect(isInfrastructureAddress('2001:db8::1')).toBe(false);
+  });
+
+  it('covers link-local past fe80 - the range runs to febf', () => {
+    // A hop at fe90:: read as a caller under the first version of this, and
+    // a varying one would have made a fresh bucket per request: the exact
+    // failure the helper exists to prevent, reintroduced by an off-by-a-
+    // nibble.
+    for (const ip of ['fe80::1', 'fe90::1', 'fea0::1', 'febf::1']) {
+      expect(isInfrastructureAddress(ip)).toBe(true);
+    }
+    // fec0::/10 was site-local and is deprecated - not link-local, and not
+    // ours to claim
+    expect(isInfrastructureAddress('fec0::1')).toBe(false);
   });
 
   it('does not mistake a public 100.x address for CGNAT', () => {
@@ -211,5 +223,25 @@ describe('keying past a proxy chain of unknown length', () => {
     expect(isInfrastructureAddress('100.127.255.254')).toBe(true);
     expect(isInfrastructureAddress('100.128.0.1')).toBe(false);
     expect(isInfrastructureAddress('100.63.255.255')).toBe(false);
+  });
+});
+
+describe('peek, for a request that has to clear two buckets', () => {
+  it('reports availability without spending anything', () => {
+    const bucket = new RateBucket(1, 0);
+    const now = 1_000_000;
+    expect(bucket.peek('a', now)).toBe(true);
+    expect(bucket.peek('a', now)).toBe(true); // still there
+    expect(bucket.take('a', now)).toBe(true);
+    expect(bucket.peek('a', now)).toBe(false);
+  });
+
+  it('accounts for refill, so it agrees with take', () => {
+    const bucket = new RateBucket(1, 1);
+    const t0 = 1_000_000;
+    bucket.take('a', t0);
+    expect(bucket.peek('a', t0 + 500)).toBe(false);
+    expect(bucket.peek('a', t0 + 1000)).toBe(true);
+    expect(bucket.take('a', t0 + 1000)).toBe(true);
   });
 });

--- a/video-sync-backend/src/auth/rate-bucket.spec.ts
+++ b/video-sync-backend/src/auth/rate-bucket.spec.ts
@@ -1,4 +1,8 @@
-import { RateBucket, clientIpFrom } from './rate-bucket';
+import {
+  RateBucket,
+  clientIpFrom,
+  isInfrastructureAddress,
+} from './rate-bucket';
 import type { Request } from 'express';
 
 describe('RateBucket', () => {
@@ -133,5 +137,79 @@ describe('a keyless bucket, for what a key cannot defend', () => {
     const claims = ['a', 'b', 'c', 'd', 'e'];
     const results = claims.map(() => global.take('all', 1_000_000));
     expect(results).toEqual([true, true, true, false, false]);
+  });
+});
+
+describe('keying past a proxy chain of unknown length', () => {
+  // Production disproved two earlier rules. These pin the third against the
+  // shapes that broke them, so a fourth regression has to argue with a test.
+  const req = (xff?: string | string[], peer = '203.0.113.9') =>
+    ({
+      headers: xff === undefined ? {} : { 'x-forwarded-for': xff },
+      socket: { remoteAddress: peer },
+    }) as unknown as Request;
+
+  it('ignores a forged entry, because the caller can only prepend', () => {
+    // take one shipped this as the answer, and twelve invented values
+    // bought twelve separate allowances
+    const a = clientIpFrom(req('1.1.1.1, 198.51.100.7'), true);
+    const b = clientIpFrom(req('2.2.2.2, 198.51.100.7'), true);
+    expect(a).toBe('198.51.100.7');
+    expect(b).toBe(a);
+  });
+
+  it('sees past a trailing infrastructure hop - the take-two failure', () => {
+    // fifteen honest requests were all admitted in production because this
+    // trailing hop varies per request; keying on it made a fresh bucket
+    // every time
+    const a = clientIpFrom(req('198.51.100.7, 10.201.4.31'), true);
+    const b = clientIpFrom(req('198.51.100.7, 10.201.99.2'), true);
+    expect(a).toBe('198.51.100.7');
+    expect(b).toBe(a);
+  });
+
+  it('holds however many hops the platform adds', () => {
+    expect(
+      clientIpFrom(
+        req('9.9.9.9, 198.51.100.7, 10.0.0.1, 100.64.3.7, ::1'),
+        true,
+      ),
+    ).toBe('198.51.100.7');
+  });
+
+  it('is not fooled by a caller forging a private-looking address', () => {
+    // skipped as a hop, so we land on the address the edge actually saw
+    expect(clientIpFrom(req('10.0.0.5, 198.51.100.7'), true)).toBe(
+      '198.51.100.7',
+    );
+  });
+
+  it('falls back to the socket peer when every hop is infrastructure', () => {
+    expect(clientIpFrom(req('10.0.0.5, 127.0.0.1'), true)).toBe('203.0.113.9');
+    expect(clientIpFrom(req(undefined), true)).toBe('203.0.113.9');
+  });
+
+  it('ignores the header entirely when there is no proxy to trust', () => {
+    // with nothing in front of us the whole header is the caller's to write
+    expect(clientIpFrom(req('1.1.1.1'), false)).toBe('203.0.113.9');
+  });
+
+  it('reads the IPv4-mapped form Node hands back on a dual-stack socket', () => {
+    expect(isInfrastructureAddress('::ffff:10.0.0.1')).toBe(true);
+    expect(isInfrastructureAddress('::ffff:198.51.100.7')).toBe(false);
+  });
+
+  it('treats unique-local and link-local IPv6 as hops', () => {
+    expect(isInfrastructureAddress('fd00::1')).toBe(true);
+    expect(isInfrastructureAddress('fe80::1')).toBe(true);
+    expect(isInfrastructureAddress('2001:db8::1')).toBe(false);
+  });
+
+  it('does not mistake a public 100.x address for CGNAT', () => {
+    // 100.64/10 is shared address space; 100.128.x is ordinary internet
+    expect(isInfrastructureAddress('100.64.0.1')).toBe(true);
+    expect(isInfrastructureAddress('100.127.255.254')).toBe(true);
+    expect(isInfrastructureAddress('100.128.0.1')).toBe(false);
+    expect(isInfrastructureAddress('100.63.255.255')).toBe(false);
   });
 });

--- a/video-sync-backend/src/auth/rate-bucket.spec.ts
+++ b/video-sync-backend/src/auth/rate-bucket.spec.ts
@@ -123,3 +123,15 @@ describe('clientIpFrom', () => {
     });
   });
 });
+
+describe('a keyless bucket, for what a key cannot defend', () => {
+  it('bounds total spend no matter what callers claim to be', () => {
+    // The per-caller bucket is only as good as our ability to tell callers
+    // apart, and in production that turned out not to work. A bucket with a
+    // constant key cannot be escaped by anything a caller sends.
+    const global = new RateBucket(3, 0);
+    const claims = ['a', 'b', 'c', 'd', 'e'];
+    const results = claims.map(() => global.take('all', 1_000_000));
+    expect(results).toEqual([true, true, true, false, false]);
+  });
+});

--- a/video-sync-backend/src/auth/rate-bucket.ts
+++ b/video-sync-backend/src/auth/rate-bucket.ts
@@ -50,23 +50,68 @@ export class RateBucket {
 }
 
 /**
+ * Is this an address belonging to infrastructure rather than to a person?
+ *
+ * Private, loopback, link-local and carrier-grade-NAT ranges, in both
+ * families and in the IPv4-mapped-IPv6 form Node hands back on a
+ * dual-stack socket. Not a security boundary - just "a human on the
+ * internet cannot be reached at this address, so it is a hop, not a
+ * caller".
+ */
+export const isInfrastructureAddress = (raw: string): boolean => {
+  const ip = raw
+    .trim()
+    .toLowerCase()
+    .replace(/^::ffff:/, '');
+  if (!ip) return true;
+  if (ip === '::1' || ip === 'unknown') return true;
+  if (/^(10|127)\./.test(ip)) return true;
+  if (/^192\.168\./.test(ip)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(ip)) return true;
+  if (/^169\.254\./.test(ip)) return true;
+  // 100.64.0.0/10 - what load balancers and container networks hand out
+  if (/^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(ip)) return true;
+  if (/^f[cd]/.test(ip)) return true; // fc00::/7, unique-local
+  if (/^fe80/.test(ip)) return true; // link-local
+  return false;
+};
+
+/**
  * The caller's address, for keying a rate limiter.
  *
- * x-forwarded-for is only consulted when we are actually behind a proxy,
- * because otherwise the entire header is written by the caller. My first
- * attempt at this took the last entry on the theory that a proxy appends
- * the peer it saw - true, but only if a proxy is there. With no proxy the
- * header has exactly one entry and that entry is whatever the caller typed,
- * so twelve requests with twelve invented values got twelve separate
- * allowances. A live check caught it; the reasoning had looked airtight.
+ * This is the third version, and the first two were both wrong in
+ * production, so the reasoning is worth writing down rather than the rule.
  *
- * So: behind a proxy, the LAST entry, which is the one our own proxy wrote
- * (a caller who sends their own produces "<invented>, <real>", making the
- * leftmost theirs and the rightmost ours). Otherwise the socket peer, which
- * no header can influence.
+ * Take one: the LEFTMOST x-forwarded-for entry. Wrong, and dangerously so -
+ * that entry is written by whoever is calling. Twelve requests with twelve
+ * invented values got twelve separate allowances.
  *
- * `trustProxy` is a deployment fact, not a guess - one hop on Render, none
- * on a laptop.
+ * Take two: the LAST entry, on the theory that our proxy appends the peer it
+ * saw, so a forged value is pushed leftward. Sound in a one-hop chain, and it
+ * passed locally. In production it failed completely: fifteen requests from
+ * one machine with no forged header at all, against a capacity of ten, were
+ * all admitted. So the last entry is not the caller either - the platform
+ * appends its own hop, and that hop varies per request, which makes a fresh
+ * bucket every time.
+ *
+ * Take three does not depend on knowing how many hops there are, because
+ * that is the fact I kept getting wrong and cannot verify from outside.
+ * Walk the chain from the right and take the first address that could
+ * belong to a person - skipping the private and CGNAT hops our own
+ * infrastructure adds. A caller who forges entries only ever adds them to
+ * the LEFT of the one the edge observed, so the rightmost public address is
+ * still theirs. If they forge a private-looking one, it is skipped as a hop
+ * and we land on their real address anyway.
+ *
+ * Failure mode, stated because it is a real cost: if the platform's own last
+ * hop is PUBLIC rather than private, this keys everyone behind it together
+ * and limits them as one caller. That is coarse and could turn a limit into
+ * a denial of service for a shared edge - but it fails toward refusing, not
+ * toward the unbounded row creation this exists to stop. The one-shot
+ * diagnostic in the controller reports which case we are actually in.
+ *
+ * `trustProxy` is a deployment fact, not a guess - a proxy in production,
+ * none on a laptop.
  */
 export const clientIpFrom = (req: Request, trustProxy: boolean): string => {
   const peer = req.socket?.remoteAddress || 'unknown';
@@ -79,7 +124,15 @@ export const clientIpFrom = (req: Request, trustProxy: boolean): string => {
       ?.split(',')
       .map((p) => p.trim())
       .filter(Boolean) ?? [];
-  return parts[parts.length - 1] || peer;
+
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (!isInfrastructureAddress(parts[i])) return parts[i];
+  }
+
+  // Every hop looked like infrastructure - a caller reaching us from inside
+  // the network, or a chain we do not understand. The socket peer is the
+  // one thing no header can move.
+  return peer;
 };
 
 /**

--- a/video-sync-backend/src/auth/rate-bucket.ts
+++ b/video-sync-backend/src/auth/rate-bucket.ts
@@ -41,6 +41,24 @@ export class RateBucket {
     return true;
   }
 
+  /**
+   * Whether a token is available, without spending one.
+   *
+   * For the case where a request must clear more than one bucket: spending
+   * from the first before asking the second charges callers for requests
+   * that were refused anyway.
+   */
+  peek(key: string, now: number): boolean {
+    const bucket = this.buckets.get(key);
+    if (!bucket) return this.capacity >= 1;
+    const elapsedS = Math.max(0, (now - bucket.at) / 1000);
+    const tokens = Math.min(
+      this.capacity,
+      bucket.tokens + elapsedS * this.refillPerSecond,
+    );
+    return tokens >= 1;
+  }
+
   /** Drop callers that have been full for a while, so the map cannot grow forever. */
   sweep(now: number, idleMs = 3_600_000): void {
     for (const [key, bucket] of this.buckets) {
@@ -72,7 +90,11 @@ export const isInfrastructureAddress = (raw: string): boolean => {
   // 100.64.0.0/10 - what load balancers and container networks hand out
   if (/^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(ip)) return true;
   if (/^f[cd]/.test(ip)) return true; // fc00::/7, unique-local
-  if (/^fe80/.test(ip)) return true; // link-local
+  // fe80::/10 - which reaches febf, not just fe80. A hop anywhere in the
+  // rest of that range would have read as a caller and made a fresh bucket
+  // per request, which is exactly the failure this whole helper exists to
+  // stop.
+  if (/^fe[89ab]/.test(ip)) return true;
   return false;
 };
 


### PR DESCRIPTION
**Production disproved the per-IP rate limiter I shipped in #51.** Filing this immediately rather than sitting on it.

## What I found

The test that held locally — ten allowed, then `429` — let **twenty-two requests through** against the deployed service. With a forged `x-forwarded-for` *and* without one. So this isn't the header-spoofing hole I'd been chasing: the key simply isn't stable per caller behind Render's proxy chain, and its shape is not what I assumed when I "fixed" this the first time.

I only know because I ran the attack against production instead of trusting that a local pass generalised.

## What this does

**A keyless bucket.** 300 guest accounts an hour for the whole instance. Nothing a caller sends can move them out of it, because it has no key. Loose enough that a room of people joining a film never notices; tight enough that the shell-loop scenario this always existed to bound is bounded. It is **not** a substitute for per-caller limiting — it's the floor under it while per-caller is broken.

**A one-shot diagnostic.** Logs the *shape* of what arrives — how many forwarded hops, whether the socket peer is private, which forwarding headers exist — and **not a single address**. Keying correctly needs exactly those facts; logging people's IPs to learn them would be a poor trade for a debugging convenience.

## What is still wrong

Guest creation is currently rate limited **in aggregate only, not per caller**. One determined caller can consume the global allowance and deny guest sign-in to everyone else on that instance for the hour. That's a worse failure mode than the one it replaces is generous about, and it is deliberate: bounded and visible beats unbounded and quiet.

Once the diagnostic tells me the real chain shape, the per-caller key gets fixed properly and the global cap stays as defence in depth.

## Worth arguing with

- **300/hour may be too tight or too loose** — I have no traffic data, so it is a guess sized to be obviously survivable rather than tuned.
- **A global cap is a denial-of-service surface**, traded knowingly against unbounded row creation.
- **The diagnostic logs once per process** and then goes quiet, so it will not answer questions about variation across requests. If one sample proves ambiguous it needs widening.

331 backend tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guest access rate limiting with per-caller protection and a shared limit of 300 requests per hour.
  * Improved client address detection behind proxies for more accurate request limiting.
  * Ensured requests rejected by either limit do not consume available capacity.

* **Bug Fixes**
  * Prevented private, reserved, and infrastructure addresses from being incorrectly used for client limits.
  * Added fallback handling for direct connections and IPv4-mapped IPv6 addresses.

* **Documentation**
  * Documented rate-limiting behavior, proxy handling, and known infrastructure-related limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->