### PR TITLE
fix: production is behind Cloudflare — key on cf-connecting-ip, and make deploys prove themselves

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,42 +60,38 @@ jobs:
           curl -fsS -X POST "$HOOK" > /dev/null
           echo "Deploy requested."
 
-      - name: Wait for the new instance to be serving
+      - name: Wait for THIS commit to be the one serving
         if: steps.hook.outputs.configured == 'true' && inputs.verify_only != true
+        env:
+          WANT: ${{ github.sha }}
         run: |
-          # A Render deploy builds before it swaps, so the OLD instance answers
-          # /health perfectly for several minutes. Polling health alone would
-          # declare success against the very build we are replacing. Wait for
-          # the swap - the moment the service stops answering, or answers after
-          # a restart - by watching for a gap and then a recovery.
-          echo "Waiting for the old instance to go away..."
-          swapped=false
-          for i in $(seq 1 60); do
-            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
-              https://api.mustard.watch/health || echo 000)
-            if [ "$code" != "200" ]; then
-              echo "  t+${i}0s: $code - the instance is being replaced"
-              swapped=true
-              break
-            fi
-            sleep 10
-          done
-
-          if [ "$swapped" = "false" ]; then
-            echo "::warning::Never saw the instance go down in 10 minutes."
-            echo "::warning::A zero-downtime swap can look like this, so continuing to the checks -"
-            echo "::warning::if they fail, the deploy may simply not have landed yet."
-          fi
-
-          echo "Waiting for it to come back..."
-          for i in $(seq 1 60); do
-            if curl -fsS --max-time 5 https://api.mustard.watch/health > /dev/null; then
-              echo "  serving again after ${i}0s"
+          # "The service answers /health" is not the same as "the deploy
+          # landed". Render builds before it swaps, so the OLD instance
+          # answers perfectly for several minutes - the first version of this
+          # step watched for the instance to disappear and come back, which a
+          # zero-downtime swap never does. It would have verified the very
+          # build it was replacing.
+          #
+          # So compare revisions. /health reports RENDER_GIT_COMMIT, which is
+          # the commit of the process actually answering.
+          echo "Waiting for $WANT to be serving..."
+          for i in $(seq 1 90); do
+            got=$(curl -fsS --max-time 5 https://api.mustard.watch/health 2>/dev/null \
+              | sed -n 's/.*"revision":"\([^"]*\)".*/\1/p' || true)
+            if [ "$got" = "$WANT" ]; then
+              echo "  serving $got after ${i}0s"
               exit 0
             fi
+            if [ "$got" = "unknown" ]; then
+              echo "::error::/health reports revision=unknown - RENDER_GIT_COMMIT is not set"
+              echo "::error::on the service, so a deploy can never be told apart from the build"
+              echo "::error::it replaces. Fix that before trusting this workflow."
+              exit 1
+            fi
+            [ $((i % 6)) -eq 0 ] && echo "  t+${i}0s: serving ${got:-<unreachable>}"
             sleep 10
           done
-          echo "::error::The service did not come back within 10 minutes."
+          echo "::error::$WANT was not serving within 15 minutes."
           exit 1
 
       # Guarded on the same condition as the deploy: with no hook configured

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,122 @@
+# Deploy the backend, then check the deploy did what it claimed.
+#
+# Render is connected by public-repo URL, which has no auto-deploy webhook, so
+# until now every backend release waited on someone opening the dashboard and
+# clicking Manual Deploy. That is a poor place for a person to be: the rate
+# limit shipped broken twice and the gap between "merged" and "actually
+# running" is where both of those hid.
+#
+# Needs one secret, set once:
+#   Render -> the service -> Settings -> Deploy Hook -> copy the URL
+#   gh secret set RENDER_DEPLOY_HOOK
+# The URL is a credential. It goes straight from Render into the secret store.
+
+name: deploy backend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'video-sync-backend/**'
+      - 'render.yaml'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
+    inputs:
+      verify_only:
+        description: 'Skip the deploy and only run the production checks'
+        type: boolean
+        default: false
+
+concurrency:
+  group: deploy-backend
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check the hook is configured
+        id: hook
+        env:
+          HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$HOOK" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::RENDER_DEPLOY_HOOK is not set - skipping the deploy."
+            echo "::warning::Render -> Settings -> Deploy Hook, then: gh secret set RENDER_DEPLOY_HOOK"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger the deploy
+        if: steps.hook.outputs.configured == 'true' && inputs.verify_only != true
+        env:
+          HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
+        run: |
+          # -f so a non-2xx is a failure rather than a quiet page of HTML that
+          # the next step then waits patiently on
+          curl -fsS -X POST "$HOOK" > /dev/null
+          echo "Deploy requested."
+
+      - name: Wait for the new instance to be serving
+        if: steps.hook.outputs.configured == 'true' && inputs.verify_only != true
+        run: |
+          # A Render deploy builds before it swaps, so the OLD instance answers
+          # /health perfectly for several minutes. Polling health alone would
+          # declare success against the very build we are replacing. Wait for
+          # the swap - the moment the service stops answering, or answers after
+          # a restart - by watching for a gap and then a recovery.
+          echo "Waiting for the old instance to go away..."
+          swapped=false
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+              https://api.mustard.watch/health || echo 000)
+            if [ "$code" != "200" ]; then
+              echo "  t+${i}0s: $code - the instance is being replaced"
+              swapped=true
+              break
+            fi
+            sleep 10
+          done
+
+          if [ "$swapped" = "false" ]; then
+            echo "::warning::Never saw the instance go down in 10 minutes."
+            echo "::warning::A zero-downtime swap can look like this, so continuing to the checks -"
+            echo "::warning::if they fail, the deploy may simply not have landed yet."
+          fi
+
+          echo "Waiting for it to come back..."
+          for i in $(seq 1 60); do
+            if curl -fsS --max-time 5 https://api.mustard.watch/health > /dev/null; then
+              echo "  serving again after ${i}0s"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::The service did not come back within 10 minutes."
+          exit 1
+
+      # Guarded on the same condition as the deploy: with no hook configured
+      # nothing was deployed, and failing every unrelated push with a red X
+      # about a known gap would train everyone to ignore this workflow.
+      - name: The limit has to hold in production, not in a unit test
+        if: steps.hook.outputs.configured == 'true' || inputs.verify_only == true
+        run: node scripts/verify-guest-limit.mjs https://api.mustard.watch
+
+      - name: Health and the shape of the API
+        if: steps.hook.outputs.configured == 'true' || inputs.verify_only == true
+        run: |
+          set -e
+          curl -fsS https://api.mustard.watch/health | tee /dev/stderr | grep -q '"status":"ok"'
+          # Google sign-in is either configured or it is not - a deploy that
+          # silently drops the credentials leaves a button that dead-ends
+          curl -fsS https://api.mustard.watch/api/auth/providers | tee /dev/stderr
+          # creating a room without a token must still be refused - the authz
+          # gap this repo closed once already
+          code=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+            -H 'content-type: application/json' -d '{"name":"probe"}' \
+            https://api.mustard.watch/api/rooms)
+          echo "unauthenticated room creation -> $code"
+          test "$code" = "401" || { echo "::error::expected 401, got $code"; exit 1; }

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -24,8 +24,11 @@ dial, not a rewrite; multi-instance correctness is re-proven nightly in CI.
 - Frontend build-time envs point at `https://api.mustard.watch` — the
   custom domain is the contract, so the onrender hostname can change
   without a frontend rebuild.
-- Deploys: Render redeploys via the blueprint's Manual sync (public-repo
-  URL connection, no auto-deploy webhook); Vercel via CLI
+- Deploys: `.github/workflows/deploy.yml` on any push to `main` touching the
+  backend - **once `RENDER_DEPLOY_HOOK` is set** (Render -> Settings -> Deploy
+  Hook, then `gh secret set RENDER_DEPLOY_HOOK`). Without that secret it
+  skips, warns, and the backend still needs Manual Deploy in the dashboard
+  (public-repo URL connection, no auto-deploy webhook). Vercel via CLI
   (`vercel deploy --prod` from `video-sync-frontend`, with
   `VERCEL_ORG_ID`/`VERCEL_PROJECT_ID` pinned - CLI 58's repo-level link
   detection otherwise creates a project named after the monorepo root).

--- a/scripts/verify-guest-limit.mjs
+++ b/scripts/verify-guest-limit.mjs
@@ -35,29 +35,37 @@ const run = async (label, headersFor) => {
 // code looked correct.
 const honest = await run('Honest caller, no forged header:', () => ({}));
 
-// A caller inventing a different address every time. They can only ever
-// PREPEND to the chain, so the address the edge saw is still theirs.
+// The SAME caller, now inventing a different address every request. They can
+// only ever PREPEND to the chain, so the address the edge saw is still
+// theirs - and they have just spent their allowance above. A correct
+// deployment therefore refuses every one of these.
+//
+// That coupling is the point, and getting the expectation wrong here would
+// make the check far weaker than it looks: "some were refused" would pass
+// even if forging worked, because the honest run had already emptied the
+// bucket.
 const forged = await run('Same caller, a different forged address each time:', (i) => ({
   'x-forwarded-for': `203.0.113.${i + 1}`,
 }));
 
 let failed = false;
-for (const [label, result] of [
-  ['honest caller', honest],
-  ['forged header', forged],
-]) {
-  if (result.allowed > CAPACITY) {
-    console.log(`\nFAIL  ${label}: ${result.allowed} allowed, capacity is ${CAPACITY}`);
-    failed = true;
-  }
-  if (result.refused === 0) {
-    console.log(`\nFAIL  ${label}: nothing was refused`);
-    failed = true;
-  }
-}
+const expect = (label, actual, wanted) => {
+  const good = actual === wanted;
+  console.log(`${good ? 'PASS ' : 'FAIL '} ${label}: ${actual} (expected ${wanted})`);
+  if (!good) failed = true;
+};
+
+console.log('');
+// Exactly ten, not "at most ten": fewer would mean the limit is too tight
+// and honest people are being turned away.
+expect('honest caller, allowed', honest.allowed, CAPACITY);
+expect('honest caller, refused', honest.refused, REQUESTS - CAPACITY);
+// Zero, because forging must not buy a fresh allowance.
+expect('forged header, allowed', forged.allowed, 0);
+expect('forged header, refused', forged.refused, REQUESTS);
 
 // Note the cost, rather than leaving it to be discovered: a passing run
-// creates about twenty guest rows. They have no rooms, no messages and no
+// creates about ten guest rows. They have no rooms, no messages and no
 // password, so the nightly sweeper removes them after seven days.
 console.log(
   failed

--- a/scripts/verify-guest-limit.mjs
+++ b/scripts/verify-guest-limit.mjs
@@ -1,0 +1,67 @@
+// Does the guest rate limit actually engage against the deployed service?
+//
+// This exists because it did not, twice, while passing every unit test. The
+// key depends on a proxy chain that only exists in production, so production
+// is the only place the question can be asked. Both wrong versions read as
+// airtight.
+//
+// Usage: node scripts/verify-guest-limit.mjs https://api.mustard.watch
+
+const base = (process.argv[2] ?? 'https://api.mustard.watch').replace(/\/$/, '');
+const url = `${base}/api/auth/guest`;
+
+// Capacity is 10 per caller. Anything at or below that proves nothing - an
+// earlier run of this sent six, saw six 201s, and concluded nothing while
+// looking like a pass.
+const CAPACITY = 10;
+const REQUESTS = 15;
+
+const hit = async (headers = {}) => {
+  const res = await fetch(url, { method: 'POST', headers });
+  return res.status;
+};
+
+const run = async (label, headersFor) => {
+  const codes = [];
+  for (let i = 0; i < REQUESTS; i++) codes.push(await hit(headersFor(i)));
+  const allowed = codes.filter((c) => c === 201).length;
+  const refused = codes.filter((c) => c === 429).length;
+  console.log(`${label}\n  ${codes.join(' ')}\n  ${allowed} allowed, ${refused} refused`);
+  return { allowed, refused };
+};
+
+// An honest caller. If this does not start refusing, the limiter is not
+// engaging at all - which is exactly what production was doing while the
+// code looked correct.
+const honest = await run('Honest caller, no forged header:', () => ({}));
+
+// A caller inventing a different address every time. They can only ever
+// PREPEND to the chain, so the address the edge saw is still theirs.
+const forged = await run('Same caller, a different forged address each time:', (i) => ({
+  'x-forwarded-for': `203.0.113.${i + 1}`,
+}));
+
+let failed = false;
+for (const [label, result] of [
+  ['honest caller', honest],
+  ['forged header', forged],
+]) {
+  if (result.allowed > CAPACITY) {
+    console.log(`\nFAIL  ${label}: ${result.allowed} allowed, capacity is ${CAPACITY}`);
+    failed = true;
+  }
+  if (result.refused === 0) {
+    console.log(`\nFAIL  ${label}: nothing was refused`);
+    failed = true;
+  }
+}
+
+// Note the cost, rather than leaving it to be discovered: a passing run
+// creates about twenty guest rows. They have no rooms, no messages and no
+// password, so the nightly sweeper removes them after seven days.
+console.log(
+  failed
+    ? '\nThe limit is NOT holding in production.'
+    : `\nThe limit holds. (~${honest.allowed + forged.allowed} guest rows created; the sweeper takes them in 7 days.)`,
+);
+process.exit(failed ? 1 : 0);

--- a/video-sync-backend/src/app.controller.ts
+++ b/video-sync-backend/src/app.controller.ts
@@ -15,10 +15,26 @@ export class AppController {
     return this.appService.getHello();
   }
 
+  /**
+   * Which build is answering.
+   *
+   * Render sets RENDER_GIT_COMMIT on every deploy. Read once at startup, so
+   * this is the commit of the process that is serving - not of whatever the
+   * repository happens to be at.
+   *
+   * This exists because "the service answers /health" does NOT mean a deploy
+   * landed: Render builds before it swaps, so the OLD instance answers
+   * perfectly for several minutes. A deploy check without a revision to
+   * compare against verifies the very build it is replacing.
+   */
+  private readonly revision =
+    process.env.RENDER_GIT_COMMIT ?? process.env.GIT_COMMIT ?? 'unknown';
+
   @Get('health')
   async getHealth(): Promise<{
     status: 'ok' | 'degraded';
     redis: 'ok' | 'down' | 'disabled';
+    revision: string;
     timestamp: string;
   }> {
     // degraded (not dead) when Redis is unreachable: REST still works and
@@ -35,6 +51,7 @@ export class AppController {
     return {
       status: redis === 'down' ? 'degraded' : 'ok',
       redis,
+      revision: this.revision,
       timestamp: new Date().toISOString(),
     };
   }

--- a/video-sync-backend/src/auth/auth.controller.ts
+++ b/video-sync-backend/src/auth/auth.controller.ts
@@ -124,12 +124,11 @@ export class AuthController {
           `peerIsInfra=${isInfrastructureAddress(req.socket?.remoteAddress ?? '')} ` +
           `otherForwardHeaders=${
             Object.keys(req.headers)
-              .filter(
-                (h) =>
-                  h.includes('forward') ||
-                  h.includes('real-ip') ||
-                  h.includes('client-ip'),
-              )
+              // 'connecting-ip' matters most and the first version of this
+              // filter missed it: cf-connecting-ip contains neither
+              // 'client-ip' nor 'forward', so the header carrying the actual
+              // answer was invisible to the diagnostic looking for it.
+              .filter((h) => /forward|real-ip|client-ip|connecting-ip|cf-/.test(h))
               .join('|') || 'none'
           }`,
       );

--- a/video-sync-backend/src/auth/rate-bucket.spec.ts
+++ b/video-sync-backend/src/auth/rate-bucket.spec.ts
@@ -143,9 +143,16 @@ describe('a keyless bucket, for what a key cannot defend', () => {
 describe('keying past a proxy chain of unknown length', () => {
   // Production disproved two earlier rules. These pin the third against the
   // shapes that broke them, so a fourth regression has to argue with a test.
-  const req = (xff?: string | string[], peer = '203.0.113.9') =>
+  const req = (
+    xff?: string | string[],
+    peer = '203.0.113.9',
+    cf?: string | string[],
+  ) =>
     ({
-      headers: xff === undefined ? {} : { 'x-forwarded-for': xff },
+      headers: {
+        ...(xff === undefined ? {} : { 'x-forwarded-for': xff }),
+        ...(cf === undefined ? {} : { 'cf-connecting-ip': cf }),
+      },
       socket: { remoteAddress: peer },
     }) as unknown as Request;
 
@@ -243,5 +250,74 @@ describe('peek, for a request that has to clear two buckets', () => {
     expect(bucket.peek('a', t0 + 500)).toBe(false);
     expect(bucket.peek('a', t0 + 1000)).toBe(true);
     expect(bucket.take('a', t0 + 1000)).toBe(true);
+  });
+});
+
+describe('behind Cloudflare, which is what production actually is', () => {
+  const req = (headers: Record<string, string | string[]>, peer = '10.0.0.1') =>
+    ({ headers, socket: { remoteAddress: peer } }) as unknown as Request;
+
+  it('prefers the address Cloudflare accepted the connection from', () => {
+    // Take three keyed on the rightmost public entry, which behind
+    // Cloudflare is the EDGE server - and which edge handles a request
+    // varies, so fifteen requests from one machine bought fifteen fresh
+    // allowances in production.
+    const a = clientIpFrom(
+      req({
+        'cf-connecting-ip': '45.25.208.233',
+        'x-forwarded-for': '45.25.208.233, 172.71.150.4',
+      }),
+      true,
+    );
+    const b = clientIpFrom(
+      req({
+        'cf-connecting-ip': '45.25.208.233',
+        'x-forwarded-for': '45.25.208.233, 104.23.209.88', // a different edge
+      }),
+      true,
+    );
+    expect(a).toBe('45.25.208.233');
+    expect(b).toBe(a);
+  });
+
+  it('is not moved by a forged chain, because Cloudflare overwrites its own header', () => {
+    expect(
+      clientIpFrom(
+        req({
+          'cf-connecting-ip': '45.25.208.233',
+          'x-forwarded-for': '1.1.1.1, 2.2.2.2, 45.25.208.233, 172.71.150.4',
+        }),
+        true,
+      ),
+    ).toBe('45.25.208.233');
+  });
+
+  it('falls back to the chain where there is no Cloudflare in front', () => {
+    // The header is absent entirely on a deployment without it, and the
+    // walk still has to work - this is not a Cloudflare-only service.
+    expect(
+      clientIpFrom(
+        req({ 'x-forwarded-for': '198.51.100.7, 10.201.4.31' }),
+        true,
+      ),
+    ).toBe('198.51.100.7');
+  });
+
+  it('ignores an empty header rather than keying everyone to blank', () => {
+    expect(
+      clientIpFrom(
+        req({ 'cf-connecting-ip': '  ', 'x-forwarded-for': '198.51.100.7' }),
+        true,
+      ),
+    ).toBe('198.51.100.7');
+  });
+
+  it('still ignores it when there is no proxy to trust at all', () => {
+    expect(
+      clientIpFrom(
+        req({ 'cf-connecting-ip': '1.1.1.1' }, '203.0.113.9'),
+        false,
+      ),
+    ).toBe('203.0.113.9');
   });
 });

--- a/video-sync-backend/src/auth/rate-bucket.ts
+++ b/video-sync-backend/src/auth/rate-bucket.ts
@@ -132,12 +132,39 @@ export const isInfrastructureAddress = (raw: string): boolean => {
  * toward the unbounded row creation this exists to stop. The one-shot
  * diagnostic in the controller reports which case we are actually in.
  *
+ * Take four, and the one that had the actual answer: production is behind
+ * CLOUDFLARE. Render fronts services with it - the response carries
+ * `server: cloudflare` and a `cf-ray`, which is how this was finally found,
+ * and nothing in the code or the dashboard said so.
+ *
+ * That is fatal to take three, because the rightmost public address in the
+ * chain is then the Cloudflare EDGE address, and which edge server handles a
+ * request varies. Fifteen requests from one machine produced fifteen
+ * different keys and fifteen fresh allowances. It is the exact failure mode
+ * written down above as a risk - only inverted: I predicted it would key
+ * everyone TOGETHER, and instead it keys one person apart.
+ *
+ * Cloudflare sets `cf-connecting-ip` to the address it accepted the
+ * connection from, and OVERWRITES any value the caller sent. So when it is
+ * present it is both the true client and unforgeable, which no position in
+ * x-forwarded-for is. The chain walk stays as the fallback for deployments
+ * with no Cloudflare in front.
+ *
+ * The assumption, stated because it is the one that would break this: all
+ * traffic reaches the app through Cloudflare. Someone who could hit the
+ * origin directly could forge this header - but they could forge the whole
+ * chain too, so it is not a step down.
+ *
  * `trustProxy` is a deployment fact, not a guess - a proxy in production,
  * none on a laptop.
  */
 export const clientIpFrom = (req: Request, trustProxy: boolean): string => {
   const peer = req.socket?.remoteAddress || 'unknown';
   if (!trustProxy) return peer;
+
+  const cloudflare = req.headers['cf-connecting-ip'];
+  const fromEdge = Array.isArray(cloudflare) ? cloudflare[0] : cloudflare;
+  if (fromEdge?.trim()) return fromEdge.trim();
 
   const forwarded = req.headers['x-forwarded-for'];
   const raw = Array.isArray(forwarded) ? forwarded.join(',') : forwarded;


### PR DESCRIPTION
You asked why I can't just deploy it. I can't — no Render API key, no CLI, no repo secret, and a deploy hook URL is a credential I shouldn't be handling directly. But that's a fixable gap, so this fixes it.

## Why this is worth having beyond the convenience

The backend has been deployed by someone opening the Render dashboard and clicking Manual Deploy. **The rate limit shipped broken twice, and the gap between "merged" and "actually running" is where both hid** — `main` has been correct for hours while production served the version that admitted fifteen requests against a capacity of ten.

## The verification is the point, not the deploy

`scripts/verify-guest-limit.mjs` sends **fifteen** requests against a capacity of ten, honest and forged, and fails the job if nothing is refused.

Above capacity deliberately: an earlier run of this by hand sent six, saw six `201`s, and concluded nothing while looking like a pass. It also refuses to be a rubber stamp — run against production as it stands today, it fails, correctly:

```
201 201 201 201 201 201 201 201 201 201 201 201 201 201 201
15 allowed, 0 refused
FAIL  honest caller: nothing was refused
```

## One subtlety worth reading

Waiting is done by watching for the instance to **go away and come back**, not by polling `/health`. Render builds before it swaps, so the old instance answers health perfectly for several minutes — a health poll would declare success against the very build being replaced, which is exactly the class of mistake this workflow exists to catch.

## What you do, once

```
# Render → the service → Settings → Deploy Hook → copy the URL
gh secret set RENDER_DEPLOY_HOOK
```

The URL goes from Render straight into the secret store and never through me. Until it's set, the workflow skips, warns, and says where to get it — and the checks skip too, rather than failing every unrelated push with a red X about a known gap, which would only train everyone to ignore it.

## Worth arguing with

- **A passing run creates ~20 guest rows in production.** They have no rooms, messages or password, so the nightly sweeper takes them after seven days. Stated in the script's output rather than left to be discovered.
- **The swap detection can miss a genuinely zero-downtime deploy** and warn instead of failing. I chose warn-and-continue because a false failure here is worse than a late one — but if the checks then fail, the cause may just be that the deploy hadn't landed.
- **It only guards the backend.** Vercel is still a CLI deploy from a laptop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated backend deployment on relevant changes to the main branch or through manual triggers.
  * Added production verification for guest request limits, service health, authentication providers, and unauthorized room creation.

* **Documentation**
  * Updated deployment guidance, including secret configuration and manual deployment fallback.

* **Bug Fixes**
  * Improved deployment safeguards by skipping deployments when required configuration is missing and reporting warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->