### PR TITLE
fix: main is red — one prettier violation, and how I let it through

### DIFF
--- a/video-sync-backend/src/auth/auth.controller.ts
+++ b/video-sync-backend/src/auth/auth.controller.ts
@@ -128,7 +128,9 @@ export class AuthController {
               // filter missed it: cf-connecting-ip contains neither
               // 'client-ip' nor 'forward', so the header carrying the actual
               // answer was invisible to the diagnostic looking for it.
-              .filter((h) => /forward|real-ip|client-ip|connecting-ip|cf-/.test(h))
+              .filter((h) =>
+                /forward|real-ip|client-ip|connecting-ip|cf-/.test(h),
+              )
               .join('|') || 'none'
           }`,
       );


### PR DESCRIPTION
**`main` has been failing CI since `ad9fac4` (#55).** One prettier violation on the diagnostic filter line. `gh run list --workflow=ci.yml --branch main` shows it plainly:

```
ad9fac4  failure     <- #55
e2c2ceb  success
088a235  success
```

The fix is one line of formatting. The interesting part is how it got in.

I ran lint and the test suite as a single command and piped lint through `tail -1`. That showed the eslint banner and hid the error underneath it. I then read the jest summary, saw 352 passing, and merged. **The check did its job — I truncated its answer and believed the truncation.**

That's the same shape as the other three mistakes in this stretch:

- a six-request rate-limit control against a capacity of ten, which could not have failed
- a live check that reported its own setup failures as product data loss
- a diagnostic whose header filter could not see `cf-connecting-ip`, the one header it existed to find

An instrument that cannot say "no" is not a check. Worth writing down, because I'd have called all four of those "verified" at the time.

Unblocks #54, whose CI was correctly failing on the merge result rather than on its own changes.