### PR TITLE
docs: record where the guest survey was looser than the code that followed

### DIFF
--- a/docs/GUEST_ACCESS.md
+++ b/docs/GUEST_ACCESS.md
@@ -106,6 +106,28 @@ the end removes the very chat rows a later query was inspecting. Each looked
 exactly like data loss. A live check that does not assert its own setup will
 report its own failures as yours.
 
+### What the survey left open, and what the code decided
+
+A review of this document caught three places where the analysis was looser
+than the implementation turned out to be. Recorded rather than quietly
+tightened, because the gap between them is the interesting part:
+
+- **The survey never specified an email for a disposable user.** `User.email`
+  is non-null and unique, so "a generated username and a nullable password" is
+  not enough to insert a row - the argument had a hole the code had to fill.
+  It fills it with `randomUUID()@guest.invalid`: collision-safe by
+  construction, and `.invalid` is reserved by RFC 2606 so it can never route
+  anywhere real.
+- **It implied the socket handshake needs a `User` row.** It does not - the
+  handshake validates a signed token with `sub` and `name` and attaches the
+  identity, with no database lookup (`jwt-auth.guard.spec.ts`). The
+  persistence constraints are `Participant.userId` and `ChatMessage.userId`,
+  which is a narrower and more accurate statement of why a row is needed.
+- **Option C (row-less guests) was under-specified.** A `guest:` subject gives
+  a participant or message no stable identity across reconnects, so history
+  and de-duplication have nowhere to hang. That is a real reason it was not
+  chosen, and the survey did not say it.
+
 ### Still not built
 
 - **Linking Google to a guest row.** Claiming takes a password. Someone who

--- a/docs/GUEST_ACCESS.md
+++ b/docs/GUEST_ACCESS.md
@@ -115,9 +115,14 @@ tightened, because the gap between them is the interesting part:
 - **The survey never specified an email for a disposable user.** `User.email`
   is non-null and unique, so "a generated username and a nullable password" is
   not enough to insert a row - the argument had a hole the code had to fill.
-  It fills it with `randomUUID()@guest.invalid`: collision-safe by
-  construction, and `.invalid` is reserved by RFC 2606 so it can never route
-  anywhere real.
+  It fills it with `randomUUID()@guest.invalid`: collision-*resistant* rather
+  than collision-*proof*, which is a distinction worth keeping. A v4 UUID has
+  122 random bits, so a repeat is not impossible, only absurd — and
+  `createGuest()` retries a username collision but not an email one, so the
+  absurd case would surface as a 500 rather than a retry. That asymmetry is
+  deliberate at these odds and recorded here rather than defended in code.
+  `.invalid` is reserved by RFC 2606, so the address can never route anywhere
+  real.
 - **It implied the socket handshake needs a `User` row.** It does not - the
   handshake validates a signed token with `sub` and `name` and attaches the
   identity, with no database lookup (`jwt-auth.guard.spec.ts`). The


### PR DESCRIPTION
The review on #50 finally landed — late, because every "review record" PR targeted a frozen base branch and CodeRabbit skips auto-review on any base but the default. That was my mistake in the mechanism, not its quota.

All five findings are on `docs/GUEST_ACCESS.md` — the design survey — rather than on shipped code. Three were worth keeping, and I've recorded them rather than quietly tightening the prose, because the gap between the argument and the implementation is the interesting part:

- **No email strategy for a disposable user.** `User.email` is non-null and unique, so "a generated username and a nullable password" cannot insert a row. The argument had a hole; the code filled it with `randomUUID()@guest.invalid` (collision-safe, and `.invalid` is RFC 2606 reserved).
- **It implied the socket handshake needs a `User` row.** It doesn't — the handshake validates a signed token and attaches the identity with no lookup. The real constraints are `Participant.userId` and `ChatMessage.userId`, which is a narrower and truer claim than the one the document made.
- **Row-less guests were rejected without stating the actual reason** — a `guest:` subject gives a participant or message no stable identity across reconnects, so history and de-duplication have nowhere to hang.

Docs only; no code paths touched, and the deploy workflow's path filter ignores it.

Closes the review thread on #50, which I'll close as its purpose is served.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guest access documentation with implementation details and known limitations.
  * Clarified requirements for generated guest email addresses.
  * Documented token validation behavior during connection setup.
  * Noted limitations affecting guest identity, history tracking, and duplicate prevention.
  * Explained that generated guest email collisions are unlikely but possible and may result in a connection error.
  * Added guidance to help interpret guest access behavior and its impact on session history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->