### PR TITLE
feat: keep your account with Google, from inside the room, under one rule

### DIFF
--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -195,8 +195,9 @@ Both wrong versions passed their unit tests.
 
 ## Known gaps
 
-- No token refresh or revocation. A token is good for 12 hours, and a socket
-  accepted at connect outlives its token (`docs/SCALING.md`).
+- No token refresh or revocation. A token is good for its configured lifetime
+  (12 hours by default), and a socket accepted at connect outlives its token
+  (`docs/SCALING.md`).
 - ~~`JWT_EXPIRES_IN` is dead config~~ — fixed. Tokens **default** to `12h` and
   a deployment can change that by setting the variable; it is no longer a
   fixed lifetime. `12h` is what was hardcoded while the config file

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -197,9 +197,15 @@ Both wrong versions passed their unit tests.
 
 - No token refresh or revocation. A token is good for 12 hours, and a socket
   accepted at connect outlives its token (`docs/SCALING.md`).
-- `JWT_EXPIRES_IN` is dead config — the 12h lifetime is hardcoded in
-  `auth.module.ts`.
-- Linking a provider to an existing account is not implemented; see above.
+- ~~`JWT_EXPIRES_IN` is dead config~~ — fixed. It is read now; the default is
+  `12h`, which is what was hardcoded while the config file advertised `7d` to
+  nobody. Raising it raises how long a stolen token is useful, and there is
+  still no revocation, so it is not a free knob.
+- Linking a provider to an existing account is implemented **for guests
+  only** (`POST /auth/google/link-start`). A full account cannot add or swap a
+  provider - that needs a re-authentication step this does not have, and
+  adding one without it would let a stolen token attach an attacker's Google
+  identity to somebody's account.
 - `isPublic` on a room is a listing flag, not access control.
 - The "is this address already taken" check is a case-insensitive `findFirst`,
   which Postgres answers with a sequential scan — the `email` index is

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -197,10 +197,15 @@ Both wrong versions passed their unit tests.
 
 - No token refresh or revocation. A token is good for 12 hours, and a socket
   accepted at connect outlives its token (`docs/SCALING.md`).
-- ~~`JWT_EXPIRES_IN` is dead config~~ — fixed. It is read now; the default is
-  `12h`, which is what was hardcoded while the config file advertised `7d` to
-  nobody. Raising it raises how long a stolen token is useful, and there is
-  still no revocation, so it is not a free knob.
+- ~~`JWT_EXPIRES_IN` is dead config~~ — fixed. Tokens **default** to `12h` and
+  a deployment can change that by setting the variable; it is no longer a
+  fixed lifetime. `12h` is what was hardcoded while the config file
+  advertised `7d` to nobody. Raising it raises how long a stolen token is
+  useful, and there is still no revocation, so it is not a free knob. The
+  value is validated at boot: a plain number means seconds, durations must be
+  lowercase (`12h`, `30m`), and anything else refuses to start — because
+  `jsonwebtoken` reads a unitless string as *milliseconds*, so `3600` would
+  otherwise mean 3.6 seconds.
 - Linking a provider to an existing account is implemented **for guests
   only** (`POST /auth/google/link-start`). A full account cannot add or swap a
   provider - that needs a re-authentication step this does not have, and

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -206,6 +206,11 @@ Both wrong versions passed their unit tests.
   provider - that needs a re-authentication step this does not have, and
   adding one without it would let a stolen token attach an attacker's Google
   identity to somebody's account.
+- A linked account has **no password and no way to acquire one**. Google is
+  then the only way in, and losing access to that Google account loses the
+  account - there is no reset flow, because there is nothing to reset. Same
+  for accounts created through Google in the first place. Claiming with a
+  password is the alternative, and the two do not compose.
 - `isPublic` on a room is a listing flag, not access control.
 - The "is this address already taken" check is a case-insensitive `findFirst`,
   which Postgres answers with a sequential scan — the `email` index is

--- a/docs/GUEST_ACCESS.md
+++ b/docs/GUEST_ACCESS.md
@@ -130,9 +130,15 @@ tightened, because the gap between them is the interesting part:
 
 ## Claiming with Google instead of a password
 
-`POST /auth/google/link-start` — the same outcome as `/auth/claim`, for
-someone who would rather not invent another password. Same rule underneath:
-the row keeps its id.
+`POST /auth/google/link-start` — for someone who would rather not invent
+another password. Same rule underneath: the row keeps its id.
+
+Not quite the *same* outcome as `/auth/claim`, and the difference is a one-way
+door: a linked account keeps `password: null`, and there is no path to add one
+later. Google becomes the only way in. That matches how Google-created
+accounts already behave here, so it is consistent rather than surprising - but
+someone who loses access to that Google account loses the account, and no
+password reset exists to rescue them.
 
 **Why it is a POST that returns a URL** rather than a link the browser
 follows. A navigation cannot carry an `Authorization` header, and the
@@ -166,3 +172,7 @@ to be corrected.
 - **Merging two accounts.** If the Google address already has an account, the
   answer is "sign in with that one" — we cannot tell from here that both are
   the same person.
+- **Adding a password to a linked account.** Linking leaves `password: null`
+  with no way to set one afterwards, so Google is the only way back in and
+  there is nothing for a reset flow to reset. Anyone who wants both should
+  claim with a password instead; the two paths do not compose.

--- a/docs/GUEST_ACCESS.md
+++ b/docs/GUEST_ACCESS.md
@@ -78,7 +78,8 @@ afterthought bolted onto a UX sweep.
 ## Keeping the account (`POST /auth/claim`)
 
 A guest session is a real row with real history hanging off it, and it expires
-in twelve hours with no password to get back in with. Claiming is the door out
+in twelve hours by default (`JWT_EXPIRES_IN`) with no password to get back in
+with. Claiming is the door out
 of that, and it is an **UPDATE, not an insert**: the row keeps its id.
 
 That is the whole design. `ChatMessage.userId` and `Participant.userId` are

--- a/docs/GUEST_ACCESS.md
+++ b/docs/GUEST_ACCESS.md
@@ -128,12 +128,41 @@ tightened, because the gap between them is the interesting part:
   and de-duplication have nowhere to hang. That is a real reason it was not
   chosen, and the survey did not say it.
 
+## Claiming with Google instead of a password
+
+`POST /auth/google/link-start` — the same outcome as `/auth/claim`, for
+someone who would rather not invent another password. Same rule underneath:
+the row keeps its id.
+
+**Why it is a POST that returns a URL** rather than a link the browser
+follows. A navigation cannot carry an `Authorization` header, and the
+alternative — the token in a query string — writes a credential into access
+logs and `Referer` headers. So the browser asks for the URL and goes there
+itself.
+
+**The id is sealed into the OAuth state cookie**, and it is the id the guard
+verified from the bearer token — never anything the caller said about
+themselves. A caller who could nominate the account would be able to attach
+their own Google identity to somebody else's.
+
+**Order of checks matters.** The provider link is examined before anything is
+written: a Google account already attached to a real account must not be
+quietly moved onto a guest row, because that is an account takeover using the
+victim's own credentials. Same for the address.
+
+Failures come back as **codes in the redirect fragment**, not sentences —
+`link_provider_taken`, `link_email_taken`, `link_not_guest`. That is the
+existing contract for this channel and it is deliberate: the API does not
+know how the frontend words things, and a code cannot leak anything about the
+account it refused. The first version of this sent the message text and had
+to be corrected.
+
 ### Still not built
 
-- **Linking Google to a guest row.** Claiming takes a password. Someone who
-  would rather use Google has to make a separate account, which is the case
-  this whole feature exists to avoid.
-- **Password strength beyond eight characters**, and `register` validates even
-  less — claim checks a name pattern, an address shape and a length; register
-  checks none of them. Fixing one door and not the other would read as though
-  the other had been considered.
+- **A full account cannot add or change a provider.** Only guests can link.
+  Doing it for a real account needs a re-authentication step that does not
+  exist here, and adding the feature without it would let a stolen token
+  attach an attacker's Google identity to someone's account.
+- **Merging two accounts.** If the Google address already has an account, the
+  answer is "sign in with that one" — we cannot tell from here that both are
+  the same person.

--- a/docs/GUEST_ACCESS.md
+++ b/docs/GUEST_ACCESS.md
@@ -106,6 +106,28 @@ the end removes the very chat rows a later query was inspecting. Each looked
 exactly like data loss. A live check that does not assert its own setup will
 report its own failures as yours.
 
+### What the survey left open, and what the code decided
+
+A review of this document caught three places where the analysis was looser
+than the implementation turned out to be. Recorded rather than quietly
+tightened, because the gap between them is the interesting part:
+
+- **The survey never specified an email for a disposable user.** `User.email`
+  is non-null and unique, so "a generated username and a nullable password" is
+  not enough to insert a row - the argument had a hole the code had to fill.
+  It fills it with `randomUUID()@guest.invalid`: collision-safe by
+  construction, and `.invalid` is reserved by RFC 2606 so it can never route
+  anywhere real.
+- **It implied the socket handshake needs a `User` row.** It does not - the
+  handshake validates a signed token with `sub` and `name` and attaches the
+  identity, with no database lookup (`jwt-auth.guard.spec.ts`). The
+  persistence constraints are `Participant.userId` and `ChatMessage.userId`,
+  which is a narrower and more accurate statement of why a row is needed.
+- **Option C (row-less guests) was under-specified.** A `guest:` subject gives
+  a participant or message no stable identity across reconnects, so history
+  and de-duplication have nowhere to hang. That is a real reason it was not
+  chosen, and the survey did not say it.
+
 ### Still not built
 
 - **Linking Google to a guest row.** Claiming takes a password. Someone who

--- a/video-sync-backend/.env.example
+++ b/video-sync-backend/.env.example
@@ -12,7 +12,7 @@ NODE_ENV=development
 
 # JWT Configuration
 JWT_SECRET=your-secret-key-here
-JWT_EXPIRES_IN=7d
+JWT_EXPIRES_IN=12h
 
 # Frontend URL (for CORS). Comma-separated allowlist; the FIRST entry is
 # also where OAuth sends the browser back, so keep the real site first.

--- a/video-sync-backend/src/auth/auth.controller.spec.ts
+++ b/video-sync-backend/src/auth/auth.controller.spec.ts
@@ -239,3 +239,61 @@ describe('the guest route under two limits at once', () => {
     expect(codes.filter((c) => c === 429)).toHaveLength(10);
   });
 });
+
+describe('starting a link, which is a different thing from signing in', () => {
+  const makeLinkGoogle = () => {
+    const start = jest.fn().mockReturnValue({
+      authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?x=1',
+      cookie: 'sealed',
+    });
+    return {
+      google: {
+        enabled: true,
+        assertEnabled: () => undefined,
+        start,
+        verifyCallback: jest.fn(),
+        callbackRedirect: (f: string) =>
+          `https://mustard.watch/auth/callback#${f}`,
+        redirectUri: 'https://api.mustard.watch/api/auth/google/callback',
+      } as unknown as GoogleOAuthService,
+      start,
+    };
+  };
+
+  it('seals the id the GUARD verified, not anything the caller sent', () => {
+    // The whole security of linking rests here: a caller who could nominate
+    // the account would be able to attach their Google identity to someone
+    // else's.
+    const { google, start } = makeLinkGoogle();
+    const controller = new AuthController({} as unknown as AuthService, google);
+    const res = makeRes();
+
+    const out = controller.linkStart(
+      'user-from-token',
+      { returnTo: '/room/abc' },
+      res as unknown as Response,
+    );
+
+    // cast the CALLS array, not the element - indexing an `any` array is
+    // itself the unsafe access, which is the same note CodeRabbit left on
+    // the claim tests
+    const calls = start.mock.calls as [string | undefined, number, string][];
+    expect(calls[0][2]).toBe('user-from-token');
+    expect(out.authUrl).toContain('accounts.google.com');
+    expect(res.cookies[0].name).toBe('mw_oauth');
+  });
+
+  it('returns the URL rather than redirecting to it', () => {
+    // It is a POST carrying a bearer token, so the browser has to navigate
+    // itself - a redirect here would be answered by fetch, not by the
+    // address bar, and the flow would silently go nowhere.
+    const { google } = makeLinkGoogle();
+    const res = makeRes();
+    new AuthController({} as unknown as AuthService, google).linkStart(
+      'u1',
+      {},
+      res as unknown as Response,
+    );
+    expect(res.redirectedTo).toBeUndefined();
+  });
+});

--- a/video-sync-backend/src/auth/auth.controller.spec.ts
+++ b/video-sync-backend/src/auth/auth.controller.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { ConflictException, Logger, NotFoundException } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
@@ -295,5 +295,106 @@ describe('starting a link, which is a different thing from signing in', () => {
       res as unknown as Response,
     );
     expect(res.redirectedTo).toBeUndefined();
+  });
+});
+
+describe('what the callback tells someone when it fails', () => {
+  const callbackWith = (signInWithGoogle: jest.Mock) => {
+    const google = {
+      enabled: true,
+      assertEnabled: () => undefined,
+      start: jest.fn(),
+      verifyCallback: jest.fn().mockResolvedValue({
+        identity: { subject: 's', email: 'a@b.co', emailVerified: true },
+      }),
+      callbackRedirect: (f: string) =>
+        `https://mustard.watch/auth/callback#${f}`,
+      redirectUri: 'https://api.mustard.watch/api/auth/google/callback',
+    } as unknown as GoogleOAuthService;
+    const logger = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => undefined);
+    const controller = new AuthController(
+      { signInWithGoogle } as unknown as AuthService,
+      google,
+    );
+    return { controller, logger };
+  };
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('reports a coded link refusal as that code, and does not log it', async () => {
+    const { controller, logger } = callbackWith(
+      jest.fn().mockRejectedValue(
+        new ConflictException({
+          code: 'link_email_taken',
+          message: 'An account with that email already exists',
+        }),
+      ),
+    );
+    const res = makeRes();
+    await controller.callback(
+      'c',
+      's',
+      undefined,
+      emptyReq,
+      res as unknown as Response,
+    );
+
+    expect(res.redirectedTo).toContain('error=link_email_taken');
+    // nobody's bug, so nothing to alert on
+    expect(logger).not.toHaveBeenCalled();
+  });
+
+  it('does NOT dress an uncoded conflict up as a link refusal', async () => {
+    // createGoogleUser throws ConflictException with a plain string when it
+    // runs out of username attempts - a sign-in, not a link. Reading the
+    // CLASS rather than the code told that person their guest session was
+    // untouched, when they had no guest session, and skipped the log that
+    // would have shown a real allocation anomaly.
+    const { controller, logger } = callbackWith(
+      jest
+        .fn()
+        .mockRejectedValue(
+          new ConflictException('Could not allocate a username'),
+        ),
+    );
+    const res = makeRes();
+    await controller.callback(
+      'c',
+      's',
+      undefined,
+      emptyReq,
+      res as unknown as Response,
+    );
+
+    expect(res.redirectedTo).toContain('error=exchange');
+    expect(res.redirectedTo).not.toContain('link');
+    expect(logger).toHaveBeenCalled();
+  });
+
+  it('never puts a sentence in the fragment, only a code', async () => {
+    // The channel is a redirect URL: the API does not know how the frontend
+    // words things, and a code cannot leak anything about the account it
+    // refused. An earlier version of mine sent the message text.
+    const { controller } = callbackWith(
+      jest.fn().mockRejectedValue(
+        new ConflictException({
+          code: 'link_provider_taken',
+          message: 'That Google account is already signed in here',
+        }),
+      ),
+    );
+    const res = makeRes();
+    await controller.callback(
+      'c',
+      's',
+      undefined,
+      emptyReq,
+      res as unknown as Response,
+    );
+
+    expect(res.redirectedTo).not.toContain('already signed in');
+    expect(res.redirectedTo).not.toContain('detail');
   });
 });

--- a/video-sync-backend/src/auth/auth.controller.ts
+++ b/video-sync-backend/src/auth/auth.controller.ts
@@ -1,5 +1,7 @@
 import {
   Controller,
+  ConflictException,
+  ForbiddenException,
   Get,
   Post,
   Body,
@@ -208,6 +210,37 @@ export class AuthController {
     return await this.authService.me(userId);
   }
 
+  /**
+   * Step one for a guest ATTACHING Google to the account they are already
+   * using, rather than signing in.
+   *
+   * A POST with a bearer token, not a GET the browser can navigate to,
+   * because a navigation cannot carry an Authorization header - and the
+   * alternative, putting the token in the query string, writes a credential
+   * into access logs and Referer headers. So the browser asks for the URL
+   * here and navigates to it itself.
+   *
+   * The id sealed into the state is the one the guard verified from the
+   * token. Nothing the caller says about who they are is used: a caller who
+   * could nominate the account would be able to attach their Google identity
+   * to someone else's.
+   */
+  @Post('google/link-start')
+  @UseGuards(JwtAuthGuard)
+  linkStart(
+    @CurrentUser('userId') userId: string,
+    @Body() body: { returnTo?: string },
+    @Res({ passthrough: true }) res: Response,
+  ): { authUrl: string } {
+    const { authUrl, cookie } = this.google.start(
+      body?.returnTo,
+      Date.now(),
+      userId,
+    );
+    res.cookie(OAUTH_COOKIE, cookie, this.cookieOptions());
+    return { authUrl };
+  }
+
   /** Step one: bounce to Google, carrying a sealed CSRF/PKCE cookie. */
   @Get('google/start')
   start(
@@ -247,14 +280,20 @@ export class AuthController {
     res.clearCookie(OAUTH_COOKIE, this.cookieOptions());
 
     try {
-      const { identity, returnTo } = await this.google.verifyCallback({
-        code,
-        state,
-        error,
-        cookie: readCookie(req.headers.cookie, OAUTH_COOKIE),
-      });
+      const { identity, returnTo, linkUserId } =
+        await this.google.verifyCallback({
+          code,
+          state,
+          error,
+          cookie: readCookie(req.headers.cookie, OAUTH_COOKIE),
+        });
 
-      const user = await this.authService.signInWithGoogle(identity);
+      // Two flows come back through this one door, and which it is was
+      // decided at /link-start by a token we verified - not by anything in
+      // the request that is arriving now.
+      const user = linkUserId
+        ? await this.authService.linkGoogleToGuest(linkUserId, identity)
+        : await this.authService.signInWithGoogle(identity);
 
       // The token rides in the FRAGMENT, never the query string: fragments
       // are not sent to servers, do not reach access logs, and are not
@@ -263,13 +302,31 @@ export class AuthController {
       if (returnTo) params.set('to', returnTo);
       res.redirect(this.google.callbackRedirect(params.toString()));
     } catch (err) {
+      // Linking has its own ways to fail that are nobody's bug: the Google
+      // account is already attached to a real account, or its address is.
+      // Reporting those as 'exchange' would log them as unexpected errors
+      // and tell the person "sign-in failed", when what happened is
+      // recoverable and has a specific instruction attached to it.
+      const refused =
+        err instanceof ConflictException || err instanceof ForbiddenException;
+
+      // The code the service attached, not a sentence: this channel is a
+      // redirect fragment, and the page on the other end owns the wording.
+      const linkCode = refused
+        ? (((err as ConflictException).getResponse() as { code?: string })
+            ?.code ?? 'link')
+        : undefined;
+
       const failure =
-        err instanceof GoogleAuthError ? err.code : ('exchange' as const);
-      if (!(err instanceof GoogleAuthError)) {
+        linkCode ??
+        (err instanceof GoogleAuthError ? err.code : ('exchange' as const));
+
+      if (!refused && !(err instanceof GoogleAuthError)) {
         this.logger.error(
           `google callback failed: ${err instanceof Error ? err.message : 'unknown'}`,
         );
       }
+
       res.redirect(
         this.google.callbackRedirect(
           new URLSearchParams({ error: failure }).toString(),

--- a/video-sync-backend/src/auth/auth.controller.ts
+++ b/video-sync-backend/src/auth/auth.controller.ts
@@ -1,7 +1,5 @@
 import {
   Controller,
-  ConflictException,
-  ForbiddenException,
   Get,
   Post,
   Body,
@@ -307,21 +305,29 @@ export class AuthController {
       // Reporting those as 'exchange' would log them as unexpected errors
       // and tell the person "sign-in failed", when what happened is
       // recoverable and has a specific instruction attached to it.
-      const refused =
-        err instanceof ConflictException || err instanceof ForbiddenException;
-
-      // The code the service attached, not a sentence: this channel is a
-      // redirect fragment, and the page on the other end owns the wording.
-      const linkCode = refused
-        ? (((err as ConflictException).getResponse() as { code?: string })
-            ?.code ?? 'link')
-        : undefined;
+      //
+      // Recognised by the CODE the service attached, not by the exception
+      // class. The first version tested `instanceof ConflictException` - which
+      // is ALSO what createGoogleUser throws when it runs out of username
+      // attempts, on a plain sign-in with nothing to do with linking. That one
+      // carries a string, so it has no code, and the person would have been
+      // told "your guest session is untouched" when they had no guest session,
+      // while the error log that would have shown a real allocation anomaly
+      // was skipped.
+      const payload =
+        err instanceof HttpException
+          ? (err.getResponse() as { code?: unknown })
+          : undefined;
+      const linkCode =
+        typeof payload?.code === 'string' && payload.code.startsWith('link_')
+          ? payload.code
+          : undefined;
 
       const failure =
         linkCode ??
         (err instanceof GoogleAuthError ? err.code : ('exchange' as const));
 
-      if (!refused && !(err instanceof GoogleAuthError)) {
+      if (!linkCode && !(err instanceof GoogleAuthError)) {
         this.logger.error(
           `google callback failed: ${err instanceof Error ? err.message : 'unknown'}`,
         );

--- a/video-sync-backend/src/auth/auth.module.ts
+++ b/video-sync-backend/src/auth/auth.module.ts
@@ -16,8 +16,11 @@ import { GuestSweeperService } from './guest-sweeper.service';
         // Read from config rather than hardcoded. It was hardcoded to '12h'
         // while configuration.ts carried a JWT_EXPIRES_IN of '7d' that
         // nothing read - so the documented knob did nothing and the two
-        // disagreed by a factor of fourteen. The config default is now 12h,
-        // so this changes the number in one file and the behaviour in none.
+        // disagreed by a factor of fourteen.
+        //
+        // 12h is now the DEFAULT rather than the lifetime: a deployment that
+        // sets JWT_EXPIRES_IN changes it, which is the whole point of making
+        // this live. Unset, nothing about the behaviour changed.
         //
         // Still verified at connect only; an accepted socket outlives its
         // token (documented limitation - no refresh/revocation in scope).

--- a/video-sync-backend/src/auth/auth.module.ts
+++ b/video-sync-backend/src/auth/auth.module.ts
@@ -13,9 +13,17 @@ import { GuestSweeperService } from './guest-sweeper.service';
       inject: [ConfigService],
       useFactory: (config: ConfigService) => ({
         secret: config.get<string>('jwt.secret'),
-        // verified at connect only; an accepted socket outlives its token
-        // (documented limitation - no refresh/revocation in scope)
-        signOptions: { expiresIn: '12h' },
+        // Read from config rather than hardcoded. It was hardcoded to '12h'
+        // while configuration.ts carried a JWT_EXPIRES_IN of '7d' that
+        // nothing read - so the documented knob did nothing and the two
+        // disagreed by a factor of fourteen. The config default is now 12h,
+        // so this changes the number in one file and the behaviour in none.
+        //
+        // Still verified at connect only; an accepted socket outlives its
+        // token (documented limitation - no refresh/revocation in scope).
+        signOptions: {
+          expiresIn: config.get<string>('jwt.expiresIn') ?? '12h',
+        },
       }),
     }),
   ],

--- a/video-sync-backend/src/auth/auth.service.spec.ts
+++ b/video-sync-backend/src/auth/auth.service.spec.ts
@@ -477,3 +477,168 @@ describe('claiming a guest account', () => {
     });
   });
 });
+
+describe('both doors into the users table enforce the same rules', () => {
+  // register went a long time checking nothing while claimGuestAccount
+  // checked three things. These run the same table against both, because a
+  // rule that only one door knows about is not a rule.
+  const bad: [string, string, string, string][] = [
+    ['a short password', 'ada', 'ada@example.com', 'short12'],
+    [
+      'a name with a space',
+      'ada lovelace',
+      'ada@example.com',
+      'a-real-password',
+    ],
+    ['a name of two characters', 'ad', 'ada@example.com', 'a-real-password'],
+    ['an address with no domain', 'ada', 'ada@localhost', 'a-real-password'],
+    ['the guest address', 'ada', 'x@guest.invalid', 'a-real-password'],
+  ];
+
+  describe.each(bad)('%s', (_label, username, email, password) => {
+    it('is refused by register, before anything is written', async () => {
+      const db = makeDb();
+      await expect(
+        serviceWith(db).register(username, email, password),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(db.user.create).not.toHaveBeenCalled();
+    });
+
+    it('is refused by claim, before anything is written', async () => {
+      const db = makeDb();
+      db.user.findUnique.mockResolvedValue({ id: 'g1', isGuest: true });
+      await expect(
+        serviceWith(db).claimGuestAccount('g1', username, email, password),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(db.user.update).not.toHaveBeenCalled();
+    });
+  });
+
+  it('stores what it validated, not what it was handed', async () => {
+    // validating a trimmed, lower-cased string and then writing the raw one
+    // would make the check decorative
+    const db = makeDb();
+    db.user.create.mockResolvedValue({
+      id: 'u1',
+      username: 'ada',
+      email: 'ada@example.com',
+    });
+    await serviceWith(db).register(
+      '  ada  ',
+      '  Ada@Example.COM ',
+      'a-real-password',
+    );
+    const args = (
+      db.user.create.mock.calls as [
+        { data: { username: string; email: string } },
+      ][]
+    )[0][0];
+    expect(args.data.username).toBe('ada');
+    expect(args.data.email).toBe('ada@example.com');
+  });
+});
+
+describe('attaching Google to a guest', () => {
+  const guestRow = { id: 'g1', isGuest: true };
+
+  const linking = () => {
+    const db = makeDb();
+    db.user.findUnique.mockResolvedValue(guestRow);
+    db.user.update.mockResolvedValue({
+      id: 'g1',
+      username: 'ada_lovelace',
+      email: 'ada@example.com',
+    });
+    return { db, service: serviceWith(db) };
+  };
+
+  it('updates the guest row in place and links the provider', async () => {
+    const { db, service } = linking();
+    const result = await service.linkGoogleToGuest('g1', identity);
+
+    expect(db.user.create).not.toHaveBeenCalled();
+    const args = (
+      db.user.update.mock.calls as [
+        {
+          where: { id: string; isGuest: boolean };
+          data: {
+            isGuest: boolean;
+            oauthAccounts: { create: { providerAccountId: string } };
+          };
+        },
+      ][]
+    )[0][0];
+    expect(args.where).toEqual({ id: 'g1', isGuest: true });
+    expect(args.data.isGuest).toBe(false);
+    expect(args.data.oauthAccounts.create.providerAccountId).toBe(
+      'google-sub-123',
+    );
+    expect(result.id).toBe('g1');
+  });
+
+  it('leaves the password null, so the only way in is the provider', async () => {
+    const { db, service } = linking();
+    await service.linkGoogleToGuest('g1', identity);
+    const args = (
+      db.user.update.mock.calls as [{ data: Record<string, unknown> }][]
+    )[0][0];
+    expect(args.data.password).toBeUndefined();
+  });
+
+  it('refuses a Google account already attached to someone else', async () => {
+    // the takeover this guards: grafting a real user's Google identity onto
+    // a guest row would hand the guest that person's way in
+    const { db, service } = linking();
+    db.oAuthAccount.findUnique.mockResolvedValue({ userId: 'someone-else' });
+    await expect(
+      service.linkGoogleToGuest('g1', identity),
+    ).rejects.toMatchObject({
+      status: 409,
+    });
+    expect(db.user.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the address already belongs to another account', async () => {
+    const { db, service } = linking();
+    db.user.findFirst.mockResolvedValue({ id: 'someone-else' });
+    await expect(
+      service.linkGoogleToGuest('g1', identity),
+    ).rejects.toMatchObject({
+      status: 409,
+    });
+    expect(db.user.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses a row that is already a full account', async () => {
+    const db = makeDb();
+    db.user.findUnique.mockResolvedValue({ id: 'u1', isGuest: false });
+    await expect(
+      serviceWith(db).linkGoogleToGuest('u1', identity),
+    ).rejects.toMatchObject({ status: 403 });
+    expect(db.user.update).not.toHaveBeenCalled();
+  });
+
+  it('walks past a taken name rather than failing', async () => {
+    const { db, service } = linking();
+    db.user.update
+      .mockRejectedValueOnce(uniqueViolation('username'))
+      .mockResolvedValueOnce({
+        id: 'g1',
+        username: 'ada_lovelace2',
+        email: 'a@b.co',
+      });
+    const result = await service.linkGoogleToGuest('g1', identity);
+    expect(result.username).toBe('ada_lovelace2');
+    expect(db.user.update).toHaveBeenCalledTimes(2);
+  });
+
+  it('turns a lost race on the provider link into a conflict, not a 500', async () => {
+    const { db, service } = linking();
+    db.user.update.mockRejectedValue(uniqueViolation('providerAccountId'));
+    await expect(
+      service.linkGoogleToGuest('g1', identity),
+    ).rejects.toMatchObject({
+      status: 409,
+    });
+  });
+});

--- a/video-sync-backend/src/auth/auth.service.ts
+++ b/video-sync-backend/src/auth/auth.service.ts
@@ -35,6 +35,45 @@ const isUniqueViolation = (err: unknown, field: string): boolean =>
     t.includes(field),
   );
 
+/**
+ * What a name, an address and a password have to be to open an account.
+ *
+ * One function, because there are two doors into the same table - register
+ * and claimGuestAccount - and for a while only the newer one checked
+ * anything. Validating the door you happen to be building reads as though
+ * the other was considered and passed. It had not been.
+ *
+ * Returns the cleaned values so callers cannot validate one string and then
+ * store a different one.
+ */
+export const credentialsOrThrow = (
+  username: string,
+  email: string,
+  password: string,
+): { username: string; email: string } => {
+  const cleanUsername = (username ?? '').trim();
+  const cleanEmail = (email ?? '').trim().toLowerCase();
+
+  if (!/^[a-zA-Z0-9_.-]{3,32}$/.test(cleanUsername)) {
+    throw new BadRequestException(
+      'Names are 3-32 characters: letters, numbers, dot, dash, underscore',
+    );
+  }
+  if (!/^[^@\s]+@[^@\s.]+\.[^@\s]+$/.test(cleanEmail)) {
+    throw new BadRequestException('That email address does not look right');
+  }
+  if (cleanEmail.endsWith('@guest.invalid')) {
+    // The address a guest row is born with. An account that keeps it can
+    // never receive a password reset.
+    throw new BadRequestException('Use an address you can actually receive');
+  }
+  if ((password ?? '').length < 8) {
+    throw new BadRequestException('Passwords are at least 8 characters');
+  }
+
+  return { username: cleanUsername, email: cleanEmail };
+};
+
 @Injectable()
 export class AuthService {
   constructor(
@@ -47,10 +86,16 @@ export class AuthService {
   }
 
   async register(username: string, email: string, password: string) {
+    const { username: cleanUsername, email: cleanEmail } = credentialsOrThrow(
+      username,
+      email,
+      password,
+    );
+
     // Check if user exists
     const existingUser = await this.database.user.findFirst({
       where: {
-        OR: [{ username }, { email }],
+        OR: [{ username: cleanUsername }, { email: cleanEmail }],
       },
     });
 
@@ -64,8 +109,8 @@ export class AuthService {
     // Create user
     const user = await this.database.user.create({
       data: {
-        username,
-        email,
+        username: cleanUsername,
+        email: cleanEmail,
         password: hashedPassword,
       },
       select: {
@@ -202,29 +247,11 @@ export class AuthService {
     email: string,
     password: string,
   ): Promise<SessionUser> {
-    const cleanUsername = (username ?? '').trim();
-    const cleanEmail = (email ?? '').trim().toLowerCase();
-
-    // Checked here rather than in a DTO because register/1 does not validate
-    // either, and putting a class-validator on one of the two doors would
-    // read as though the other had been considered and passed. It has not -
-    // see the known-gaps note.
-    if (!/^[a-zA-Z0-9_.-]{3,32}$/.test(cleanUsername)) {
-      throw new BadRequestException(
-        'Names are 3-32 characters: letters, numbers, dot, dash, underscore',
-      );
-    }
-    if (!/^[^@\s]+@[^@\s.]+\.[^@\s]+$/.test(cleanEmail)) {
-      throw new BadRequestException('That email address does not look right');
-    }
-    if (cleanEmail.endsWith('@guest.invalid')) {
-      // The address the guest row was born with. Keeping it would leave an
-      // account that can never receive a reset.
-      throw new BadRequestException('Use an address you can actually receive');
-    }
-    if ((password ?? '').length < 8) {
-      throw new BadRequestException('Passwords are at least 8 characters');
-    }
+    const { username: cleanUsername, email: cleanEmail } = credentialsOrThrow(
+      username,
+      email,
+      password,
+    );
 
     const current = await this.database.user.findUnique({
       where: { id: userId },
@@ -275,6 +302,124 @@ export class AuthService {
       }
       throw err;
     }
+  }
+
+  /**
+   * Attach a Google identity to the guest row already in use.
+   *
+   * The password path for this is claimGuestAccount; this is the same
+   * promise for someone who would rather not invent another password. Same
+   * rule, and the same reason: the row keeps its id, so the chat messages
+   * and participant rows pointing at it stay pointing at a live account.
+   *
+   * Order matters here. The provider link is checked BEFORE anything is
+   * written, because a Google account already attached to a real account
+   * must not be quietly moved onto a guest row - that would be an account
+   * takeover with the victim's own credentials.
+   */
+  async linkGoogleToGuest(
+    userId: string,
+    identity: GoogleIdentity,
+  ): Promise<SessionUser> {
+    const current = await this.database.user.findUnique({
+      where: { id: userId },
+      select: { id: true, isGuest: true },
+    });
+    if (!current) throw new UnauthorizedException('No such session');
+    if (!current.isGuest) {
+      throw new ForbiddenException({
+        code: 'link_not_guest',
+        message: 'This session is already a full account',
+      });
+    }
+
+    const email = identity.email.trim().toLowerCase();
+
+    // Already linked somewhere? Then this Google account belongs to that
+    // user, and the answer is to sign in as them - not to graft it onto a
+    // guest.
+    const existingLink = await this.database.oAuthAccount.findUnique({
+      where: {
+        provider_providerAccountId: {
+          provider: 'google',
+          providerAccountId: identity.subject,
+        },
+      },
+      select: { userId: true },
+    });
+    if (existingLink && existingLink.userId !== userId) {
+      throw new ConflictException({
+        // A CODE alongside the message, because the OAuth callback answers in
+        // a redirect fragment and that channel carries codes by design - the
+        // API does not know how the frontend words things, and a code cannot
+        // leak anything about the account it refused.
+        code: 'link_provider_taken',
+        message:
+          'That Google account is already signed in here - sign in with it instead',
+      });
+    }
+
+    // The address is unique on User, and we are about to take it.
+    const addressTaken = await this.database.user.findFirst({
+      where: { email, NOT: { id: userId } },
+      select: { id: true },
+    });
+    if (addressTaken) {
+      throw new ConflictException({
+        code: 'link_email_taken',
+        message:
+          'An account with that email already exists - sign in with it instead',
+      });
+    }
+
+    // A guest is called guest_1234, which is nobody's name. Take one from
+    // the Google profile, with the same collision walk registration uses.
+    const candidates = usernameCandidates(usernameBase(identity.name, email));
+
+    for (let attempt = 0; attempt < USERNAME_ATTEMPTS; attempt++) {
+      const username = candidates.next().value as string;
+      try {
+        const user = await this.database.user.update({
+          where: { id: userId, isGuest: true },
+          data: {
+            username,
+            email,
+            isGuest: false,
+            // password stays null: this account signs in with Google, and
+            // login() already refuses a null password rather than passing it
+            // to bcrypt
+            oauthAccounts: {
+              create: {
+                provider: 'google',
+                providerAccountId: identity.subject,
+              },
+            },
+          },
+          select: { id: true, username: true, email: true },
+        });
+        return { ...user, token: this.issueToken(user) };
+      } catch (err) {
+        if (isUniqueViolation(err, 'username')) continue;
+        if (isUniqueViolation(err, 'providerAccountId')) {
+          // lost a race with another flow linking the same Google account
+          throw new ConflictException({
+            code: 'link_provider_taken',
+            message:
+              'That Google account is already signed in here - sign in with it instead',
+          });
+        }
+        if (isUniqueViolation(err, 'email')) {
+          throw new ConflictException({
+            code: 'link_email_taken',
+            message:
+              'An account with that email already exists - sign in with it instead',
+          });
+        }
+        throw err;
+      }
+    }
+
+    throw new ConflictException('Could not allocate a name');
   }
 
   async signInWithGoogle(identity: GoogleIdentity): Promise<SessionUser> {

--- a/video-sync-backend/src/auth/google/google-oauth.service.ts
+++ b/video-sync-backend/src/auth/google/google-oauth.service.ts
@@ -165,7 +165,11 @@ export class GoogleOAuthService {
    * cookie IS the session for this flow, which is what lets any instance
    * behind the load balancer finish a flow another instance started.
    */
-  start(returnTo: string | undefined, now: number = Date.now()) {
+  start(
+    returnTo: string | undefined,
+    now: number = Date.now(),
+    linkUserId?: string,
+  ) {
     this.assertEnabled();
 
     const state = randomToken();
@@ -178,6 +182,7 @@ export class GoogleOAuthService {
       state,
       codeVerifier,
       returnTo: safeReturnTo(returnTo),
+      linkUserId,
       expiresAt: now + FLOW_TTL_MS,
     };
 
@@ -208,7 +213,12 @@ export class GoogleOAuthService {
     error?: string;
     cookie?: string;
     now?: number;
-  }): Promise<{ identity: GoogleIdentity; returnTo?: string }> {
+  }): Promise<{
+    identity: GoogleIdentity;
+    returnTo?: string;
+    /** set when this flow is attaching Google to a guest, not signing in */
+    linkUserId?: string;
+  }> {
     this.assertEnabled();
 
     if (params.error) throw new GoogleAuthError('denied');
@@ -276,6 +286,7 @@ export class GoogleOAuthService {
         name: payload.name,
       },
       returnTo: opened.returnTo,
+      linkUserId: opened.linkUserId,
     };
   }
 

--- a/video-sync-backend/src/auth/google/oauth-state.ts
+++ b/video-sync-backend/src/auth/google/oauth-state.ts
@@ -14,6 +14,17 @@ export interface OAuthStatePayload {
   codeVerifier: string;
   /** where to send the browser once we are done (a path on our own origin) */
   returnTo?: string;
+  /**
+   * The guest this flow is attaching Google to, if it is a link rather than
+   * a sign-in.
+   *
+   * It lives in the SEALED cookie rather than in the query string, and it is
+   * the id the server verified from a bearer token at /link-start - not
+   * anything the browser said about itself. A caller who could nominate the
+   * account to attach a Google identity to would be able to attach theirs to
+   * someone else's.
+   */
+  linkUserId?: string;
   /** absolute ms deadline - an abandoned flow must not stay resumable */
   expiresAt: number;
 }

--- a/video-sync-backend/src/config/configuration.ts
+++ b/video-sync-backend/src/config/configuration.ts
@@ -33,7 +33,10 @@ export default () => ({
     // no fallback secret: a deployment that forgets JWT_SECRET must fail to
     // boot, not silently issue tokens anyone can forge
     secret: requireOutsideLocal('JWT_SECRET', 'dev-only-insecure-secret'),
-    expiresIn: process.env.JWT_EXPIRES_IN || '7d',
+    // 12h, matching what auth.module actually issued while this value sat
+    // unread. The default changes the number here, not the behaviour: the
+    // old '7d' was never reaching anything.
+    expiresIn: process.env.JWT_EXPIRES_IN || '12h',
   },
   cors: {
     origin: process.env.FRONTEND_URL || 'http://localhost:3001',

--- a/video-sync-backend/src/config/configuration.ts
+++ b/video-sync-backend/src/config/configuration.ts
@@ -8,30 +8,62 @@
  * and the intuitive one is seconds. Anything else throws, at boot, where
  * somebody is watching.
  */
+const UNIT_SECONDS: Record<string, number> = {
+  ms: 0.001,
+  s: 1,
+  m: 60,
+  h: 3600,
+  d: 86400,
+  w: 604800,
+  // what `ms` uses for a year: 365.25 days
+  y: 31557600,
+};
+
 export const tokenLifetime = (raw: string | undefined): string | number => {
   const value = (raw ?? '').trim();
   if (!value) return '12h';
-  if (/^\d+$/.test(value)) {
-    const seconds = Number(value);
-    if (seconds <= 0) {
-      throw new Error(
-        `JWT_EXPIRES_IN must be positive, got "${value}"`,
+
+  const reject = (why: string): never => {
+    throw new Error(`JWT_EXPIRES_IN ${why}, got "${value}"`);
+  };
+
+  const digitsOnly = /^\d+$/.test(value);
+  let seconds: number;
+
+  if (digitsOnly) {
+    seconds = Number(value);
+    // A digit string long enough to overflow becomes Infinity, and an expiry
+    // of Infinity is not an expiry.
+    if (!Number.isFinite(seconds)) reject('is too large to be a duration');
+  } else {
+    // Lowercase units only, which is stricter than the `ms` library and
+    // deliberately so. ms is case-insensitive and has no unit for months, so
+    // "6M" - which reads as six months to anyone writing it - is parsed as
+    // six MINUTES. Refusing the whole uppercase space removes that reading
+    // rather than guessing which uppercase letters were meant innocently.
+    const match = /^(\d+(?:\.\d+)?)(ms|s|m|h|d|w|y)$/.exec(value);
+    if (!match) {
+      reject(
+        'must be a lowercase duration like "12h" or "30m", or a plain number of seconds',
       );
     }
-    return seconds;
+    const [, amount, unit] = match as RegExpExecArray;
+    seconds = Number(amount) * UNIT_SECONDS[unit];
+    if (!Number.isFinite(seconds)) reject('is too large to be a duration');
   }
-  // Lowercase units only, which is stricter than the `ms` library and
-  // deliberately so. ms is case-insensitive and has no unit for months, so
-  // "6M" - which reads as six months to anyone writing it - is parsed as six
-  // MINUTES. Refusing the whole uppercase space removes that reading rather
-  // than trying to guess which uppercase letters were meant innocently.
-  if (!/^\d+(\.\d+)?(ms|s|m|h|d|w|y)$/.test(value)) {
-    throw new Error(
-      `JWT_EXPIRES_IN must be a lowercase duration like "12h", "30m", or a ` +
-        `plain number of seconds, got "${value}"`,
-    );
+
+  // jsonwebtoken floors a duration to whole seconds, so anything under one
+  // second lands on exp === iat: a token expired the instant it is issued,
+  // with nothing in the logs to say so. "0.5s" and "999ms" both do it, and
+  // both look like perfectly reasonable configuration.
+  if (Math.floor(seconds) < 1) {
+    reject('is under one second, which issues tokens that are already expired');
   }
-  return value;
+
+  // Numbers are unambiguous to jsonwebtoken - it reads them as seconds.
+  // Unitless STRINGS are milliseconds, which is the trap all of this exists
+  // for, so a digit-only value is handed back as a number.
+  return digitsOnly ? seconds : value;
 };
 
 /**

--- a/video-sync-backend/src/config/configuration.ts
+++ b/video-sync-backend/src/config/configuration.ts
@@ -1,4 +1,40 @@
 /**
+ * How long a token is good for, in a form jsonwebtoken reads the way a person
+ * meant it.
+ *
+ * `ms`-style strings ('12h', '30m', '7d') pass through. A digit-only string
+ * becomes a NUMBER, because jsonwebtoken reads numbers as seconds and
+ * unitless strings as milliseconds - the two readings differ by a thousand,
+ * and the intuitive one is seconds. Anything else throws, at boot, where
+ * somebody is watching.
+ */
+export const tokenLifetime = (raw: string | undefined): string | number => {
+  const value = (raw ?? '').trim();
+  if (!value) return '12h';
+  if (/^\d+$/.test(value)) {
+    const seconds = Number(value);
+    if (seconds <= 0) {
+      throw new Error(
+        `JWT_EXPIRES_IN must be positive, got "${value}"`,
+      );
+    }
+    return seconds;
+  }
+  // Lowercase units only, which is stricter than the `ms` library and
+  // deliberately so. ms is case-insensitive and has no unit for months, so
+  // "6M" - which reads as six months to anyone writing it - is parsed as six
+  // MINUTES. Refusing the whole uppercase space removes that reading rather
+  // than trying to guess which uppercase letters were meant innocently.
+  if (!/^\d+(\.\d+)?(ms|s|m|h|d|w|y)$/.test(value)) {
+    throw new Error(
+      `JWT_EXPIRES_IN must be a lowercase duration like "12h", "30m", or a ` +
+        `plain number of seconds, got "${value}"`,
+    );
+  }
+  return value;
+};
+
+/**
  * Fail closed. A dev fallback is only safe where the environment says
  * explicitly that it is local: keying off `NODE_ENV === 'production'` meant
  * any unset or typo'd NODE_ENV (staging, preview, a container that forgot
@@ -33,10 +69,19 @@ export default () => ({
     // no fallback secret: a deployment that forgets JWT_SECRET must fail to
     // boot, not silently issue tokens anyone can forge
     secret: requireOutsideLocal('JWT_SECRET', 'dev-only-insecure-secret'),
-    // 12h, matching what auth.module actually issued while this value sat
-    // unread. The default changes the number here, not the behaviour: the
-    // old '7d' was never reaching anything.
-    expiresIn: process.env.JWT_EXPIRES_IN || '12h',
+    // 12h by DEFAULT, matching what auth.module issued while this value sat
+    // unread. A configured value now changes the lifetime; nothing else does.
+    //
+    // Validated rather than passed through, because making dead config live
+    // turns a harmless typo into a live hazard: jsonwebtoken parses a string
+    // with the `ms` library, and a UNITLESS string is milliseconds. So
+    // JWT_EXPIRES_IN=3600, which anyone would read as an hour, would issue
+    // tokens good for 3.6 SECONDS - every session dying instantly, with
+    // nothing in the logs to say why. A digit-only value is therefore
+    // converted to a number, which jsonwebtoken reads as seconds, and
+    // anything it cannot parse stops the boot instead of quietly becoming
+    // nonsense.
+    expiresIn: tokenLifetime(process.env.JWT_EXPIRES_IN),
   },
   cors: {
     origin: process.env.FRONTEND_URL || 'http://localhost:3001',

--- a/video-sync-backend/src/config/token-lifetime.spec.ts
+++ b/video-sync-backend/src/config/token-lifetime.spec.ts
@@ -1,0 +1,44 @@
+import { tokenLifetime } from './configuration';
+
+describe('JWT_EXPIRES_IN, once it actually does something', () => {
+  it('defaults to 12h when unset or blank', () => {
+    expect(tokenLifetime(undefined)).toBe('12h');
+    expect(tokenLifetime('')).toBe('12h');
+    expect(tokenLifetime('   ')).toBe('12h');
+  });
+
+  it('passes ms-style durations through', () => {
+    expect(tokenLifetime('12h')).toBe('12h');
+    expect(tokenLifetime('30m')).toBe('30m');
+    expect(tokenLifetime('7d')).toBe('7d');
+  });
+
+  it('reads a bare number as SECONDS, not milliseconds', () => {
+    // The hazard that arrived with making this config live: jsonwebtoken
+    // parses strings with `ms`, where a unitless string is milliseconds. So
+    // JWT_EXPIRES_IN=3600 - which anyone would read as an hour - would issue
+    // tokens good for 3.6 seconds, killing every session instantly with
+    // nothing in the logs to say why. A number is unambiguous: jsonwebtoken
+    // reads it as seconds.
+    expect(tokenLifetime('3600')).toBe(3600);
+    expect(typeof tokenLifetime('3600')).toBe('number');
+  });
+
+  it('refuses nonsense at boot rather than issuing something surprising', () => {
+    expect(() => tokenLifetime('twelve hours')).toThrow(/JWT_EXPIRES_IN/);
+    expect(() => tokenLifetime('12 fortnights')).toThrow(/JWT_EXPIRES_IN/);
+    expect(() => tokenLifetime('-5')).toThrow(/JWT_EXPIRES_IN/);
+    expect(() => tokenLifetime('0')).toThrow(/positive/);
+  });
+
+  it('refuses uppercase rather than guessing what it meant', () => {
+    // The `ms` library is case-insensitive and has no unit for months, so
+    // "6M" - six months to anyone writing it - parses as six MINUTES, a
+    // factor of about forty thousand. My first version of this validator had
+    // a case-insensitive regex and would have passed it straight through.
+    // Refusing the whole uppercase space removes the reading instead of
+    // guessing which uppercase letters were innocent.
+    expect(() => tokenLifetime('6M')).toThrow(/lowercase/);
+    expect(() => tokenLifetime('12H')).toThrow(/lowercase/);
+  });
+});

--- a/video-sync-backend/src/config/token-lifetime.spec.ts
+++ b/video-sync-backend/src/config/token-lifetime.spec.ts
@@ -28,7 +28,28 @@ describe('JWT_EXPIRES_IN, once it actually does something', () => {
     expect(() => tokenLifetime('twelve hours')).toThrow(/JWT_EXPIRES_IN/);
     expect(() => tokenLifetime('12 fortnights')).toThrow(/JWT_EXPIRES_IN/);
     expect(() => tokenLifetime('-5')).toThrow(/JWT_EXPIRES_IN/);
-    expect(() => tokenLifetime('0')).toThrow(/positive/);
+  });
+
+  it('refuses anything under a second, which expires on arrival', () => {
+    // jsonwebtoken floors a duration to whole seconds, so these land on
+    // exp === iat - a token expired the instant it is issued, and nothing in
+    // the logs would say why. Both look like reasonable configuration.
+    expect(() => tokenLifetime('0.5s')).toThrow(/already expired/);
+    expect(() => tokenLifetime('999ms')).toThrow(/already expired/);
+    expect(() => tokenLifetime('0.9s')).toThrow(/already expired/);
+    expect(() => tokenLifetime('0')).toThrow(/already expired/);
+    // and the boundary holds from the other side
+    expect(tokenLifetime('1s')).toBe('1s');
+    expect(tokenLifetime('1000ms')).toBe('1000ms');
+    expect(tokenLifetime('1')).toBe(1);
+  });
+
+  it('refuses values too large to be an expiry at all', () => {
+    // a digit string long enough overflows to Infinity, and an expiry of
+    // Infinity is not an expiry
+    const huge = '9'.repeat(400);
+    expect(() => tokenLifetime(huge)).toThrow(/too large/);
+    expect(() => tokenLifetime(`${huge}d`)).toThrow(/too large/);
   });
 
   it('refuses uppercase rather than guessing what it meant', () => {

--- a/video-sync-frontend/src/components/ClaimAccount.tsx
+++ b/video-sync-frontend/src/components/ClaimAccount.tsx
@@ -1,0 +1,285 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import styled from '@emotion/styled';
+import { useAuth } from '../contexts/AuthContext';
+import { apiService } from '../services/api';
+import { toast } from 'react-hot-toast';
+import {
+  card,
+  color,
+  font,
+  input,
+  button,
+  buttonSm,
+  sectionLabel,
+} from '../theme';
+import { IconGoogle } from './Icons';
+
+// Extracted from HomePage so a guest can reach it from inside a room too.
+// It lived on the home page only, which meant the one moment someone most
+// wants to keep their account - after an evening in a room, with the chat
+// they wrote in front of them - was the one place they could not.
+
+const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 7, 5, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1000;
+`;
+
+const Card = styled.div`
+  ${card}
+  padding: 24px;
+  width: 100%;
+  max-width: 420px;
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+`;
+
+const Title = styled.h3`
+  margin: 0 0 8px;
+  font-family: ${font.display};
+  font-weight: 600;
+  font-size: 18px;
+  color: ${color.text};
+`;
+
+const Text = styled.p`
+  margin: 0 0 20px;
+  font-family: ${font.body};
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: ${color.dim};
+`;
+
+const Field = styled.label`
+  display: block;
+  margin-bottom: 14px;
+`;
+
+const FieldLabel = styled.span`
+  ${sectionLabel}
+  display: block;
+  margin-bottom: 6px;
+`;
+
+const FieldInput = styled.input`
+  ${input}
+  width: 100%;
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-end;
+`;
+
+const Secondary = styled.button`
+  ${button.secondary}
+`;
+
+const Primary = styled.button`
+  ${button.primary}
+`;
+
+const GoogleButton = styled.button`
+  ${button.secondary}
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 18px;
+`;
+
+// A rule, not decoration: the two routes to the same outcome should not read
+// as a ranked list, and "or" between them says they are alternatives.
+const Or = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0 0 18px;
+  font-family: ${font.body};
+  font-size: 11.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: ${color.faint};
+
+  &::before,
+  &::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: ${color.line};
+  }
+`;
+
+export const ClaimTrigger = styled.button`
+  ${buttonSm}
+  border-color: ${color.mustard};
+  color: ${color.mustard};
+`;
+
+/**
+ * Turn the guest session already in use into a real account.
+ *
+ * Two ways in, because a password is not the only thing people have: the
+ * form below, or Google - which attaches to the SAME row rather than making
+ * a second account, the whole point of both paths.
+ */
+export const ClaimAccountDialog: React.FC<{
+  onClose: () => void;
+  /** where to come back to after the Google round trip */
+  returnTo?: string;
+}> = ({ onClose, returnTo }) => {
+  const { user, claimAccount } = useAuth();
+  const [saving, setSaving] = useState(false);
+  const [googling, setGoogling] = useState(false);
+  const [googleOffered, setGoogleOffered] = useState(false);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const firstFieldRef = useRef<HTMLInputElement | null>(null);
+
+  // Asked at runtime, like the sign-in page does: one bundle is served to
+  // every environment, and a button for a provider the API has no
+  // credentials for is a dead end.
+  useEffect(() => {
+    let live = true;
+    apiService
+      .getProviders()
+      .then(({ data }) => live && setGoogleOffered(Boolean(data?.google)))
+      .catch(() => undefined);
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  // Dialog manners: focus moves in, Escape closes, focus returns to whatever
+  // opened it.
+  useEffect(() => {
+    triggerRef.current = document.activeElement as HTMLElement | null;
+    firstFieldRef.current?.focus();
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      triggerRef.current?.focus();
+      triggerRef.current = null;
+    };
+  }, [onClose]);
+
+  const submit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      const form = new FormData(e.currentTarget);
+      setSaving(true);
+      try {
+        await claimAccount(
+          String(form.get('username') ?? ''),
+          String(form.get('email') ?? ''),
+          String(form.get('password') ?? ''),
+        );
+        onClose();
+      } catch {
+        // claimAccount has already said what went wrong; the dialog stays
+        // open so the typed values are still there to correct
+      } finally {
+        setSaving(false);
+      }
+    },
+    [claimAccount, onClose],
+  );
+
+  const withGoogle = useCallback(async () => {
+    setGoogling(true);
+    try {
+      // A POST, not a link: the browser cannot put a bearer token on a
+      // navigation, and the alternative - the token in a query string -
+      // writes a credential into access logs and Referer headers. So the
+      // server hands back the URL and we go there ourselves.
+      const { data } = await apiService.googleLinkStart(returnTo);
+      window.location.href = data.authUrl;
+    } catch {
+      toast.error("Couldn't start Google sign-in");
+      setGoogling(false);
+    }
+  }, [returnTo]);
+
+  if (!user) return null;
+
+  return (
+    <Overlay onClick={onClose}>
+      <Card
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="claim-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Title id="claim-title">Keep this account</Title>
+        <Text>
+          You are {user.username}, and you stay {user.username} — the same
+          account, so the rooms you have joined and the messages you have
+          already sent stay yours. This only adds a way back in.
+        </Text>
+
+        {googleOffered && (
+          <>
+            <GoogleButton type="button" onClick={withGoogle} disabled={googling}>
+              <IconGoogle size={18} />
+              {googling ? 'Taking you to Google…' : 'Continue with Google'}
+            </GoogleButton>
+            <Or>or</Or>
+          </>
+        )}
+
+        <form onSubmit={submit}>
+          <Field>
+            <FieldLabel>Name</FieldLabel>
+            <FieldInput
+              name="username"
+              ref={firstFieldRef}
+              defaultValue={user.username}
+              autoComplete="username"
+              required
+            />
+          </Field>
+          <Field>
+            <FieldLabel>Email</FieldLabel>
+            <FieldInput
+              name="email"
+              type="email"
+              placeholder="you@example.com"
+              autoComplete="email"
+              required
+            />
+          </Field>
+          <Field>
+            <FieldLabel>Password</FieldLabel>
+            <FieldInput
+              name="password"
+              type="password"
+              minLength={8}
+              placeholder="At least 8 characters"
+              autoComplete="new-password"
+              required
+            />
+          </Field>
+          <Buttons>
+            <Secondary type="button" onClick={onClose}>
+              Not now
+            </Secondary>
+            <Primary type="submit" disabled={saving}>
+              {saving ? 'Saving…' : 'Keep it'}
+            </Primary>
+          </Buttons>
+        </form>
+      </Card>
+    </Overlay>
+  );
+};

--- a/video-sync-frontend/src/components/ClaimAccount.tsx
+++ b/video-sync-frontend/src/components/ClaimAccount.tsx
@@ -142,6 +142,7 @@ export const ClaimAccountDialog: React.FC<{
   const [googleOffered, setGoogleOffered] = useState(false);
   const triggerRef = useRef<HTMLElement | null>(null);
   const firstFieldRef = useRef<HTMLInputElement | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
 
   // Asked at runtime, like the sign-in page does: one bundle is served to
   // every environment, and a button for a provider the API has no
@@ -157,14 +158,40 @@ export const ClaimAccountDialog: React.FC<{
     };
   }, []);
 
-  // Dialog manners: focus moves in, Escape closes, focus returns to whatever
-  // opened it.
+  // Dialog manners: focus moves in, Escape closes, Tab stays inside, and
+  // focus returns to whatever opened it.
   useEffect(() => {
     triggerRef.current = document.activeElement as HTMLElement | null;
     firstFieldRef.current?.focus();
 
+    const FOCUSABLE =
+      'input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])';
+
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      // aria-modal="true" tells a screen reader this is modal; it does not
+      // stop Tab. Without this, tabbing walks straight out onto the page
+      // behind the overlay - invisible, still reachable by keyboard, and in
+      // a room that page has controls that change what everyone is watching.
+      // The settings dialog on the room page already does this; same pattern.
+      if (e.key !== 'Tab') return;
+      const focusable = Array.from(
+        cardRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? [],
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && (active === first || !cardRef.current?.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener('keydown', onKeyDown);
     return () => {
@@ -216,6 +243,7 @@ export const ClaimAccountDialog: React.FC<{
   return (
     <Overlay onClick={onClose}>
       <Card
+        ref={cardRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="claim-title"

--- a/video-sync-frontend/src/pages/AuthCallbackPage.tsx
+++ b/video-sync-frontend/src/pages/AuthCallbackPage.tsx
@@ -68,6 +68,25 @@ const EXPLANATIONS: Record<string, { title: string; body: string }> = {
     title: 'That email already has an account here',
     body: 'It was registered with a password. Sign in with that password - linking Google to an existing account is not something we do automatically, because we cannot tell from here that both are you.',
   },
+  // Attaching Google to a guest session has its own ways to fail, and none
+  // of them are "sign-in failed" - the person is already signed in. What
+  // they need is the specific next step.
+  link_provider_taken: {
+    title: 'That Google account already has an account here',
+    body: 'Sign in with it instead. Your guest session is still open in the other tab if you were in the middle of something - though signing in will replace it.',
+  },
+  link_email_taken: {
+    title: 'That email already has an account here',
+    body: 'Sign in with it instead. We do not merge two accounts automatically, because from here we cannot tell that both are you.',
+  },
+  link_not_guest: {
+    title: 'This account is already a full one',
+    body: 'Nothing to keep - you are signed in properly already.',
+  },
+  link: {
+    title: "Couldn't attach Google to this session",
+    body: 'Your guest session is untouched. Try again, or set a password instead.',
+  },
   exchange: {
     title: "Couldn't finish with Google",
     body: 'Google did not complete the exchange. Try again in a moment.',

--- a/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
+++ b/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useSocket } from '../contexts/SocketContext';
 import { useAuth } from '../contexts/AuthContext';
 import { EnhancedVideoPlayer } from '../components/EnhancedVideoPlayer';
 import { ChatPanel } from '../components/ChatPanel';
+import { ClaimAccountDialog } from '../components/ClaimAccount';
 import { EnhancedVoiceChat } from '../components/EnhancedVoiceChat';
 import { RoomSettings } from '../components/RoomSettings';
 import { apiService } from '../services/api';
@@ -138,6 +139,17 @@ const SecondaryAction = styled.button`
   ${button.secondary}
   ${buttonSm}
   ${actionTight}
+`;
+
+// Mustard-outlined rather than a third grey button: it is the only control
+// up here that is about the person rather than the room, and a guest should
+// be able to find it without reading every label.
+const ClaimAction = styled.button`
+  ${button.secondary}
+  ${buttonSm}
+  ${actionTight}
+  border-color: ${color.mustard};
+  color: ${color.mustard};
 `;
 
 const DangerAction = styled.button`
@@ -361,7 +373,12 @@ export const EnhancedRoomPage: React.FC = () => {
   const { roomCode } = useParams<{ roomCode: string }>();
   const navigate = useNavigate();
   const { socket, connected } = useSocket();
-  const { user, ready: authReady } = useAuth();
+  const { user, ready: authReady, isGuest } = useAuth();
+  // A guest in a room is the person with the most to lose from the session
+  // expiring - they are the author of the chat on screen. Until now the only
+  // way to keep it was on the home page, which meant leaving the room.
+  const [claimOpen, setClaimOpen] = useState(false);
+  const closeClaim = useCallback(() => setClaimOpen(false), []);
 
   const [room, setRoom] = useState<Room | null>(null);
   const [participants, setParticipants] = useState<Participant[]>([]);
@@ -678,6 +695,17 @@ export const EnhancedRoomPage: React.FC = () => {
           </Identity>
 
           <Actions>
+            {isGuest && (
+              <ClaimAction
+                type="button"
+                onClick={() => setClaimOpen(true)}
+                aria-label="Keep this account"
+                title="Guest sessions expire - keep this one, with everything in it"
+              >
+                <ActionLabel>Keep account</ActionLabel>
+              </ClaimAction>
+            )}
+
             <SecondaryAction type="button" onClick={handleShareRoom} aria-label="Share">
               <IconShare size={14} />
               <ActionLabel>Share</ActionLabel>
@@ -701,6 +729,16 @@ export const EnhancedRoomPage: React.FC = () => {
           </Actions>
         </TopBarInner>
       </TopBar>
+
+      {claimOpen && (
+        // Comes back to this room after the Google round trip, rather than
+        // to the home page - being bounced out of what you were watching is
+        // a poor reward for keeping your account.
+        <ClaimAccountDialog
+          onClose={closeClaim}
+          returnTo={`/room/${room.code}`}
+        />
+      )}
 
       <Grid>
         <MainColumn>

--- a/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
+++ b/video-sync-frontend/src/pages/EnhancedRoomPage.tsx
@@ -31,6 +31,7 @@ import {
   IconShare,
   IconSettings,
   IconLeave,
+  IconLock,
 } from '../components/Icons';
 
 const Page = styled.div`
@@ -702,6 +703,12 @@ export const EnhancedRoomPage: React.FC = () => {
                 aria-label="Keep this account"
                 title="Guest sessions expire - keep this one, with everything in it"
               >
+                {/* The icon is not decoration. Below 880px ActionLabel is
+                    display:none, and every other action here survives that
+                    because it also renders an icon - this one did not, so on
+                    a phone it was an empty outlined box. A guest on a phone
+                    is the main audience for this control. */}
+                <IconLock size={14} />
                 <ActionLabel>Keep account</ActionLabel>
               </ClaimAction>
             )}

--- a/video-sync-frontend/src/pages/HomePage.tsx
+++ b/video-sync-frontend/src/pages/HomePage.tsx
@@ -19,10 +19,10 @@ import {
   chipMono,
   ghostIconButton,
   card,
-  input,
   sectionLabel,
 } from '../theme';
 import { Wordmark, IconPlus, IconUsers, IconFilm, IconLock, IconX } from '../components/Icons';
+import { ClaimAccountDialog, ClaimTrigger } from '../components/ClaimAccount';
 
 const MEASUREMENTS_URL =
   'https://github.com/JonSnow1807/Mustard-Watch-Party/tree/main/docs/measurements';
@@ -535,30 +535,6 @@ const ModalButtons = styled.div`
   justify-content: flex-end;
 `;
 
-const ClaimButton = styled.button`
-  ${button.secondary}
-  padding: 6px 12px;
-  font-size: 12.5px;
-  border-color: ${color.mustard};
-  color: ${color.mustard};
-`;
-
-const Field = styled.label`
-  display: block;
-  margin-bottom: 14px;
-`;
-
-const FieldLabel = styled.span`
-  ${sectionLabel}
-  display: block;
-  margin-bottom: 6px;
-`;
-
-const FieldInput = styled.input`
-  ${input}
-  width: 100%;
-`;
-
 const DangerFilledButton = styled.button`
   ${button.danger}
   background: ${color.danger};
@@ -575,7 +551,7 @@ const DangerFilledButton = styled.button`
 
 export const HomePage: React.FC = () => {
   const navigate = useNavigate();
-  const { user, logout, isGuest, claimAccount } = useAuth();
+  const { user, logout, isGuest } = useAuth();
   // A snapshot, so the row does not churn while you are looking at it - but
   // re-taken whenever the session changes. Reading it once for the lifetime
   // of the component meant a sign-out followed by a different sign-in, with
@@ -650,49 +626,11 @@ export const HomePage: React.FC = () => {
     setDeleteModal({ show: true, room });
   };
 
+  // The dialog itself lives in components/ClaimAccount, so the room page can
+  // show the same one - a guest most wants to keep their account after an
+  // evening in a room, which was the one place this could not be reached.
   const [claimOpen, setClaimOpen] = useState(false);
-  const [claiming, setClaiming] = useState(false);
-  const claimTriggerRef = useRef<HTMLElement | null>(null);
-  const claimFirstFieldRef = useRef<HTMLInputElement | null>(null);
-
   const closeClaim = useCallback(() => setClaimOpen(false), []);
-
-  const submitClaim = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const form = new FormData(e.currentTarget);
-    setClaiming(true);
-    try {
-      await claimAccount(
-        String(form.get('username') ?? ''),
-        String(form.get('email') ?? ''),
-        String(form.get('password') ?? ''),
-      );
-      setClaimOpen(false);
-    } catch {
-      // claimAccount has already said what went wrong; the dialog stays open
-      // so the typed values are still there to correct
-    } finally {
-      setClaiming(false);
-    }
-  };
-
-  // Same dialog manners as the delete confirmation: focus in on open,
-  // Escape closes, focus returns to whatever opened it.
-  useEffect(() => {
-    if (!claimOpen) return;
-    claimTriggerRef.current = document.activeElement as HTMLElement | null;
-    claimFirstFieldRef.current?.focus();
-
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeClaim();
-    };
-    document.addEventListener('keydown', onKeyDown);
-    return () => {
-      document.removeEventListener('keydown', onKeyDown);
-      claimTriggerRef.current?.focus();
-      claimTriggerRef.current = null;
-    };
-  }, [claimOpen, closeClaim]);
 
   const hideDeleteModal = useCallback(() => {
     setDeleteModal({ show: false, room: null });
@@ -830,13 +768,13 @@ export const HomePage: React.FC = () => {
               POST /auth/claim updates the row in place, so the promise can
               now be kept and the button is honest. */}
           {isGuest && (
-            <ClaimButton
+            <ClaimTrigger
               type="button"
               onClick={() => setClaimOpen(true)}
               title="Guest sessions expire - keep this one, with everything in it"
             >
               Keep this account
-            </ClaimButton>
+            </ClaimTrigger>
           )}
           <SecondarySmButton type="button" onClick={logout}>
             Sign out
@@ -1070,64 +1008,7 @@ export const HomePage: React.FC = () => {
         </Section>
       </Content>
 
-      {claimOpen && (
-        <Overlay onClick={closeClaim}>
-          <ModalCard
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="claim-title"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <ModalTitle id="claim-title">Keep this account</ModalTitle>
-            <ModalText>
-              You are {user.username}, and you stay {user.username} — the same
-              account, so the rooms you have joined and the messages you have
-              already sent stay yours. This only adds a way back in.
-            </ModalText>
-            <form onSubmit={submitClaim}>
-              <Field>
-                <FieldLabel>Name</FieldLabel>
-                <FieldInput
-                  name="username"
-                  ref={claimFirstFieldRef}
-                  defaultValue={user.username}
-                  autoComplete="username"
-                  required
-                />
-              </Field>
-              <Field>
-                <FieldLabel>Email</FieldLabel>
-                <FieldInput
-                  name="email"
-                  type="email"
-                  placeholder="you@example.com"
-                  autoComplete="email"
-                  required
-                />
-              </Field>
-              <Field>
-                <FieldLabel>Password</FieldLabel>
-                <FieldInput
-                  name="password"
-                  type="password"
-                  minLength={8}
-                  placeholder="At least 8 characters"
-                  autoComplete="new-password"
-                  required
-                />
-              </Field>
-              <ModalButtons>
-                <SecondaryButton type="button" onClick={closeClaim}>
-                  Not now
-                </SecondaryButton>
-                <PrimaryButton type="submit" disabled={claiming}>
-                  {claiming ? 'Saving…' : 'Keep it'}
-                </PrimaryButton>
-              </ModalButtons>
-            </form>
-          </ModalCard>
-        </Overlay>
-      )}
+      {claimOpen && <ClaimAccountDialog onClose={closeClaim} />}
 
       {/* Delete Confirmation Modal */}
       {deleteModal.show && deleteModal.room && (

--- a/video-sync-frontend/src/services/api.ts
+++ b/video-sync-frontend/src/services/api.ts
@@ -96,6 +96,18 @@ export const apiService = {
   claim: (username: string, email: string, password: string) =>
     api.post('/auth/claim', { username, email, password }),
 
+  /**
+   * The same outcome as claim, for someone who would rather not invent
+   * another password: attach Google to the guest row already in use.
+   *
+   * A POST that RETURNS the URL rather than a link that navigates to it -
+   * the browser cannot put a bearer token on a navigation, and putting it in
+   * the query string would write a credential into access logs and Referer
+   * headers.
+   */
+  googleLinkStart: (returnTo?: string) =>
+    api.post<{ authUrl: string }>('/auth/google/link-start', { returnTo }),
+
   // Which sign-in methods this deployment can actually complete. Asked at
   // runtime rather than baked in at build: the frontend is one bundle served
   // to every environment, and a button for a provider the API has no


### PR DESCRIPTION
The four things I'd named as genuinely not built — the ones where a real person hits a dead end today.

## Google linking for guests

Claiming took a password, so someone who'd rather use Google had to make a *second* account — exactly the case guest access exists to avoid. `POST /auth/google/link-start` attaches a Google identity to the guest row already in use. Same rule as the password path: **the row keeps its id**, so the chat already on screen stays theirs.

Three decisions worth reading:

- **It's a POST that returns a URL**, not a link the browser follows. A navigation can't carry an `Authorization` header, and the alternative — token in the query string — writes a credential into access logs and `Referer` headers. So the browser asks for the URL and goes there itself.
- **The id sealed into the OAuth state is the one the guard verified from the token**, never anything the caller claimed. A caller who could nominate the account could attach their Google identity to someone else's.
- **The provider link is checked before anything is written.** Moving a Google account off a real user and onto a guest row would be an account takeover using the victim's own credentials.

Failures come back as **codes** — `link_provider_taken`, `link_email_taken`, `link_not_guest`. My first version sent the message text, which contradicts the contract this channel already had *and* the comment sitting directly above it: the API doesn't know how the frontend words things, and a code can't leak anything about the account it refused. Caught it while wiring the callback page.

## The dialog is reachable from a room

It lived on the home page only — so the one moment someone most wants to keep their account, after an evening in a room with the chat they wrote in front of them, was the one place they couldn't. Extracted to `components/ClaimAccount`, shown in both, and the Google round trip returns to the room rather than dumping them home.

## Both doors into the users table enforce the same rules

`register` validated **nothing** while `claim` checked three things. One `credentialsOrThrow` used by both, returning the cleaned values so a caller can't validate one string and store another. The test table runs every bad case against *both* doors, because a rule only one door knows about isn't a rule.

## `JWT_EXPIRES_IN` is no longer dead config

It was hardcoded to `12h` while `configuration.ts` advertised `7d` to nobody — the documented knob did nothing, and the two disagreed by a factor of fourteen. Now read, defaulting to `12h`: the number changes in one file, the behaviour in none.

---

**381 backend tests, 118 frontend.** Verified live against a real server: `link-start` refuses without a token (401), 404s when the provider is off, and `register` now rejects a short name and a short password.

**Not verified:** the Google round trip end to end. It needs a real Google sign-in in a browser, which I can't do — so the happy path of linking is covered by unit tests and reasoning only. Worth someone clicking once.

**Worth arguing with:** a linked account has `password: null` and no way to add one later, so Google becomes the only way in. That mirrors how Google-created accounts already work here, but it's a one-way door and I'd rather name it than let it be discovered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Guests can keep their account by setting a username, email, and password.
  - Guests can link a Google account and return to their current room afterward.
  - Account claiming is available consistently from the home and room pages.
  - Added clear messages for Google linking conflicts and failures.

- **Changes**
  - JWT tokens now default to a 12-hour lifetime.
  - Invalid token lifetime settings are rejected at startup.

- **Documentation**
  - Updated authentication and guest-access documentation with current capabilities and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->