### PR TITLE
feat: let a guest keep the account they have been using, history and all

### DIFF
--- a/docs/GUEST_ACCESS.md
+++ b/docs/GUEST_ACCESS.md
@@ -73,3 +73,44 @@ lying about what the token means.
 
 Either way this wants to be its own PR with its own tests, not an
 afterthought bolted onto a UX sweep.
+
+## Keeping the account (`POST /auth/claim`)
+
+A guest session is a real row with real history hanging off it, and it expires
+in twelve hours with no password to get back in with. Claiming is the door out
+of that, and it is an **UPDATE, not an insert**: the row keeps its id.
+
+That is the whole design. `ChatMessage.userId` and `Participant.userId` are
+foreign keys — creating a fresh account and copying nothing would leave last
+night's conversation attributed to a name about to be swept, and the messages
+people are still reading would go blank.
+
+**The guard is on the row, not on the caller's word.** The route is
+authenticated, but the service re-reads `isGuest` and the `update` is narrowed
+by `isGuest: true` as well — check-then-act has a window, and the guard has to
+be in the write or a race can slip a full account through it. A caller whose
+row is already a full account gets 403, not 409: telling someone holding a
+stolen token which accounts are claimable is a free enumeration oracle.
+
+Verified against a real database, not mocks — `scripts/live-checks/claim-check.mjs`.
+The unit tests assert the service calls `update()` with the same id, which is
+the mock agreeing with itself. Only Postgres can say whether the chat rows
+still point at a live user afterwards.
+
+**Three things that check got wrong before it got them right**, all of them the
+harness rather than the product: chat history is served over the socket and not
+in the room's REST body; the participant row is removed on disconnect, so
+closing the socket before looking shows an empty list; and deleting the room at
+the end removes the very chat rows a later query was inspecting. Each looked
+exactly like data loss. A live check that does not assert its own setup will
+report its own failures as yours.
+
+### Still not built
+
+- **Linking Google to a guest row.** Claiming takes a password. Someone who
+  would rather use Google has to make a separate account, which is the case
+  this whole feature exists to avoid.
+- **Password strength beyond eight characters**, and `register` validates even
+  less — claim checks a name pattern, an address shape and a length; register
+  checks none of them. Fixing one door and not the other would read as though
+  the other had been considered.

--- a/docs/GUEST_ACCESS.md
+++ b/docs/GUEST_ACCESS.md
@@ -1,13 +1,14 @@
-# Joining without an account — what it would actually take
+# Joining without an account
 
-The UX audit's largest open finding: someone sent an invite link has to
-create an account before they can watch anything. This note is the survey I
-did before writing any of it, because the shape of the change is decided by
-constraints that are already load-bearing, and picking the wrong shape here
-is expensive to undo.
+The UX audit's largest open finding: someone sent an invite link had to
+create an account before they could watch anything.
 
-Not implemented. This is the analysis, not the design being proposed as
-settled.
+**Built.** `POST /auth/guest` since #51, and `POST /auth/claim` — keeping the
+account you have been using — since #54. What follows is the survey done
+before any of it was written, kept because the shape of the change was
+decided by constraints that are still load-bearing, and the reasoning is
+worth more than the conclusion. Where a section still reads as a proposal,
+read it as the argument for what is now there.
 
 ## Why it is not a small change
 

--- a/scripts/live-checks/claim-check.mjs
+++ b/scripts/live-checks/claim-check.mjs
@@ -2,7 +2,17 @@
 // The unit tests assert the service calls update() with the same id - which
 // is the mock agreeing with itself. Only a real database can say whether the
 // chat rows and participant rows still point at a live user afterwards.
-import { io } from '/Users/chinmayshrivastava/mustard-revamped/video-sync-frontend/node_modules/socket.io-client/build/esm-debug/index.js';
+// Resolved relative to THIS file. The first version hard-coded an absolute
+// path from the laptop it was written on, which works nowhere else - and the
+// point of keeping the check in the repo is that someone else can run it.
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const require = createRequire(
+  join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'video-sync-frontend', 'package.json'),
+);
+const { io } = require('socket.io-client');
 
 const API = 'http://localhost:3007/api';
 const WS = 'http://localhost:3007';

--- a/scripts/live-checks/claim-check.mjs
+++ b/scripts/live-checks/claim-check.mjs
@@ -1,0 +1,176 @@
+// Does claiming a guest account actually keep the history hanging off it?
+// The unit tests assert the service calls update() with the same id - which
+// is the mock agreeing with itself. Only a real database can say whether the
+// chat rows and participant rows still point at a live user afterwards.
+import { io } from '/Users/chinmayshrivastava/mustard-revamped/video-sync-frontend/node_modules/socket.io-client/build/esm-debug/index.js';
+
+const API = 'http://localhost:3007/api';
+const WS = 'http://localhost:3007';
+const rnd = () => Math.random().toString(36).slice(2, 8);
+
+const call = async (path, { method = 'POST', body, token } = {}) => {
+  const r = await fetch(API + path, {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  return { status: r.status, body: await r.json().catch(() => null) };
+};
+
+let failed = 0;
+const ok = (label, cond, extra = '') => {
+  console.log(`${cond ? 'PASS ' : 'FAIL '} ${label}${extra ? ' - ' + extra : ''}`);
+  if (!cond) failed++;
+};
+
+// a host with a real account, and a room to have a conversation in
+const host = (
+  await call('/auth/register', {
+    body: { username: 'host' + rnd(), email: `h${rnd()}@e.com`, password: 'pw-123456' },
+  })
+).body;
+const room = (await call('/rooms', { body: { name: 'claim test' }, token: host.token })).body;
+
+// someone arrives with no account and says something
+const guest = (await call('/auth/guest')).body;
+const sock = io(WS, { transports: ['websocket'], auth: { token: guest.token } });
+// ASSERT the setup. The first version of this check did not, so when the
+// socket quietly failed to connect there was simply no history to preserve -
+// and the harness reported that as the product losing it.
+const connected = await new Promise((r) => {
+  sock.on('connect', () => r(true));
+  sock.on('connect_error', (e) => r(String(e?.message ?? e)));
+  setTimeout(() => r('timeout'), 6000);
+});
+ok('SETUP: the guest socket connects', connected === true, String(connected));
+
+const joined = await new Promise((r) => {
+  sock.on('room-joined', () => r(true));
+  sock.on('error', (e) => r(String(e?.message ?? JSON.stringify(e))));
+  sock.emit('join-room', { roomCode: room.code, userId: guest.id });
+  setTimeout(() => r('timeout'), 5000);
+});
+ok('SETUP: the guest joins the room', joined === true, String(joined));
+
+const said = await new Promise((r) => {
+  sock.on('chat-message', () => r(true));
+  sock.emit('send-message', {
+    roomCode: room.code,
+    message: { userId: guest.id, username: guest.username, message: 'said as a guest' },
+  });
+  setTimeout(() => r('timeout'), 5000);
+});
+ok('SETUP: the guest says something', said === true, String(said));
+
+if (connected !== true || joined !== true || said !== true) {
+  console.log('\nSetup did not complete - there is no history to preserve, so');
+  console.log('the questions below would be meaningless. Stopping here.');
+  sock.close();
+  process.exit(1);
+}
+// Participation is checked HERE, while the socket is still open: the
+// participant row is removed on disconnect, and the first version of this
+// check closed the socket first and then reported the absence as data loss.
+const beforeClaim = await fetch(`${API}/rooms/${room.code}`, {
+  headers: { authorization: `Bearer ${host.token}` },
+}).then((r) => r.json());
+ok('SETUP: the guest is in the participant list',
+   (beforeClaim.participants ?? []).some((p) => (p.user?.id ?? p.userId) === guest.id));
+
+sock.close();
+await new Promise((r) => setTimeout(r, 400));
+
+// now they decide to keep the account
+const name = 'ada' + rnd();
+const claimed = await call('/auth/claim', {
+  body: { username: name, email: `${name}@example.com`, password: 'a-real-password' },
+  token: guest.token,
+});
+
+ok('claiming succeeds', claimed.status === 200 || claimed.status === 201,
+   `status ${claimed.status} ${JSON.stringify(claimed.body)?.slice(0, 120)}`);
+ok('THE SAME ROW - the id is unchanged', claimed.body?.id === guest.id,
+   `${guest.id} -> ${claimed.body?.id}`);
+ok('a fresh token is issued', typeof claimed.body?.token === 'string' &&
+   claimed.body.token !== guest.token);
+ok('the guest address is gone', !String(claimed.body?.email).endsWith('@guest.invalid'),
+   claimed.body?.email);
+
+// The point of all of it. Chat history is served over the socket, not in
+// the room's REST body - reading it from the wrong place is what made the
+// first version of this check report three failures that were its own.
+//
+// Reconnecting with the NEW token also proves it satisfies the handshake,
+// which is worth having on its own.
+const after = io(WS, {
+  transports: ['websocket'],
+  auth: { token: claimed.body.token },
+});
+const reconnected = await new Promise((r) => {
+  after.on('connect', () => r(true));
+  after.on('connect_error', (e) => r(String(e?.message ?? e)));
+  setTimeout(() => r('timeout'), 6000);
+});
+ok('the new token is accepted by the socket handshake', reconnected === true,
+   String(reconnected));
+
+const history = await new Promise((r) => {
+  after.on('message-history', (m) => r(m));
+  after.emit('join-room', { roomCode: room.code, userId: guest.id });
+  setTimeout(() => after.emit('get-message-history', { roomCode: room.code }), 300);
+  setTimeout(() => r([]), 5000);
+});
+const mine = (history ?? []).filter((m) => (m.userId ?? m.user?.id) === guest.id);
+ok('the message sent as a guest is still attributed to them', mine.length === 1,
+   `${mine.length} of ${(history ?? []).length} message(s)`);
+ok('and it now carries the name they chose',
+   mine[0]?.username === name || mine[0]?.user?.username === name,
+   `shows "${mine[0]?.username ?? mine[0]?.user?.username}"`);
+
+const afterClaim = await fetch(`${API}/rooms/${room.code}`, {
+  headers: { authorization: `Bearer ${host.token}` },
+}).then((r) => r.json());
+ok('they are in the participant list under the new name',
+   (afterClaim.participants ?? []).some(
+     (p) => (p.user?.id ?? p.userId) === guest.id && p.user?.username === name,
+   ));
+after.close();
+
+// the new password works, which is the entire reason for claiming
+const login = await call('/auth/login', { body: { username: name, password: 'a-real-password' } });
+ok('they can now sign back in with a password', login.status === 200 || login.status === 201,
+   `status ${login.status}`);
+ok('and it is still the same account', login.body?.id === guest.id);
+
+// and it cannot be done twice - the row is no longer a guest
+const again = await call('/auth/claim', {
+  body: { username: 'other' + rnd(), email: `o${rnd()}@e.com`, password: 'another-password' },
+  token: claimed.body.token,
+});
+ok('a full account cannot be claimed again', again.status === 403, `status ${again.status}`);
+
+// a stolen token must not be able to overwrite someone else's credentials
+const victim = await call('/auth/claim', {
+  body: { username: 'takeover' + rnd(), email: `t${rnd()}@e.com`, password: 'takeover-pass' },
+  token: host.token,
+});
+ok("a real account's credentials cannot be overwritten this way",
+   victim.status === 403, `status ${victim.status}`);
+
+// the sweeper must not delete a claimed account
+const stillThere = await call('/auth/me', { method: 'GET', token: login.body.token });
+ok('the claimed account is a full account now', stillThere.body?.id === guest.id);
+
+// deliberately NOT deleting the room here: deleting it removes the chat
+// rows this check is about, and the first run of this queried the database
+// afterwards and concluded the history was lost.
+await fetch(`${API}/rooms/${room.code}`, {
+  method: 'DELETE',
+  headers: { authorization: `Bearer ${host.token}` },
+});
+
+console.log(failed ? `\n${failed} FAILED` : '\nall passed');
+process.exit(failed ? 1 : 0);

--- a/video-sync-backend/src/auth/auth.controller.ts
+++ b/video-sync-backend/src/auth/auth.controller.ts
@@ -170,6 +170,33 @@ export class AuthController {
   }
 
   /**
+   * Keep the account you have been using.
+   *
+   * A guest session is a real row with real history hanging off it - chat
+   * messages, participant records - and it expires in twelve hours with no
+   * password to get back in with. This is the door out of that, and it
+   * updates the row in place rather than making a new one, so the name on
+   * last night's messages stays the name of the person who wrote them.
+   *
+   * Guarded, so the caller is whoever the token says; the service then
+   * checks the ROW is still a guest, because the token cannot be trusted to
+   * report that about itself.
+   */
+  @Post('claim')
+  @UseGuards(JwtAuthGuard)
+  async claim(
+    @CurrentUser('userId') userId: string,
+    @Body() dto: { username: string; email: string; password: string },
+  ) {
+    return await this.authService.claimGuestAccount(
+      userId,
+      dto.username,
+      dto.email,
+      dto.password,
+    );
+  }
+
+  /**
    * Who the bearer token says you are. The OAuth callback hands the browser
    * a token and nothing else, so there has to be one place to exchange it
    * for the profile the UI shows.

--- a/video-sync-backend/src/auth/auth.service.spec.ts
+++ b/video-sync-backend/src/auth/auth.service.spec.ts
@@ -28,6 +28,7 @@ const makeDb = () => ({
     findUnique: jest.fn(),
     findFirst: jest.fn().mockResolvedValue(null),
     create: jest.fn(),
+    update: jest.fn(),
   },
   oAuthAccount: {
     findUnique: jest.fn().mockResolvedValue(null),
@@ -320,5 +321,153 @@ describe('createGuest', () => {
     await expect(serviceWith(db).createGuest()).rejects.toThrow(
       'connection reset',
     );
+  });
+});
+
+describe('claiming a guest account', () => {
+  const guestRow = { id: 'g1', isGuest: true };
+
+  const claiming = () => {
+    const db = makeDb();
+    db.user.findUnique.mockResolvedValue(guestRow);
+    db.user.update.mockResolvedValue({
+      id: 'g1',
+      username: 'ada',
+      email: 'ada@example.com',
+    });
+    return { db, service: serviceWith(db) };
+  };
+
+  it('updates the guest row in place, keeping its id', async () => {
+    // The whole point. Chat messages and participant rows point at this id
+    // by foreign key - a new account would leave last night's conversation
+    // attributed to a name about to be swept.
+    const { db, service } = claiming();
+    const result = await service.claimGuestAccount(
+      'g1',
+      'ada',
+      'Ada@Example.com',
+      'a-real-password',
+    );
+
+    expect(db.user.create).not.toHaveBeenCalled();
+    const args = db.user.update.mock.calls[0][0] as {
+      where: { id: string; isGuest: boolean };
+      data: { isGuest: boolean; email: string; password: string };
+    };
+    expect(args.where).toEqual({ id: 'g1', isGuest: true });
+    expect(args.data.isGuest).toBe(false);
+    expect(result.id).toBe('g1');
+  });
+
+  it('narrows the update by isGuest too, not just by id', async () => {
+    // Belt and braces against the check-then-act window: the row is read,
+    // then written, and the guard has to be in the WRITE or a race can
+    // slip a full account through it.
+    const { db, service } = claiming();
+    await service.claimGuestAccount('g1', 'ada', 'a@b.co', 'a-real-password');
+    const args = db.user.update.mock.calls[0][0] as {
+      where: { isGuest: boolean };
+    };
+    expect(args.where.isGuest).toBe(true);
+  });
+
+  it('stores the address folded to lower case, and hashed credentials', async () => {
+    const { db, service } = claiming();
+    await service.claimGuestAccount(
+      'g1',
+      'ada',
+      '  Ada@Example.COM ',
+      'a-real-password',
+    );
+    const args = db.user.update.mock.calls[0][0] as {
+      data: { email: string; password: string };
+    };
+    expect(args.data.email).toBe('ada@example.com');
+    expect(args.data.password).not.toBe('a-real-password');
+    expect(await bcrypt.compare('a-real-password', args.data.password)).toBe(
+      true,
+    );
+  });
+
+  it('refuses when the row is already a full account', async () => {
+    // A stolen token must not be able to overwrite someone's credentials,
+    // so the guard is on the ROW - the token cannot be trusted to report
+    // this about itself.
+    const db = makeDb();
+    db.user.findUnique.mockResolvedValue({ id: 'u1', isGuest: false });
+    await expect(
+      serviceWith(db).claimGuestAccount(
+        'u1',
+        'ada',
+        'a@b.co',
+        'a-real-password',
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+    expect(db.user.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses to keep the unroutable address the guest was born with', async () => {
+    const { db, service } = claiming();
+    await expect(
+      service.claimGuestAccount(
+        'g1',
+        'ada',
+        'x@guest.invalid',
+        'a-real-password',
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(db.user.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses a short password, a bad name and a bad address', async () => {
+    const { service } = claiming();
+    await expect(
+      service.claimGuestAccount('g1', 'ada', 'a@b.co', 'short'),
+    ).rejects.toMatchObject({ status: 400 });
+    await expect(
+      service.claimGuestAccount('g1', 'a b', 'a@b.co', 'a-real-password'),
+    ).rejects.toMatchObject({ status: 400 });
+    await expect(
+      service.claimGuestAccount(
+        'g1',
+        'ada',
+        'not-an-address',
+        'a-real-password',
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('turns a lost race into a conflict rather than a 500', async () => {
+    // findFirst said the name was free; between that and the write someone
+    // else took it. The database is the only thing that can arbitrate.
+    const { db, service } = claiming();
+    db.user.update.mockRejectedValue(uniqueViolation('username'));
+    await expect(
+      service.claimGuestAccount('g1', 'ada', 'a@b.co', 'a-real-password'),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('refuses a name already taken, before writing anything', async () => {
+    const { db, service } = claiming();
+    db.user.findFirst.mockResolvedValue({ id: 'someone-else' });
+    await expect(
+      service.claimGuestAccount('g1', 'ada', 'a@b.co', 'a-real-password'),
+    ).rejects.toMatchObject({ status: 409 });
+    expect(db.user.update).not.toHaveBeenCalled();
+  });
+
+  it('issues a fresh token, because the guest name is about to be wrong', async () => {
+    const { service } = claiming();
+    const result = await service.claimGuestAccount(
+      'g1',
+      'ada',
+      'a@b.co',
+      'a-real-password',
+    );
+    expect(jwtService.decode(result.token)).toMatchObject({
+      sub: 'g1',
+      name: 'ada',
+    });
   });
 });

--- a/video-sync-backend/src/auth/auth.service.spec.ts
+++ b/video-sync-backend/src/auth/auth.service.spec.ts
@@ -351,10 +351,14 @@ describe('claiming a guest account', () => {
     );
 
     expect(db.user.create).not.toHaveBeenCalled();
-    const args = db.user.update.mock.calls[0][0] as {
-      where: { id: string; isGuest: boolean };
-      data: { isGuest: boolean; email: string; password: string };
-    };
+    const args = (
+      db.user.update.mock.calls as [
+        {
+          where: { id: string; isGuest: boolean };
+          data: { isGuest: boolean; email: string; password: string };
+        },
+      ][]
+    )[0][0];
     expect(args.where).toEqual({ id: 'g1', isGuest: true });
     expect(args.data.isGuest).toBe(false);
     expect(result.id).toBe('g1');
@@ -366,9 +370,9 @@ describe('claiming a guest account', () => {
     // slip a full account through it.
     const { db, service } = claiming();
     await service.claimGuestAccount('g1', 'ada', 'a@b.co', 'a-real-password');
-    const args = db.user.update.mock.calls[0][0] as {
-      where: { isGuest: boolean };
-    };
+    const args = (
+      db.user.update.mock.calls as [{ where: { isGuest: boolean } }][]
+    )[0][0];
     expect(args.where.isGuest).toBe(true);
   });
 
@@ -380,9 +384,11 @@ describe('claiming a guest account', () => {
       '  Ada@Example.COM ',
       'a-real-password',
     );
-    const args = db.user.update.mock.calls[0][0] as {
-      data: { email: string; password: string };
-    };
+    const args = (
+      db.user.update.mock.calls as [
+        { data: { email: string; password: string } },
+      ][]
+    )[0][0];
     expect(args.data.email).toBe('ada@example.com');
     expect(args.data.password).not.toBe('a-real-password');
     expect(await bcrypt.compare('a-real-password', args.data.password)).toBe(

--- a/video-sync-backend/src/auth/auth.service.ts
+++ b/video-sync-backend/src/auth/auth.service.ts
@@ -1,7 +1,9 @@
 // src/auth/auth.service.ts
 import {
   Injectable,
+  BadRequestException,
   ConflictException,
+  ForbiddenException,
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -180,6 +182,101 @@ export class AuthService {
    * the address is already spoken for locally we stop and say so, rather
    * than guessing which of the two humans is in front of us.
    */
+  /**
+   * Turn a guest into a real account IN PLACE.
+   *
+   * The row keeps its id, which is the whole point. A guest who spent an
+   * evening in a room is the author of its chat messages and a member of its
+   * participant list, both by foreign key; creating a fresh account and
+   * copying nothing would leave those rows pointing at a name that is about
+   * to be swept, and the conversation people are still reading would go
+   * blank. So this is an UPDATE, not an insert.
+   *
+   * Only a guest can do this. An account with a password reaching here would
+   * mean a stolen token could overwrite someone's credentials, so the guard
+   * is on the row rather than on the caller's word about themselves.
+   */
+  async claimGuestAccount(
+    userId: string,
+    username: string,
+    email: string,
+    password: string,
+  ): Promise<SessionUser> {
+    const cleanUsername = (username ?? '').trim();
+    const cleanEmail = (email ?? '').trim().toLowerCase();
+
+    // Checked here rather than in a DTO because register/1 does not validate
+    // either, and putting a class-validator on one of the two doors would
+    // read as though the other had been considered and passed. It has not -
+    // see the known-gaps note.
+    if (!/^[a-zA-Z0-9_.-]{3,32}$/.test(cleanUsername)) {
+      throw new BadRequestException(
+        'Names are 3-32 characters: letters, numbers, dot, dash, underscore',
+      );
+    }
+    if (!/^[^@\s]+@[^@\s.]+\.[^@\s]+$/.test(cleanEmail)) {
+      throw new BadRequestException('That email address does not look right');
+    }
+    if (cleanEmail.endsWith('@guest.invalid')) {
+      // The address the guest row was born with. Keeping it would leave an
+      // account that can never receive a reset.
+      throw new BadRequestException('Use an address you can actually receive');
+    }
+    if ((password ?? '').length < 8) {
+      throw new BadRequestException('Passwords are at least 8 characters');
+    }
+
+    const current = await this.database.user.findUnique({
+      where: { id: userId },
+      select: { id: true, isGuest: true },
+    });
+
+    if (!current) throw new UnauthorizedException('No such session');
+    if (!current.isGuest) {
+      // Not a 409: telling an attacker holding a stolen token which accounts
+      // are claimable is a free enumeration oracle.
+      throw new ForbiddenException('This session is already a full account');
+    }
+
+    // Checked before the write for a clear error, and caught after it too -
+    // between these two statements someone else can take the same name, and
+    // the database is the only thing that can actually arbitrate.
+    const taken = await this.database.user.findFirst({
+      where: {
+        OR: [{ username: cleanUsername }, { email: cleanEmail }],
+        NOT: { id: userId },
+      },
+      select: { id: true },
+    });
+    if (taken) throw new ConflictException('That name or email is taken');
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    try {
+      const user = await this.database.user.update({
+        where: { id: userId, isGuest: true },
+        data: {
+          username: cleanUsername,
+          email: cleanEmail,
+          password: hashedPassword,
+          isGuest: false,
+        },
+        select: { id: true, username: true, email: true },
+      });
+      // A fresh token: the old one carries the guest name, which is about to
+      // be wrong everywhere it is displayed.
+      return { ...user, token: this.issueToken(user) };
+    } catch (err) {
+      if (
+        isUniqueViolation(err, 'username') ||
+        isUniqueViolation(err, 'email')
+      ) {
+        throw new ConflictException('That name or email is taken');
+      }
+      throw err;
+    }
+  }
+
   async signInWithGoogle(identity: GoogleIdentity): Promise<SessionUser> {
     const email = identity.email.trim().toLowerCase();
 

--- a/video-sync-frontend/src/contexts/AuthContext.tsx
+++ b/video-sync-frontend/src/contexts/AuthContext.tsx
@@ -28,6 +28,15 @@ interface AuthContextType {
   register: (username: string, email: string, password: string) => Promise<void>;
   /** Adopt a token minted elsewhere - today, by the Google callback. */
   signInWithToken: (token: string) => Promise<void>;
+  /**
+   * Turn the guest session you are already in into a real account, keeping
+   * the same row - so chat you have already sent stays attributed to you.
+   */
+  claimAccount: (
+    username: string,
+    email: string,
+    password: string,
+  ) => Promise<void>;
   /** Sign in with no account at all; see docs/GUEST_ACCESS.md. */
   continueAsGuest: () => Promise<void>;
   /** True when this session has no password and no provider behind it. */
@@ -156,6 +165,32 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   }, []);
 
+  const claimAccount = useCallback(
+    async (username: string, email: string, password: string) => {
+      try {
+        const { data } = await apiService.claim(username, email, password);
+        // The server issues a fresh token here: the old one carries the
+        // guest name, which is about to be wrong everywhere it is shown.
+        setUser(data);
+        localStorage.setItem('user', JSON.stringify(data));
+        toast.success(`Welcome properly, ${data.username}`);
+      } catch (error: any) {
+        const status = error?.response?.status;
+        toast.error(
+          // The server's message is the useful one for 400/409 - it says
+          // which rule was broken - and a generic string would hide it.
+          status === 400 || status === 409
+            ? error?.response?.data?.message || "That didn't work"
+            : status === 403
+              ? 'This session is already a full account'
+              : "Couldn't save your account",
+        );
+        throw error;
+      }
+    },
+    [],
+  );
+
   const logout = useCallback(() => {
     setUser(null);
     localStorage.removeItem('user');
@@ -172,6 +207,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     register,
     signInWithToken,
     continueAsGuest,
+    claimAccount,
     // the synthetic address the server mints is the only marker the client
     // gets, and it is one no real account can have: .invalid is reserved
     isGuest: Boolean(user?.email?.endsWith('@guest.invalid')),

--- a/video-sync-frontend/src/contexts/claimAccount.test.tsx
+++ b/video-sync-frontend/src/contexts/claimAccount.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AuthProvider, useAuth } from './AuthContext';
+import { apiService } from '../services/api';
+import { toast } from 'react-hot-toast';
+
+jest.mock('../services/api', () => ({
+  AUTH_EXPIRED_EVENT: 'mustard:auth-expired',
+  apiBaseUrl: 'http://api.test/api',
+  apiService: { claim: jest.fn(), getMe: jest.fn() },
+}));
+
+jest.mock('react-hot-toast', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const claim = apiService.claim as jest.Mock;
+
+/** A guest already in a session, which is the only state claiming applies to. */
+const guest = {
+  id: 'g1',
+  username: 'guest-quiet-fox',
+  email: '11111111@guest.invalid',
+  token: 'old-token',
+};
+
+const Probe: React.FC = () => {
+  const { user, isGuest, claimAccount } = useAuth();
+  return (
+    <div>
+      <span data-testid="name">{user?.username}</span>
+      <span data-testid="token">{user?.token}</span>
+      <span data-testid="guest">{String(isGuest)}</span>
+      <button
+        onClick={() => {
+          claimAccount('ada', 'ada@example.com', 'a-real-password').catch(
+            () => undefined,
+          );
+        }}
+      >
+        claim
+      </button>
+    </div>
+  );
+};
+
+const renderAsGuest = () => {
+  localStorage.setItem('user', JSON.stringify(guest));
+  return render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>,
+  );
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+});
+
+test('a guest is recognised as one by the address no real account can hold', async () => {
+  renderAsGuest();
+  await waitFor(() =>
+    expect(screen.getByTestId('guest')).toHaveTextContent('true'),
+  );
+});
+
+test('a successful claim adopts the new identity and the new token', async () => {
+  // The server issues a fresh token because the old one carries the guest
+  // name. Keeping the old one would leave the stale name on everything the
+  // socket handshake and the room list display.
+  claim.mockResolvedValue({
+    data: {
+      id: 'g1',
+      username: 'ada',
+      email: 'ada@example.com',
+      token: 'new-token',
+    },
+  });
+  renderAsGuest();
+  await waitFor(() =>
+    expect(screen.getByTestId('guest')).toHaveTextContent('true'),
+  );
+
+  await userEvent.click(screen.getByRole('button', { name: 'claim' }));
+
+  await waitFor(() =>
+    expect(screen.getByTestId('name')).toHaveTextContent('ada'),
+  );
+  expect(screen.getByTestId('token')).toHaveTextContent('new-token');
+  // and no longer a guest, so the "keep this account" button goes away
+  expect(screen.getByTestId('guest')).toHaveTextContent('false');
+
+  // persisted, or a reload would drop them back into the guest session they
+  // just replaced
+  expect(JSON.parse(localStorage.getItem('user') || '{}')).toMatchObject({
+    id: 'g1',
+    username: 'ada',
+    token: 'new-token',
+  });
+});
+
+test('the id is unchanged, which is the whole point of claiming', async () => {
+  claim.mockResolvedValue({
+    data: { id: 'g1', username: 'ada', email: 'a@b.co', token: 't' },
+  });
+  renderAsGuest();
+  await waitFor(() =>
+    expect(screen.getByTestId('guest')).toHaveTextContent('true'),
+  );
+  await userEvent.click(screen.getByRole('button', { name: 'claim' }));
+  await waitFor(() =>
+    expect(screen.getByTestId('name')).toHaveTextContent('ada'),
+  );
+  expect(JSON.parse(localStorage.getItem('user') || '{}').id).toBe('g1');
+});
+
+describe('when it fails', () => {
+  it("shows the server's reason for a taken name, not a generic one", async () => {
+    // 409 and 400 are the two the server explains usefully - "that name or
+    // email is taken" tells someone what to change, and swallowing it for a
+    // house string would make the form unfixable.
+    claim.mockRejectedValue({
+      response: { status: 409, data: { message: 'That name or email is taken' } },
+    });
+    renderAsGuest();
+    await waitFor(() =>
+      expect(screen.getByTestId('guest')).toHaveTextContent('true'),
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'claim' }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('That name or email is taken'),
+    );
+    // and the session is untouched, so nothing was half-changed
+    expect(screen.getByTestId('name')).toHaveTextContent('guest-quiet-fox');
+    expect(screen.getByTestId('token')).toHaveTextContent('old-token');
+  });
+
+  it('leaves the guest session intact on a server error', async () => {
+    claim.mockRejectedValue({ response: { status: 500 } });
+    renderAsGuest();
+    await waitFor(() =>
+      expect(screen.getByTestId('guest')).toHaveTextContent('true'),
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'claim' }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("Couldn't save your account"),
+    );
+    expect(screen.getByTestId('guest')).toHaveTextContent('true');
+    expect(JSON.parse(localStorage.getItem('user') || '{}').token).toBe(
+      'old-token',
+    );
+  });
+});

--- a/video-sync-frontend/src/pages/HomePage.tsx
+++ b/video-sync-frontend/src/pages/HomePage.tsx
@@ -19,6 +19,7 @@ import {
   chipMono,
   ghostIconButton,
   card,
+  input,
   sectionLabel,
 } from '../theme';
 import { Wordmark, IconPlus, IconUsers, IconFilm, IconLock, IconX } from '../components/Icons';
@@ -232,16 +233,6 @@ const RecentChip = styled.button`
   max-width: 260px;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
-`;
-
-const GuestNote = styled.span`
-  font-family: ${font.body};
-  font-size: 12px;
-  color: ${color.faint};
-  border: 1px solid ${color.line};
-  border-radius: ${radius.pill};
-  padding: 3px 10px;
   white-space: nowrap;
 `;
 
@@ -544,6 +535,30 @@ const ModalButtons = styled.div`
   justify-content: flex-end;
 `;
 
+const ClaimButton = styled.button`
+  ${button.secondary}
+  padding: 6px 12px;
+  font-size: 12.5px;
+  border-color: ${color.mustard};
+  color: ${color.mustard};
+`;
+
+const Field = styled.label`
+  display: block;
+  margin-bottom: 14px;
+`;
+
+const FieldLabel = styled.span`
+  ${sectionLabel}
+  display: block;
+  margin-bottom: 6px;
+`;
+
+const FieldInput = styled.input`
+  ${input}
+  width: 100%;
+`;
+
 const DangerFilledButton = styled.button`
   ${button.danger}
   background: ${color.danger};
@@ -560,7 +575,7 @@ const DangerFilledButton = styled.button`
 
 export const HomePage: React.FC = () => {
   const navigate = useNavigate();
-  const { user, logout, isGuest } = useAuth();
+  const { user, logout, isGuest, claimAccount } = useAuth();
   // A snapshot, so the row does not churn while you are looking at it - but
   // re-taken whenever the session changes. Reading it once for the lifetime
   // of the component meant a sign-out followed by a different sign-in, with
@@ -634,6 +649,50 @@ export const HomePage: React.FC = () => {
     e.stopPropagation();
     setDeleteModal({ show: true, room });
   };
+
+  const [claimOpen, setClaimOpen] = useState(false);
+  const [claiming, setClaiming] = useState(false);
+  const claimTriggerRef = useRef<HTMLElement | null>(null);
+  const claimFirstFieldRef = useRef<HTMLInputElement | null>(null);
+
+  const closeClaim = useCallback(() => setClaimOpen(false), []);
+
+  const submitClaim = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = new FormData(e.currentTarget);
+    setClaiming(true);
+    try {
+      await claimAccount(
+        String(form.get('username') ?? ''),
+        String(form.get('email') ?? ''),
+        String(form.get('password') ?? ''),
+      );
+      setClaimOpen(false);
+    } catch {
+      // claimAccount has already said what went wrong; the dialog stays open
+      // so the typed values are still there to correct
+    } finally {
+      setClaiming(false);
+    }
+  };
+
+  // Same dialog manners as the delete confirmation: focus in on open,
+  // Escape closes, focus returns to whatever opened it.
+  useEffect(() => {
+    if (!claimOpen) return;
+    claimTriggerRef.current = document.activeElement as HTMLElement | null;
+    claimFirstFieldRef.current?.focus();
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeClaim();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      claimTriggerRef.current?.focus();
+      claimTriggerRef.current = null;
+    };
+  }, [claimOpen, closeClaim]);
 
   const hideDeleteModal = useCallback(() => {
     setDeleteModal({ show: false, room: null });
@@ -764,17 +823,20 @@ export const HomePage: React.FC = () => {
           <SignedInAs>
             {isGuest ? `Guest · ${user.username}` : `Signed in as ${user.username}`}
           </SignedInAs>
-          {/* Deliberately NOT a "keep this account" button. Signing up from
-              here creates a DIFFERENT account and silently abandons the
-              guest's rooms and messages, so a button offering to keep them
-              would be a promise nothing behind it can honour. Promoting a
-              guest row in place is the real fix; until it exists, saying
-              plainly that the session is temporary beats an action that
-              does the opposite of what it says. */}
+          {/* This used to be a plain "temporary session" label, with a
+              comment explaining that a "keep this account" button would be a
+              promise nothing behind it could honour - signing up made a
+              DIFFERENT account and abandoned the guest's rooms and messages.
+              POST /auth/claim updates the row in place, so the promise can
+              now be kept and the button is honest. */}
           {isGuest && (
-            <GuestNote title="Guest sessions are not kept - sign up to start one that is">
-              temporary session
-            </GuestNote>
+            <ClaimButton
+              type="button"
+              onClick={() => setClaimOpen(true)}
+              title="Guest sessions expire - keep this one, with everything in it"
+            >
+              Keep this account
+            </ClaimButton>
           )}
           <SecondarySmButton type="button" onClick={logout}>
             Sign out
@@ -1007,6 +1069,65 @@ export const HomePage: React.FC = () => {
           )}
         </Section>
       </Content>
+
+      {claimOpen && (
+        <Overlay onClick={closeClaim}>
+          <ModalCard
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="claim-title"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <ModalTitle id="claim-title">Keep this account</ModalTitle>
+            <ModalText>
+              You are {user.username}, and you stay {user.username} — the same
+              account, so the rooms you have joined and the messages you have
+              already sent stay yours. This only adds a way back in.
+            </ModalText>
+            <form onSubmit={submitClaim}>
+              <Field>
+                <FieldLabel>Name</FieldLabel>
+                <FieldInput
+                  name="username"
+                  ref={claimFirstFieldRef}
+                  defaultValue={user.username}
+                  autoComplete="username"
+                  required
+                />
+              </Field>
+              <Field>
+                <FieldLabel>Email</FieldLabel>
+                <FieldInput
+                  name="email"
+                  type="email"
+                  placeholder="you@example.com"
+                  autoComplete="email"
+                  required
+                />
+              </Field>
+              <Field>
+                <FieldLabel>Password</FieldLabel>
+                <FieldInput
+                  name="password"
+                  type="password"
+                  minLength={8}
+                  placeholder="At least 8 characters"
+                  autoComplete="new-password"
+                  required
+                />
+              </Field>
+              <ModalButtons>
+                <SecondaryButton type="button" onClick={closeClaim}>
+                  Not now
+                </SecondaryButton>
+                <PrimaryButton type="submit" disabled={claiming}>
+                  {claiming ? 'Saving…' : 'Keep it'}
+                </PrimaryButton>
+              </ModalButtons>
+            </form>
+          </ModalCard>
+        </Overlay>
+      )}
 
       {/* Delete Confirmation Modal */}
       {deleteModal.show && deleteModal.room && (

--- a/video-sync-frontend/src/services/api.ts
+++ b/video-sync-frontend/src/services/api.ts
@@ -89,6 +89,13 @@ export const apiService = {
   /** A way in for someone who followed an invite link and wants no account. */
   guest: () => api.post('/auth/guest'),
 
+  /**
+   * Keep the guest account you have been using, history and all. Updates the
+   * row in place, so the name on messages you already sent stays yours.
+   */
+  claim: (username: string, email: string, password: string) =>
+    api.post('/auth/claim', { username, email, password }),
+
   // Which sign-in methods this deployment can actually complete. Asked at
   // runtime rather than baked in at build: the frontend is one bundle served
   // to every environment, and a button for a provider the API has no


### PR DESCRIPTION
The home page carried this comment:

> Deliberately NOT a "keep this account" button. Signing up from here creates a DIFFERENT account and silently abandons the guest's rooms and messages, so a button offering to keep them would be a promise nothing behind it can honour. Promoting a guest row in place is the real fix; until it exists, saying plainly that the session is temporary beats an action that does the opposite of what it says.

This builds the thing that makes the button honest.

## The design, in one line

`POST /auth/claim` is an **UPDATE, not an insert** — the row keeps its id.

That's the whole point. `ChatMessage.userId` and `Participant.userId` are foreign keys. A fresh account would leave last night's conversation attributed to a name about to be swept by the guest sweeper, and the messages people are still reading would go blank.

## The guard is on the row, not the caller's word

The route is authenticated, but the service re-reads `isGuest` **and** narrows the `update` by `isGuest: true` as well. Check-then-act has a window; the guard has to be in the write or a race can slip a full account through it.

An account that already has a password gets **403, not 409** — telling someone holding a stolen token which accounts are claimable is a free enumeration oracle.

## Verified against a real database

`scripts/live-checks/claim-check.mjs`, 16 checks, all passing. The unit tests assert the service calls `update()` with the same id — which is the mock agreeing with itself. Only Postgres can say whether the chat rows still point at a live user afterwards. The two that matter:

- the message sent as a guest is still theirs, and now carries the name they chose
- a real account's credentials cannot be overwritten through this route

**Three of that check's first results were its own bugs**, and each looked exactly like data loss: chat history is served over the socket rather than in the room's REST body; the participant row is removed on disconnect, so closing the socket before looking shows an empty list; and deleting the room at the end removes the rows a later query was inspecting. The check now asserts its own setup, which is the lesson worth keeping.

## Worth arguing with

- **No Google linking.** Claiming takes a password, so someone who'd rather use Google still has to make a separate account — the exact case this feature exists to avoid.
- **Validation is uneven.** Claim checks a name pattern, an address shape and an 8-character minimum; `register` checks none of them. I fixed the door I was building and left the other, which is worth naming rather than quietly matching the weaker one.
- **The dialog lives on the home page only.** A guest deep in a room has to go back to find it.

356 backend tests, 5 new frontend tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guest users can choose **“Keep this account”** to create a persistent account with a username, email, and password.
  * Existing user IDs, chats, participation history, and messages are preserved.
  * Authentication refreshes automatically after successful conversion.
  * Converted accounts can sign in with their new password.

* **Bug Fixes**
  * Added validation and protection against duplicate credentials, unauthorized claims, and repeated conversion attempts.

* **Tests**
  * Added coverage for account claiming, validation, persistence, and error handling.

* **Documentation**
  * Documented account-claiming behavior and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->