### PR TITLE
feat: stop trusting a token before it expires, including the socket it opened

### DIFF
--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -193,11 +193,61 @@ joining a film.
 whole behaviour depends on infrastructure that only exists in production.
 Both wrong versions passed their unit tests.
 
+## Revocation
+
+A token can be taken out of circulation before it expires. Two levers, because
+they answer different questions:
+
+| | `POST /auth/logout` | `POST /auth/logout-all` |
+|---|---|---|
+| Scope | this one session | every session this account has |
+| Mechanism | the token's `jti` is recorded as revoked | the user's `tokenVersion` is bumped past what existing tokens claim |
+| For | signing out | a token that may have leaked |
+
+**The snapshot, and why the guard still does no IO.** Both planes check
+revocation on every request and every handshake, and both were built to do no
+database lookup at all. So `RevocationService` holds an in-memory snapshot —
+the jtis revoked in the last twelve hours, and the users who have ever revoked
+everything. Both sets are small by construction; for most deployments the
+second is empty. The check is a `Set.has` and a `Map.get`.
+
+**Postgres is the truth, Redis is only the news.** Revocation that forgets on
+restart is not revocation, and this deployment treats Redis as a cache that
+may be absent. So records go to Postgres; Redis pub/sub, when present, tells
+the other instances within a round trip. Without it they converge on the next
+refresh.
+
+**The honest staleness bound is 30 seconds.** If the pub/sub message never
+arrives — Redis down, a dropped subscription, an instance that booted while it
+was unreachable — another instance keeps honouring a revoked token until its
+next refresh. Thirty seconds, not twelve hours.
+
+**Sockets are closed, not just refused.** A connection authenticates once and
+is then trusted while it stays open, which used to mean signing out stopped
+the REST calls and left the person watching along. Revoking now closes the
+matching connections on both namespaces, and a periodic sweep closes any whose
+token has simply expired. The client is told `session-ended` with a reason
+first — a silent disconnect is indistinguishable from a blip, and the retry
+loop would reconnect forever with a dead token.
+
+**What is deliberately not covered**
+
+- **`relay-go` does not check revocation.** It verifies the signature and
+  nothing else, so a revoked token still satisfies the relay until it expires.
+  The relay carries timing traffic for a room the holder was already in;
+  closing that hole means giving the relay a view of the snapshot, which it
+  has no database or Redis connection for today.
+- **A token with no `jti`** — issued before this existed — cannot be revoked
+  individually. `logout` reports `{revoked: false}` rather than claiming a
+  success that did nothing. `logout-all` still reaches it.
+- **Signing out is best-effort on the client.** The local session is dropped
+  first and unconditionally; if the revoke call fails, the person is still
+  signed out of that machine and the token dies on its own schedule.
+
 ## Known gaps
 
-- No token refresh or revocation. A token is good for its configured lifetime
-  (12 hours by default), and a socket accepted at connect outlives its token
-  (`docs/SCALING.md`).
+- No token **refresh**. A session ends when its token expires; there is no
+  way to extend one without signing in again.
 - ~~`JWT_EXPIRES_IN` is dead config~~ — fixed. Tokens **default** to `12h` and
   a deployment can change that by setting the variable; it is no longer a
   fixed lifetime. `12h` is what was hardcoded while the config file

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -207,8 +207,9 @@ they answer different questions:
 **The snapshot, and why the guard still does no IO.** Both planes check
 revocation on every request and every handshake, and both were built to do no
 database lookup at all. So `RevocationService` holds an in-memory snapshot —
-the jtis revoked in the last twelve hours, and the users who have ever revoked
-everything. Both sets are small by construction; for most deployments the
+each revoked `jti` until the token it refuses would have expired anyway, and
+the users who have ever revoked everything. (Twelve hours is only the default
+lifetime; `JWT_EXPIRES_IN` moves it, and the retention moves with it.) Both sets are small by construction; for most deployments the
 second is empty. The check is a `Set.has` and a `Map.get`.
 
 **Postgres is the truth, Redis is only the news.** Revocation that forgets on

--- a/scripts/live-checks/revocation-check.mjs
+++ b/scripts/live-checks/revocation-check.mjs
@@ -135,13 +135,21 @@ ok('its socket is told as well', (await allEnded) === 'signed out everywhere',
 const back = await call('/auth/login', {
   body: { username: name, password: 'a-real-password' },
 });
-ok('signing in again gives a token that WORKS', back.status < 400 &&
-   (await call('/auth/me', { method: 'GET', token: back.body?.token })).status === 200,
+const backToken = back.body?.token;
+ok('signing in again gives a token that WORKS', Boolean(backToken) &&
+   (await call('/auth/me', { method: 'GET', token: backToken })).status === 200,
    'a new token issued at the old version would be refused instantly');
 
-const backSocket = connect(back.body.token);
-ok('and it opens a socket', (await backSocket.opened) === true);
-backSocket.socket.close();
+// Guarded, because a check that throws here takes the summary and the socket
+// cleanup with it - every result above would be lost to a TypeError about
+// the one thing that failed.
+if (backToken) {
+  const backSocket = connect(backToken);
+  ok('and it opens a socket', (await backSocket.opened) === true);
+  backSocket.socket.close();
+} else {
+  ok('and it opens a socket', false, 'no token to try with');
+}
 other.socket.close();
 first.socket.close();
 

--- a/scripts/live-checks/revocation-check.mjs
+++ b/scripts/live-checks/revocation-check.mjs
@@ -1,0 +1,149 @@
+// Does signing out actually stop the token - including the socket that was
+// already open?
+//
+// This is the half that unit tests cannot reach. Revocation crosses three
+// planes that were each built to be independent: the REST guard, the socket
+// handshake, and a connection that was authenticated once and then trusted
+// for as long as it stayed open. The last of those is the reason this
+// feature existed to be built, and a mock cannot tell you whether a real
+// socket got closed.
+//
+// Usage: node scripts/live-checks/revocation-check.mjs [http://localhost:3007]
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const require = createRequire(
+  join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    '..',
+    'video-sync-frontend',
+    'package.json',
+  ),
+);
+const { io } = require('socket.io-client');
+
+const BASE = (process.argv[2] ?? 'http://localhost:3007').replace(/\/$/, '');
+const API = `${BASE}/api`;
+const rnd = () => Math.random().toString(36).slice(2, 8);
+
+const call = async (path, { method = 'POST', body, token } = {}) => {
+  const r = await fetch(API + path, {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  return { status: r.status, body: await r.json().catch(() => null) };
+};
+
+let failed = 0;
+const ok = (label, cond, extra = '') => {
+  console.log(`${cond ? 'PASS ' : 'FAIL '} ${label}${extra ? ' - ' + extra : ''}`);
+  if (!cond) failed++;
+};
+
+const connect = (token) => {
+  const socket = io(BASE, { transports: ['websocket'], auth: { token } });
+  const opened = new Promise((r) => {
+    socket.on('connect', () => r(true));
+    socket.on('connect_error', (e) => r(String(e?.message ?? e)));
+    setTimeout(() => r('timeout'), 8000);
+  });
+  return { socket, opened };
+};
+
+// two sessions for the same person: a phone and a laptop
+const name = 'revoke' + rnd();
+const account = (
+  await call('/auth/register', {
+    body: { username: name, email: `${name}@example.com`, password: 'a-real-password' },
+  })
+).body;
+ok('SETUP: an account', Boolean(account?.token), account?.username);
+if (!account?.token) process.exit(1);
+
+const second = (
+  await call('/auth/login', { body: { username: name, password: 'a-real-password' } })
+).body;
+ok('SETUP: a second session for the same person', Boolean(second?.token));
+
+// both tokens work over REST, and both open sockets
+ok(
+  'both sessions work before anything is revoked',
+  (await call('/auth/me', { method: 'GET', token: account.token })).status === 200 &&
+    (await call('/auth/me', { method: 'GET', token: second.token })).status === 200,
+);
+
+const first = connect(account.token);
+const other = connect(second.token);
+ok('SETUP: both sockets connect', (await first.opened) === true && (await other.opened) === true);
+
+// the socket must be told, not just dropped: a silent disconnect is
+// indistinguishable from a blip and the client retries forever
+const ended = new Promise((r) => {
+  first.socket.on('session-ended', (m) => r(m?.reason ?? 'no reason'));
+  setTimeout(() => r(null), 8000);
+});
+
+// sign out ONE session
+const out = await call('/auth/logout', { token: account.token });
+ok('signing out reports that it revoked something', out.body?.revoked === true,
+   `status ${out.status} ${JSON.stringify(out.body)}`);
+
+const meAfter = await call('/auth/me', { method: 'GET', token: account.token });
+ok('the signed-out token is refused over REST', meAfter.status === 401,
+   `status ${meAfter.status}`);
+
+ok('and the OTHER session is untouched',
+   (await call('/auth/me', { method: 'GET', token: second.token })).status === 200);
+
+const reason = await ended;
+ok('the live socket was told why it is closing', reason === 'session signed out',
+   String(reason));
+
+await new Promise((r) => setTimeout(r, 400));
+ok('and it is actually closed', first.socket.connected === false);
+ok('while the other socket stays up', other.socket.connected === true);
+
+// a revoked token must not be able to open a NEW socket either
+const rejoin = connect(account.token);
+const rejoined = await rejoin.opened;
+ok('a signed-out token cannot open a new socket', rejoined !== true, String(rejoined));
+rejoin.socket.close();
+
+// now sign out EVERYWHERE, from the surviving session
+const allEnded = new Promise((r) => {
+  other.socket.on('session-ended', (m) => r(m?.reason ?? 'no reason'));
+  setTimeout(() => r(null), 8000);
+});
+const all = await call('/auth/logout-all', { token: second.token });
+ok('signing out everywhere bumps the version', typeof all.body?.version === 'number',
+   JSON.stringify(all.body));
+
+ok('the session that did it is refused too',
+   (await call('/auth/me', { method: 'GET', token: second.token })).status === 401);
+
+ok('its socket is told as well', (await allEnded) === 'signed out everywhere',
+   String(await allEnded));
+
+// and signing in again works, at the new version - the bug this would
+// otherwise hide is a fresh token being born already revoked
+const back = await call('/auth/login', {
+  body: { username: name, password: 'a-real-password' },
+});
+ok('signing in again gives a token that WORKS', back.status < 400 &&
+   (await call('/auth/me', { method: 'GET', token: back.body?.token })).status === 200,
+   'a new token issued at the old version would be refused instantly');
+
+const backSocket = connect(back.body.token);
+ok('and it opens a socket', (await backSocket.opened) === true);
+backSocket.socket.close();
+other.socket.close();
+first.socket.close();
+
+console.log(failed ? `\n${failed} FAILED` : '\nall passed');
+process.exit(failed ? 1 : 0);

--- a/video-sync-backend/prisma/migrations/20260813120000_token_revocation/migration.sql
+++ b/video-sync-backend/prisma/migrations/20260813120000_token_revocation/migration.sql
@@ -1,0 +1,31 @@
+-- Token revocation: a way to stop trusting a token before it expires.
+--
+-- Two levers, because they answer different questions. tokenVersion is
+-- "distrust everything this user holds" - one integer, every session gone.
+-- RevokedToken is "distrust this one session" - what an ordinary sign-out
+-- writes.
+
+-- Additive with a default and NOT NULL: a catalog change in PostgreSQL 11+,
+-- not a table rewrite, so existing rows are untouched and nobody waits.
+ALTER TABLE "User" ADD COLUMN "tokenVersion" INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE "RevokedToken" (
+    "jti" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RevokedToken_pkey" PRIMARY KEY ("jti")
+);
+
+-- The sweep deletes by expiry; nothing on the request path reads this table
+-- (the guard consults an in-memory snapshot), so these two serve the sweep
+-- and the cascade rather than any hot query.
+CREATE INDEX "RevokedToken_expiresAt_idx" ON "RevokedToken"("expiresAt");
+CREATE INDEX "RevokedToken_userId_idx" ON "RevokedToken"("userId");
+
+-- ON DELETE CASCADE: deleting a user should not be blocked by rows that
+-- exist only to distrust that user's tokens. The guest sweeper deletes
+-- users, and RESTRICT here would make it fail on anyone who had signed out.
+ALTER TABLE "RevokedToken" ADD CONSTRAINT "RevokedToken_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/video-sync-backend/prisma/schema.prisma
+++ b/video-sync-backend/prisma/schema.prisma
@@ -8,15 +8,15 @@ generator client {
 
 // The datasource block tells Prisma how to connect to your database
 datasource db {
-  provider = "postgresql"  // We're using PostgreSQL
-  url      = env("DATABASE_URL")  // Connection string from environment variable
+  provider = "postgresql" // We're using PostgreSQL
+  url      = env("DATABASE_URL") // Connection string from environment variable
 }
 
 // User model - represents people using your application
 model User {
-  id            String         @id @default(uuid())  // Unique identifier
-  username      String         @unique               // Must be unique across all users
-  email         String         @unique               // Email must also be unique
+  id            String         @id @default(uuid()) // Unique identifier
+  username      String         @unique // Must be unique across all users
+  email         String         @unique // Email must also be unique
   // Nullable since Google sign-in: an account that has only ever arrived
   // through a provider has no password, and a NOT NULL column would have
   // forced us to invent one (an unusable hash is still a login surface).
@@ -25,79 +25,88 @@ model User {
   password      String?
   /**
    * Someone who came in on an invite link without registering.
-   *
    * A real row rather than a rowless token, because three things already
    * depend on one existing: the socket handshake refuses a connection whose
    * token has no subject, and both Participant.userId and ChatMessage.userId
    * are foreign keys. A guest that is a User satisfies all three with no
    * branch anywhere downstream - see docs/GUEST_ACCESS.md.
-   *
    * The flag exists so these can be swept up later and so the UI can say
    * what someone is. Nothing else reads it: a guest is not less trusted
    * inside a room, they are just unregistered.
    */
   isGuest       Boolean        @default(false)
-  createdAt     DateTime       @default(now())      // Automatically set when created
-  updatedAt     DateTime       @updatedAt           // Automatically updated on changes
+  /**
+   * Bumped to invalidate every token this user currently holds.
+   * A token carries the version it was issued under; a mismatch is a
+   * refusal. This is the "sign out everywhere" lever and the answer to a
+   * leaked token - one integer, and every session that user has anywhere
+   * stops working at once.
+   * It is coarse on purpose. Revoking ONE session is RevokedToken below;
+   * this is for when you do not know which session to distrust.
+   */
+  tokenVersion  Int            @default(0)
+  createdAt     DateTime       @default(now()) // Automatically set when created
+  updatedAt     DateTime       @updatedAt // Automatically updated on changes
   chatMessages  ChatMessage[]
+  revokedTokens RevokedToken[]
 
   // Relations - these define how Users connect to other data
-  roomsCreated  Room[]         @relation("RoomCreator")    // Rooms this user created
-  participants  Participant[]                              // Room participations
-  oauthAccounts OAuthAccount[]                             // Linked provider identities
+  roomsCreated  Room[]         @relation("RoomCreator") // Rooms this user created
+  participants  Participant[] // Room participations
+  oauthAccounts OAuthAccount[] // Linked provider identities
 
   // Indexes improve query performance
-  @@index([email])      // Fast lookups by email
-  @@index([username])   // Fast lookups by username
+  @@index([email]) // Fast lookups by email
+  @@index([username]) // Fast lookups by username
   // the sweeper reads guests by age; without this it scans every user
   @@index([isGuest, createdAt])
 }
 
 // Room model - represents a video watching session
 model Room {
-  id            String         @id @default(uuid())
-  name          String                              // Human-readable room name
-  code          String         @unique @default(cuid())  // Unique code for joining
-  videoUrl      String?                            // Optional video URL
-  isActive      Boolean        @default(true)       // Is room currently active?
-  maxUsers      Int?                               // Optional maximum concurrent users (null = unlimited)
-  createdAt     DateTime       @default(now())
-  updatedAt     DateTime       @updatedAt
-  chatMessages  ChatMessage[]
-  isPublic      Boolean        @default(false)
-  description   String?
-  tags          String[]       @default([])
-  allowGuestControl Boolean    @default(false)      // Allow non-hosts to control video
-  
+  id                String        @id @default(uuid())
+  name              String // Human-readable room name
+  code              String        @unique @default(cuid()) // Unique code for joining
+  videoUrl          String? // Optional video URL
+  isActive          Boolean       @default(true) // Is room currently active?
+  maxUsers          Int? // Optional maximum concurrent users (null = unlimited)
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+  chatMessages      ChatMessage[]
+  isPublic          Boolean       @default(false)
+  description       String?
+  tags              String[]      @default([])
+  allowGuestControl Boolean       @default(false) // Allow non-hosts to control video
+
   // Video synchronization state
-  currentTime   Float          @default(0)          // Current video position in seconds
-  isPlaying     Boolean        @default(false)      // Is video playing or paused?
-  lastSyncAt    DateTime       @default(now())      // Last time sync occurred
-  
+  currentTime Float    @default(0) // Current video position in seconds
+  isPlaying   Boolean  @default(false) // Is video playing or paused?
+  lastSyncAt  DateTime @default(now()) // Last time sync occurred
+
   // Relations
-  creatorId     String                              // Who created this room
-  creator       User           @relation("RoomCreator", fields: [creatorId], references: [id])
-  participants  Participant[]                       // Who's in this room
-  syncEvents    SyncEvent[]                         // History of sync events
-  
-  @@index([code])        // Fast room lookups by code
-  @@index([isActive])    // Fast queries for active rooms
+  creatorId    String // Who created this room
+  creator      User          @relation("RoomCreator", fields: [creatorId], references: [id])
+  participants Participant[] // Who's in this room
+  syncEvents   SyncEvent[] // History of sync events
+
+  @@index([code]) // Fast room lookups by code
+  @@index([isActive]) // Fast queries for active rooms
 }
 
 // Participant model - represents a user in a room
 model Participant {
-  id            String         @id @default(uuid())
-  joinedAt      DateTime       @default(now())      // When they joined
-  leftAt        DateTime?                           // When they left (null if still in)
-  isActive      Boolean        @default(true)       // Currently in room?
-  lastPingAt    DateTime       @default(now())      // For connection monitoring
-  
+  id         String    @id @default(uuid())
+  joinedAt   DateTime  @default(now()) // When they joined
+  leftAt     DateTime? // When they left (null if still in)
+  isActive   Boolean   @default(true) // Currently in room?
+  lastPingAt DateTime  @default(now()) // For connection monitoring
+
   // Relations
-  userId        String
-  user          User           @relation(fields: [userId], references: [id])
-  roomId        String
-  room          Room           @relation(fields: [roomId], references: [id])
-  
+  userId String
+  user   User   @relation(fields: [userId], references: [id])
+  roomId String
+  room   Room   @relation(fields: [roomId], references: [id])
+
   // Ensure a user can only be in a room once
   @@unique([userId, roomId])
   // Fast queries for active participants in a room
@@ -106,30 +115,30 @@ model Participant {
 
 // SyncEvent model - tracks synchronization history
 model SyncEvent {
-  id            String         @id @default(uuid())
-  type          EventType                           // What kind of event
-  timestamp     DateTime       @default(now())      // When it happened
-  videoTime     Float                              // Video position at event time
-  
+  id        String    @id @default(uuid())
+  type      EventType // What kind of event
+  timestamp DateTime  @default(now()) // When it happened
+  videoTime Float // Video position at event time
+
   // Relations
-  roomId        String
-  room          Room           @relation(fields: [roomId], references: [id])
-  
+  roomId String
+  room   Room   @relation(fields: [roomId], references: [id])
+
   // Fast queries for room event history
   @@index([roomId, timestamp])
 }
 
 model ChatMessage {
-  id            String         @id @default(uuid())
-  content       String
-  createdAt     DateTime       @default(now())
-  
+  id        String   @id @default(uuid())
+  content   String
+  createdAt DateTime @default(now())
+
   // Relations
-  userId        String
-  user          User           @relation(fields: [userId], references: [id])
-  roomId        String
-  room          Room           @relation(fields: [roomId], references: [id])
-  
+  userId String
+  user   User   @relation(fields: [userId], references: [id])
+  roomId String
+  room   Room   @relation(fields: [roomId], references: [id])
+
   @@index([roomId, createdAt])
 }
 
@@ -143,8 +152,8 @@ model ChatMessage {
 // to at most one local user.
 model OAuthAccount {
   id                String   @id @default(uuid())
-  provider          String                            // 'google'
-  providerAccountId String                            // the provider's stable subject ('sub')
+  provider          String // 'google'
+  providerAccountId String // the provider's stable subject ('sub')
   // Kept for support/debugging only. NEVER used to find a user: matching an
   // incoming provider email against local accounts is how OAuth becomes
   // account takeover when local emails are unverified.
@@ -152,8 +161,8 @@ model OAuthAccount {
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 
-  userId            String
-  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
   @@index([userId])
@@ -161,9 +170,41 @@ model OAuthAccount {
 
 // EventType enum - possible synchronization events
 enum EventType {
-  PLAY      // User pressed play
-  PAUSE     // User pressed pause
-  SEEK      // User jumped to different time
-  JOIN      // User joined room
-  LEAVE     // User left room
+  PLAY // User pressed play
+  PAUSE // User pressed pause
+  SEEK // User jumped to different time
+  JOIN // User joined room
+  LEAVE // User left room
+}
+
+/**
+ * A single token taken out of circulation before it expired - what an
+ * ordinary sign-out writes.
+ * Postgres rather than Redis is deliberate: revocation that forgets on
+ * restart is not revocation, and this deployment treats Redis as a cache
+ * that may be absent (docs/SCALING.md). Redis still carries the
+ * NOTIFICATION so other instances drop the token from memory promptly; the
+ * truth is here.
+ * Rows are useless once the token would have expired anyway, so expiresAt
+ * is kept and swept nightly. Without that this table grows forever with
+ * entries no check can ever match.
+ */
+model RevokedToken {
+  /**
+   * the token's jti claim
+   */
+  jti       String   @id
+  userId    String
+  /**
+   * when the token would have expired on its own - the sweep boundary
+   */
+  expiresAt DateTime
+  revokedAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  // the sweeper deletes by expiry; the guard never queries this table at
+  // all (it reads an in-memory snapshot), so this index serves the sweep
+  @@index([expiresAt])
+  @@index([userId])
 }

--- a/video-sync-backend/src/auth/auth.controller.spec.ts
+++ b/video-sync-backend/src/auth/auth.controller.spec.ts
@@ -2,6 +2,10 @@ import { ConflictException, Logger, NotFoundException } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { JwtService } from '@nestjs/jwt';
+import type { RevocationService } from './revocation.service';
+
+const jwtService = new JwtService({ secret: 'test-secret' });
 import { GoogleOAuthService } from './google/google-oauth.service';
 
 /** Just enough Response to see what the handler decided. */
@@ -49,10 +53,20 @@ const makeGoogle = (enabled: boolean) => {
   } as unknown as GoogleOAuthService;
 };
 
+/** Revoked nothing, which is what every test here but the logout ones assume. */
+const noRevocations = () =>
+  ({
+    isRevoked: () => null,
+    revokeToken: jest.fn().mockResolvedValue(undefined),
+    revokeAllForUser: jest.fn().mockResolvedValue(2),
+  }) as unknown as RevocationService;
+
 const controllerWith = (enabled: boolean) =>
   new AuthController(
     { signInWithGoogle: jest.fn() } as unknown as AuthService,
     makeGoogle(enabled),
+    noRevocations(),
+    jwtService,
   );
 
 const emptyReq = { headers: {} } as Request;
@@ -148,6 +162,8 @@ describe('the guest route under two limits at once', () => {
     const controller = new AuthController(
       { createGuest } as unknown as AuthService,
       makeGoogle(false),
+      noRevocations(),
+      jwtService,
     );
     return { controller, createGuest };
   };
@@ -265,7 +281,12 @@ describe('starting a link, which is a different thing from signing in', () => {
     // the account would be able to attach their Google identity to someone
     // else's.
     const { google, start } = makeLinkGoogle();
-    const controller = new AuthController({} as unknown as AuthService, google);
+    const controller = new AuthController(
+      {} as unknown as AuthService,
+      google,
+      noRevocations(),
+      jwtService,
+    );
     const res = makeRes();
 
     const out = controller.linkStart(
@@ -289,11 +310,12 @@ describe('starting a link, which is a different thing from signing in', () => {
     // address bar, and the flow would silently go nowhere.
     const { google } = makeLinkGoogle();
     const res = makeRes();
-    new AuthController({} as unknown as AuthService, google).linkStart(
-      'u1',
-      {},
-      res as unknown as Response,
-    );
+    new AuthController(
+      {} as unknown as AuthService,
+      google,
+      noRevocations(),
+      jwtService,
+    ).linkStart('u1', {}, res as unknown as Response);
     expect(res.redirectedTo).toBeUndefined();
   });
 });
@@ -317,6 +339,8 @@ describe('what the callback tells someone when it fails', () => {
     const controller = new AuthController(
       { signInWithGoogle } as unknown as AuthService,
       google,
+      noRevocations(),
+      jwtService,
     );
     return { controller, logger };
   };

--- a/video-sync-backend/src/auth/auth.controller.spec.ts
+++ b/video-sync-backend/src/auth/auth.controller.spec.ts
@@ -422,3 +422,74 @@ describe('what the callback tells someone when it fails', () => {
     expect(res.redirectedTo).not.toContain('detail');
   });
 });
+
+describe('signing out', () => {
+  const withRevocations = () => {
+    const revocations = {
+      isRevoked: () => null,
+      revokeToken: jest.fn().mockResolvedValue(undefined),
+      revokeAllForUser: jest.fn().mockResolvedValue(4),
+    };
+    const controller = new AuthController(
+      {} as unknown as AuthService,
+      makeGoogle(false),
+      revocations as unknown as RevocationService,
+      jwtService,
+    );
+    return { controller, revocations };
+  };
+
+  const bearing = (token: string) =>
+    ({ headers: { authorization: `Bearer ${token}` } }) as Request;
+
+  it('revokes the token the request arrived on', async () => {
+    const { controller, revocations } = withRevocations();
+    const token = jwtService.sign({ sub: 'u1', name: 'ada', jti: 'j1' });
+
+    await expect(controller.logout(bearing(token))).resolves.toEqual({
+      revoked: true,
+    });
+
+    const [jti, userId] = (
+      revocations.revokeToken.mock.calls as [string, string, Date][]
+    )[0];
+    expect(jti).toBe('j1');
+    expect(userId).toBe('u1');
+  });
+
+  it('says so honestly when the token cannot be revoked individually', async () => {
+    // Tokens issued before jti existed carry none. Reporting success would
+    // tell someone their session was ended when it was not.
+    const { controller, revocations } = withRevocations();
+    const token = jwtService.sign({ sub: 'u1', name: 'ada' });
+
+    await expect(controller.logout(bearing(token))).resolves.toEqual({
+      revoked: false,
+    });
+    expect(revocations.revokeToken).not.toHaveBeenCalled();
+  });
+
+  it('keeps the revocation record only as long as the token would have lived', async () => {
+    const { controller, revocations } = withRevocations();
+    const token = jwtService.sign(
+      { sub: 'u1', name: 'ada', jti: 'j1' },
+      { expiresIn: '1h' },
+    );
+
+    await controller.logout(bearing(token));
+
+    const [, , expiresAt] = (
+      revocations.revokeToken.mock.calls as [string, string, Date][]
+    )[0];
+    const hourAway = Date.now() + 3600_000;
+    // within a minute of an hour from now, not 1970 - the exp claim is in
+    // SECONDS and treating it as milliseconds would put it in the past
+    expect(Math.abs(expiresAt.getTime() - hourAway)).toBeLessThan(60_000);
+  });
+
+  it('signs out everywhere by bumping the version, and reports it', async () => {
+    const { controller, revocations } = withRevocations();
+    await expect(controller.logoutAll('u1')).resolves.toEqual({ version: 4 });
+    expect(revocations.revokeAllForUser).toHaveBeenCalledWith('u1');
+  });
+});

--- a/video-sync-backend/src/auth/auth.controller.ts
+++ b/video-sync-backend/src/auth/auth.controller.ts
@@ -14,6 +14,9 @@ import {
 import type { Request, Response } from 'express';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './jwt-auth.guard';
+import { JwtService } from '@nestjs/jwt';
+import { RevocationService } from './revocation.service';
+import type { TokenPayload } from './token-payload';
 import { CurrentUser } from './current-user.decorator';
 import {
   GoogleAuthError,
@@ -32,6 +35,8 @@ export class AuthController {
   constructor(
     private authService: AuthService,
     private google: GoogleOAuthService,
+    private readonly revocations: RevocationService,
+    private readonly jwt: JwtService,
   ) {}
 
   /** 10 guests per IP per hour, refilling steadily rather than all at once. */
@@ -195,6 +200,64 @@ export class AuthController {
       dto.email,
       dto.password,
     );
+  }
+
+  /**
+   * Stop trusting the token this request arrived on.
+   *
+   * Sign-out used to be a client-side event: the browser dropped the token
+   * and the server never heard about it. Anyone holding a copy - a shared
+   * machine, a proxy log, a screenshot of a URL from before the fragment
+   * fix - kept a working session for the rest of its twelve hours.
+   *
+   * Reads the token again here rather than trusting the guard's decoded
+   * user, because the jti and exp are needed and the guard only attaches
+   * identity. Same token, same secret, verified twice - cheap.
+   */
+  @Post('logout')
+  @UseGuards(JwtAuthGuard)
+  async logout(@Req() req: Request): Promise<{ revoked: boolean }> {
+    const payload = this.decodeOwnToken(req);
+    if (!payload?.jti || !payload.sub) {
+      // A token from before jti existed. It cannot be revoked individually,
+      // and saying so is better than reporting a success that did nothing.
+      return { revoked: false };
+    }
+    await this.revocations.revokeToken(
+      payload.jti,
+      payload.sub,
+      // exp is in SECONDS; the record only has to outlive the token itself
+      new Date((payload.exp ?? Math.floor(Date.now() / 1000) + 43200) * 1000),
+    );
+    return { revoked: true };
+  }
+
+  /**
+   * Stop trusting everything this account holds, everywhere.
+   *
+   * The answer to "my token leaked" or "I left myself signed in somewhere I
+   * cannot get back to". One integer moves and every session that account
+   * has - phone, laptop, a socket someone left open - stops at once.
+   */
+  @Post('logout-all')
+  @UseGuards(JwtAuthGuard)
+  async logoutAll(
+    @CurrentUser('userId') userId: string,
+  ): Promise<{ version: number }> {
+    const version = await this.revocations.revokeAllForUser(userId);
+    return { version };
+  }
+
+  /** The raw token off the request, for the claims the guard does not keep. */
+  private decodeOwnToken(req: Request): TokenPayload | null {
+    const header = req.headers?.authorization;
+    const token = header?.trim().split(/\s+/)[1];
+    if (!token) return null;
+    try {
+      return this.jwt.verify<TokenPayload>(token);
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/video-sync-backend/src/auth/auth.module.ts
+++ b/video-sync-backend/src/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { GoogleOAuthService } from './google/google-oauth.service';
 import { GuestSweeperService } from './guest-sweeper.service';
+import { RevocationService } from './revocation.service';
 
 @Module({
   imports: [
@@ -31,7 +32,15 @@ import { GuestSweeperService } from './guest-sweeper.service';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, GoogleOAuthService, GuestSweeperService],
-  exports: [AuthService, JwtModule],
+  providers: [
+    AuthService,
+    GoogleOAuthService,
+    GuestSweeperService,
+    RevocationService,
+  ],
+  // RevocationService is exported because JwtAuthGuard depends on it, and
+  // that guard is instantiated in whichever module uses it - rooms, sync -
+  // not here. An unexported provider would fail those modules at boot.
+  exports: [AuthService, JwtModule, RevocationService],
 })
 export class AuthModule {}

--- a/video-sync-backend/src/auth/auth.service.ts
+++ b/video-sync-backend/src/auth/auth.service.ts
@@ -81,8 +81,30 @@ export class AuthService {
     private jwt: JwtService,
   ) {}
 
-  private issueToken(user: { id: string; username: string }): string {
-    return this.jwt.sign({ sub: user.id, name: user.username });
+  /**
+   * Mint a session token.
+   *
+   * `tokenVersion` is REQUIRED rather than optional, and that is the whole
+   * defence against the worst bug this feature can have: a token issued
+   * carrying version 0 for a user whose version has moved on is refused the
+   * instant it is used. Someone signs in, gets a token, and is immediately
+   * signed out again, with the logs saying only "revoked". Making the type
+   * demand it means the compiler finds every issuance site instead of me.
+   *
+   * The jti is what lets ONE session be revoked later; without it the only
+   * lever is the version, which takes out every session the user has.
+   */
+  private issueToken(user: {
+    id: string;
+    username: string;
+    tokenVersion: number;
+  }): string {
+    return this.jwt.sign({
+      sub: user.id,
+      name: user.username,
+      jti: randomUUID(),
+      ver: user.tokenVersion,
+    });
   }
 
   async register(username: string, email: string, password: string) {
@@ -118,6 +140,7 @@ export class AuthService {
         username: true,
         email: true,
         createdAt: true,
+        tokenVersion: true,
       },
     });
 
@@ -188,7 +211,7 @@ export class AuthService {
             password: null,
             isGuest: true,
           },
-          select: { id: true, username: true, email: true },
+          select: { id: true, username: true, email: true, tokenVersion: true },
         });
         return { ...user, token: this.issueToken(user) };
       } catch (err) {
@@ -206,7 +229,7 @@ export class AuthService {
   async me(userId: string) {
     const user = await this.database.user.findUnique({
       where: { id: userId },
-      select: { id: true, username: true, email: true },
+      select: { id: true, username: true, email: true, tokenVersion: true },
     });
     if (!user) {
       // A valid signature over a user that no longer exists - a deleted
@@ -288,7 +311,7 @@ export class AuthService {
           password: hashedPassword,
           isGuest: false,
         },
-        select: { id: true, username: true, email: true },
+        select: { id: true, username: true, email: true, tokenVersion: true },
       });
       // A fresh token: the old one carries the guest name, which is about to
       // be wrong everywhere it is displayed.
@@ -395,7 +418,7 @@ export class AuthService {
               },
             },
           },
-          select: { id: true, username: true, email: true },
+          select: { id: true, username: true, email: true, tokenVersion: true },
         });
         return { ...user, token: this.issueToken(user) };
       } catch (err) {
@@ -448,7 +471,16 @@ export class AuthService {
           providerAccountId: subject,
         },
       },
-      select: { user: { select: { id: true, username: true, email: true } } },
+      select: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            email: true,
+            tokenVersion: true,
+          },
+        },
+      },
     });
     return linked
       ? { ...linked.user, token: this.issueToken(linked.user) }
@@ -481,7 +513,7 @@ export class AuthService {
               },
             },
           },
-          select: { id: true, username: true, email: true },
+          select: { id: true, username: true, email: true, tokenVersion: true },
         });
         return { ...user, token: this.issueToken(user) };
       } catch (err) {

--- a/video-sync-backend/src/auth/jwt-auth.guard.spec.ts
+++ b/video-sync-backend/src/auth/jwt-auth.guard.spec.ts
@@ -219,9 +219,13 @@ describe('a token that is signed, unexpired, and no longer trusted', () => {
 
   it('refuses a token whose session was signed out', () => {
     const token = jwt.sign({ sub: 'u1', name: 'ada', jti: 'j1' });
+    // The exact text, not /signed out/ - which also matches the account-wide
+    // message, so a guard that reported "all sessions" for both reasons would
+    // pass this and the test below. Telling them apart is the entire point of
+    // returning a reason.
     expect(() =>
       guardRefusing('token').canActivate(ctx(bearer(token))),
-    ).toThrow(/signed out/);
+    ).toThrow('This session was signed out - sign in again');
   });
 
   it('says something different when every session was signed out', () => {
@@ -229,7 +233,7 @@ describe('a token that is signed, unexpired, and no longer trusted', () => {
     // somebody else responding to a compromise.
     const token = jwt.sign({ sub: 'u1', name: 'ada', jti: 'j1' });
     expect(() => guardRefusing('user').canActivate(ctx(bearer(token)))).toThrow(
-      /All sessions/,
+      'All sessions were signed out - sign in again',
     );
   });
 

--- a/video-sync-backend/src/auth/jwt-auth.guard.spec.ts
+++ b/video-sync-backend/src/auth/jwt-auth.guard.spec.ts
@@ -2,6 +2,7 @@ import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { JwtService, JwtSignOptions } from '@nestjs/jwt';
 import type { Socket } from 'socket.io';
 import { AuthedRequest, JwtAuthGuard } from './jwt-auth.guard';
+import type { RevocationService } from './revocation.service';
 import { currentUser } from './current-user.decorator';
 import type { TokenPayload } from './token-payload';
 import { wsAuthMiddleware, AuthedSocketData } from '../sync/ws-auth';
@@ -23,7 +24,24 @@ const SECRET = 'test-secret-not-production';
 const OTHER_SECRET = 'a-different-secret';
 
 const jwt = new JwtService({ secret: SECRET });
-const guard = new JwtAuthGuard(jwt);
+/**
+ * A revocation service that has revoked nothing.
+ *
+ * Named rather than inlined because "nothing is revoked" is the assumption
+ * every test below already made implicitly, and it should be visible now
+ * that it is a real dependency with its own answers.
+ */
+const nothingRevoked = {
+  isRevoked: () => null,
+} as unknown as RevocationService;
+
+const guard = new JwtAuthGuard(jwt, nothingRevoked);
+
+/** A guard whose snapshot refuses the token, for the two cases below. */
+const guardRefusing = (why: 'token' | 'user') =>
+  new JwtAuthGuard(jwt, {
+    isRevoked: () => why,
+  } as unknown as RevocationService);
 
 /** A request carrying whatever Authorization header the test wants. */
 function contextFor(
@@ -184,5 +202,41 @@ describe('JwtAuthGuard', () => {
       userId: socketData.userId,
       username: socketData.username,
     }).toEqual(request.user);
+  });
+});
+
+describe('a token that is signed, unexpired, and no longer trusted', () => {
+  // The gap this closes: signing out was a client-side event. The server
+  // never heard, so any copy of the token kept working for the rest of its
+  // life. A valid signature is not permission.
+  const bearer = (token: string) =>
+    ({ headers: { authorization: `Bearer ${token}` } }) as AuthedRequest;
+
+  const ctx = (req: AuthedRequest) =>
+    ({
+      switchToHttp: () => ({ getRequest: () => req }),
+    }) as unknown as ExecutionContext;
+
+  it('refuses a token whose session was signed out', () => {
+    const token = jwt.sign({ sub: 'u1', name: 'ada', jti: 'j1' });
+    expect(() =>
+      guardRefusing('token').canActivate(ctx(bearer(token))),
+    ).toThrow(/signed out/);
+  });
+
+  it('says something different when every session was signed out', () => {
+    // Worth telling apart: one is something you did, the other may be
+    // somebody else responding to a compromise.
+    const token = jwt.sign({ sub: 'u1', name: 'ada', jti: 'j1' });
+    expect(() => guardRefusing('user').canActivate(ctx(bearer(token)))).toThrow(
+      /All sessions/,
+    );
+  });
+
+  it('still lets an untouched token through', () => {
+    const token = jwt.sign({ sub: 'u1', name: 'ada', jti: 'j1' });
+    const req = bearer(token);
+    expect(guard.canActivate(ctx(req))).toBe(true);
+    expect(req.user).toEqual({ userId: 'u1', username: 'ada' });
   });
 });

--- a/video-sync-backend/src/auth/jwt-auth.guard.ts
+++ b/video-sync-backend/src/auth/jwt-auth.guard.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { subjectOf, type AuthedUser, TokenPayload } from './token-payload';
+import { RevocationService } from './revocation.service';
 
 /**
  * The request as this guard sees it: an Authorization header on the way in,
@@ -29,7 +30,10 @@ export interface AuthedRequest {
  */
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
-  constructor(private readonly jwt: JwtService) {}
+  constructor(
+    private readonly jwt: JwtService,
+    private readonly revocations: RevocationService,
+  ) {}
 
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest<AuthedRequest>();
@@ -68,6 +72,22 @@ export class JwtAuthGuard implements CanActivate {
     // shared with the WS middleware so the two planes cannot drift
     if (subjectOf(payload) === null) {
       throw new UnauthorizedException('Token is missing a subject');
+    }
+
+    // A valid signature is not permission: the token may have been taken out
+    // of circulation since it was signed. This reads an in-memory snapshot -
+    // no database call, which is what lets this guard stay synchronous and
+    // free of IO the way it was built to be.
+    const revoked = this.revocations.isRevoked(payload);
+    if (revoked !== null) {
+      // The two are worth telling apart. "Signed out" is something the
+      // person did; "signed out everywhere" may mean somebody else did it
+      // because the account was compromised.
+      throw new UnauthorizedException(
+        revoked === 'token'
+          ? 'This session was signed out - sign in again'
+          : 'All sessions were signed out - sign in again',
+      );
     }
 
     request.user = {

--- a/video-sync-backend/src/auth/revocation.service.spec.ts
+++ b/video-sync-backend/src/auth/revocation.service.spec.ts
@@ -1,0 +1,184 @@
+import { RevocationService } from './revocation.service';
+import type { DatabaseService } from '../database/database.service';
+import type { TokenPayload } from './token-payload';
+
+const makeDb = (
+  tokens: { jti: string }[] = [],
+  users: { id: string; tokenVersion: number }[] = [],
+) => ({
+  revokedToken: {
+    findMany: jest.fn().mockResolvedValue(tokens),
+    upsert: jest.fn().mockResolvedValue(undefined),
+    deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+  },
+  user: {
+    findMany: jest.fn().mockResolvedValue(users),
+    update: jest.fn().mockResolvedValue({ tokenVersion: 1 }),
+  },
+});
+
+const service = async (db: ReturnType<typeof makeDb>) => {
+  const s = new RevocationService(db as unknown as DatabaseService, null, null);
+  await s.refresh();
+  return s;
+};
+
+const token = (over: Partial<TokenPayload> = {}): TokenPayload => ({
+  sub: 'u1',
+  name: 'ada',
+  jti: 'j1',
+  ver: 0,
+  ...over,
+});
+
+describe('what the snapshot refuses', () => {
+  it('lets an untouched token through', async () => {
+    const s = await service(makeDb());
+    expect(s.isRevoked(token())).toBeNull();
+  });
+
+  it('refuses a token whose jti was revoked', async () => {
+    const s = await service(makeDb([{ jti: 'j1' }]));
+    expect(s.isRevoked(token())).toBe('token');
+    // and only that one - revoking a session must not sign out the others
+    expect(s.isRevoked(token({ jti: 'j2' }))).toBeNull();
+  });
+
+  it('refuses a token issued under an older version', async () => {
+    const s = await service(makeDb([], [{ id: 'u1', tokenVersion: 3 }]));
+    expect(s.isRevoked(token({ ver: 2 }))).toBe('user');
+    expect(s.isRevoked(token({ ver: 3 }))).toBeNull();
+    // a token issued AFTER the bump is newer, not staler
+    expect(s.isRevoked(token({ ver: 4 }))).toBeNull();
+  });
+
+  it('treats a missing version as 0, so old tokens keep working', async () => {
+    // Tokens minted before this feature existed carry no ver. They are not
+    // suspicious, they are just old, and refusing them would sign out
+    // everyone the moment this deployed.
+    const s = await service(makeDb());
+    const noVer: TokenPayload = { sub: 'u1', name: 'ada', jti: 'j1' };
+    expect(s.isRevoked(noVer)).toBeNull();
+  });
+
+  it('refuses a malformed version rather than reading it as 0', async () => {
+    // 0 is the version everyone starts at, so treating a nonsense claim as 0
+    // would let a token argue its way back past a revocation.
+    const s = await service(makeDb([], [{ id: 'u1', tokenVersion: 2 }]));
+    expect(s.isRevoked(token({ ver: 'nope' } as unknown as TokenPayload))).toBe(
+      'user',
+    );
+    expect(s.isRevoked(token({ ver: -1 }))).toBe('user');
+    expect(s.isRevoked(token({ ver: 1.5 }))).toBe('user');
+  });
+
+  it('refuses everything until the first load has finished', () => {
+    // An empty snapshot and a loaded-empty snapshot look identical, and
+    // answering "not revoked" from the first is a confident lie. This window
+    // is one instance booting; refusing is the safe side and the caller
+    // retries.
+    const s = new RevocationService(
+      makeDb() as unknown as DatabaseService,
+      null,
+      null,
+    );
+    expect(s.isRevoked(token())).toBe('user');
+  });
+});
+
+describe('when the database is unreachable', () => {
+  it('keeps the previous snapshot rather than emptying it', async () => {
+    // An empty snapshot trusts every revoked token. A stale one only misses
+    // revocations made since it was taken - strictly the better failure.
+    const db = makeDb([{ jti: 'j1' }]);
+    const s = await service(db);
+    expect(s.isRevoked(token())).toBe('token');
+
+    db.revokedToken.findMany.mockRejectedValue(new Error('down'));
+    await s.refresh();
+    expect(s.isRevoked(token())).toBe('token');
+  });
+});
+
+describe('revoking', () => {
+  it('writes the record before trusting its own memory', async () => {
+    // Revocation that forgets on restart is not revocation. Postgres is the
+    // truth; the in-memory set is a cache of it.
+    const db = makeDb();
+    const s = await service(db);
+    const expires = new Date(Date.now() + 3600_000);
+
+    await s.revokeToken('j1', 'u1', expires);
+
+    expect(db.revokedToken.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { jti: 'j1' },
+        create: { jti: 'j1', userId: 'u1', expiresAt: expires },
+      }),
+    );
+    expect(s.isRevoked(token())).toBe('token');
+  });
+
+  it('takes effect on this instance immediately, with no Redis at all', async () => {
+    // Redis carries the news to OTHER instances. A deployment without it is
+    // a single instance, where the news has nowhere to go and the local set
+    // is the whole story.
+    const s = await service(makeDb());
+    await s.revokeAllForUser('u1');
+    expect(s.isRevoked(token({ ver: 0 }))).toBe('user');
+  });
+
+  it('bumps the version rather than setting it, so two revocations both count', async () => {
+    const db = makeDb();
+    const s = await service(db);
+    await s.revokeAllForUser('u1');
+    const args = (
+      db.user.update.mock.calls as [{ data: { tokenVersion: unknown } }][]
+    )[0][0];
+    expect(args.data.tokenVersion).toEqual({ increment: 1 });
+  });
+
+  it('tells listeners, so live sockets can be closed', async () => {
+    const s = await service(makeDb());
+    const seen: unknown[] = [];
+    s.onEvent((e) => seen.push(e));
+    await s.revokeToken('j9', 'u1', new Date(Date.now() + 1000));
+    expect(seen).toEqual([{ kind: 'token', jti: 'j9' }]);
+  });
+
+  it('survives a listener that throws', async () => {
+    // One badly behaved handler must not stop the revocation from being
+    // announced to the others, or from having happened at all.
+    const s = await service(makeDb());
+    s.onEvent(() => {
+      throw new Error('boom');
+    });
+    const seen: unknown[] = [];
+    s.onEvent((e) => seen.push(e));
+    await expect(
+      s.revokeToken('j9', 'u1', new Date(Date.now() + 1000)),
+    ).resolves.toBeUndefined();
+    expect(seen).toHaveLength(1);
+  });
+});
+
+describe('the sweep', () => {
+  it('deletes only records past the expiry of the token they refuse', async () => {
+    // A token past its own expiry is refused by the signature check before
+    // this is consulted, so the record can never match again.
+    const db = makeDb();
+    const s = await service(db);
+    const now = new Date('2026-08-13T00:00:00Z');
+    await s.sweep(now);
+    expect(db.revokedToken.deleteMany).toHaveBeenCalledWith({
+      where: { expiresAt: { lt: now } },
+    });
+  });
+
+  it('does not take the process down when it fails', async () => {
+    const db = makeDb();
+    const s = await service(db);
+    db.revokedToken.deleteMany.mockRejectedValue(new Error('down'));
+    await expect(s.sweep()).resolves.toBe(0);
+  });
+});

--- a/video-sync-backend/src/auth/revocation.service.spec.ts
+++ b/video-sync-backend/src/auth/revocation.service.spec.ts
@@ -182,3 +182,75 @@ describe('the sweep', () => {
     await expect(s.sweep()).resolves.toBe(0);
   });
 });
+
+describe('a revocation that lands while a refresh is in flight', () => {
+  it('survives the refresh instead of being thrown away', async () => {
+    // refresh() reads from Postgres and then replaces the snapshot. Anything
+    // revoked between the read and the replacement used to be discarded by
+    // that assignment and accepted until the next tick - which contradicts
+    // the one guarantee this makes about its own instance.
+    const db = makeDb();
+    const s = await service(db);
+
+    let release!: () => void;
+    const held = new Promise<void>((r) => (release = r));
+    db.revokedToken.findMany.mockImplementation(async () => {
+      await held; // the read has happened; the assignment has not
+      return [];
+    });
+
+    const refreshing = s.refresh();
+    await s.revokeToken('j-late', 'u1', new Date(Date.now() + 3600_000));
+    release();
+    await refreshing;
+
+    expect(s.isRevoked(token({ jti: 'j-late' }))).toBe('token');
+  });
+
+  it('keeps the higher version rather than the one the query returned', async () => {
+    const db = makeDb();
+    const s = await service(db);
+
+    let release!: () => void;
+    const held = new Promise<void>((r) => (release = r));
+    db.user.findMany.mockImplementation(async () => {
+      await held;
+      return [{ id: 'u1', tokenVersion: 0 }];
+    });
+
+    const refreshing = s.refresh();
+    db.user.update.mockResolvedValue({ tokenVersion: 5 });
+    await s.revokeAllForUser('u1');
+    release();
+    await refreshing;
+
+    expect(s.isRevoked(token({ ver: 4 }))).toBe('user');
+  });
+});
+
+describe('a malformed announcement from another instance', () => {
+  const applyEvent = (s: RevocationService, raw: string) =>
+    (s as unknown as { applyEvent(r: string): void }).applyEvent(raw);
+
+  it('does not un-revoke a user by omitting the version', async () => {
+    // 0 is the version every account starts at, so falling back to it turns
+    // a truncated message into an un-revocation.
+    const s = await service(makeDb([], [{ id: 'u1', tokenVersion: 3 }]));
+    expect(s.isRevoked(token({ ver: 1 }))).toBe('user');
+
+    applyEvent(s, JSON.stringify({ kind: 'user', userId: 'u1' }));
+    expect(s.isRevoked(token({ ver: 1 }))).toBe('user');
+  });
+
+  it('never moves a stored version backwards', async () => {
+    const s = await service(makeDb([], [{ id: 'u1', tokenVersion: 3 }]));
+    applyEvent(s, JSON.stringify({ kind: 'user', userId: 'u1', version: 1 }));
+    expect(s.isRevoked(token({ ver: 2 }))).toBe('user');
+  });
+
+  it('ignores nonsense without throwing', async () => {
+    const s = await service(makeDb());
+    expect(() => applyEvent(s, 'not json')).not.toThrow();
+    expect(() => applyEvent(s, JSON.stringify({ kind: 'wat' }))).not.toThrow();
+  });
+});

--- a/video-sync-backend/src/auth/revocation.service.spec.ts
+++ b/video-sync-backend/src/auth/revocation.service.spec.ts
@@ -228,6 +228,37 @@ describe('a revocation that lands while a refresh is in flight', () => {
   });
 });
 
+describe('two refreshes overlapping', () => {
+  it("does not let the second one drop the first one's revocations", async () => {
+    // The pending buffers and the refreshing flag are shared state. Two
+    // overlapping refreshes clear each other's buffers, and the first to
+    // finish turns the flag off for the one still running - which puts back
+    // exactly the dropped-revocation bug the buffers exist to prevent. A
+    // slow query and a 30s timer is all it takes.
+    const db = makeDb();
+    const s = await service(db);
+
+    let release!: () => void;
+    const held = new Promise<void>((r) => (release = r));
+    let calls = 0;
+    db.revokedToken.findMany.mockImplementation(async () => {
+      calls++;
+      await held;
+      return [];
+    });
+
+    const first = s.refresh();
+    const second = s.refresh(); // arrives while the first is still reading
+    await s.revokeToken('j-late', 'u1', new Date(Date.now() + 3600_000));
+    release();
+    await Promise.all([first, second]);
+
+    expect(s.isRevoked(token({ jti: 'j-late' }))).toBe('token');
+    // and the second call joined the first rather than starting its own
+    expect(calls).toBe(1);
+  });
+});
+
 describe('a malformed announcement from another instance', () => {
   const applyEvent = (s: RevocationService, raw: string) =>
     (s as unknown as { applyEvent(r: string): void }).applyEvent(raw);

--- a/video-sync-backend/src/auth/revocation.service.ts
+++ b/video-sync-backend/src/auth/revocation.service.ts
@@ -1,0 +1,255 @@
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Cron, CronExpression, Interval } from '@nestjs/schedule';
+import type Redis from 'ioredis';
+import { DatabaseService } from '../database/database.service';
+import { REDIS_PUB, REDIS_SUB } from '../redis/redis.module';
+import { subjectOf, versionOf, type TokenPayload } from './token-payload';
+
+/** Where instances tell each other that something was revoked. */
+export const REVOCATION_CHANNEL = 'mustard:revocations';
+
+/**
+ * How stale an instance's picture of revocations can get if the pub/sub
+ * message never arrives - Redis down, a dropped subscription, an instance
+ * that started while Redis was unreachable.
+ *
+ * This is the honest answer to "how long does a revoked token keep working
+ * in the worst case". Thirty seconds, not twelve hours.
+ */
+const REFRESH_MS = 30_000;
+
+interface RevocationEvent {
+  kind: 'token' | 'user';
+  jti?: string;
+  userId?: string;
+  version?: number;
+}
+
+/**
+ * Which tokens are no longer trusted, in a form the request path can consult
+ * without touching anything.
+ *
+ * The two checks it answers are on EVERY authenticated request and every
+ * socket handshake, so neither may do IO. Both planes were built to do no
+ * database lookup at all, and adding one per request to gain revocation
+ * would be paying for the feature in the wrong currency.
+ *
+ * So: an in-memory snapshot, refreshed from Postgres. It stays small by
+ * construction - it holds only the tokens revoked in the last twelve hours
+ * and only the users who have ever revoked everything, which for almost
+ * every deployment is nobody. Postgres is the truth, because revocation
+ * that forgets on restart is not revocation. Redis, when present, only
+ * carries the news so other instances hear it in milliseconds rather than
+ * within REFRESH_MS.
+ */
+@Injectable()
+export class RevocationService implements OnModuleInit {
+  private readonly logger = new Logger(RevocationService.name);
+
+  /** jti values that must be refused, whatever else the token says. */
+  private revokedTokens = new Set<string>();
+  /** userId -> current version. Absent means 0, which is almost everyone. */
+  private userVersions = new Map<string, number>();
+  /** false until the first load succeeds - see isRevoked. */
+  private loaded = false;
+
+  constructor(
+    private readonly database: DatabaseService,
+    @Inject(REDIS_PUB) private readonly pub: Redis | null,
+    @Inject(REDIS_SUB) private readonly sub: Redis | null,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.refresh();
+
+    if (this.sub) {
+      try {
+        await this.sub.subscribe(REVOCATION_CHANNEL);
+        this.sub.on('message', (channel, raw) => {
+          if (channel !== REVOCATION_CHANNEL) return;
+          this.applyEvent(raw);
+        });
+      } catch (err) {
+        // Not fatal: the periodic refresh is the floor under this, and it
+        // does not depend on Redis at all.
+        this.logger.warn(
+          `revocation pub/sub unavailable, falling back to ${REFRESH_MS}ms polling: ${
+            err instanceof Error ? err.message : 'unknown'
+          }`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Is this token refused?
+   *
+   * Returns a reason rather than a boolean so the caller can say something
+   * true to the person holding it - "signed out" and "signed out everywhere"
+   * are different events and one of them means their password may have
+   * changed.
+   */
+  isRevoked(payload: TokenPayload): 'token' | 'user' | null {
+    // Before the first load has completed we know nothing, and answering
+    // "not revoked" from an empty snapshot would be a confident lie. This
+    // window is the boot of a single instance, and refusing during it is
+    // safer than serving a revoked token - the caller retries.
+    if (!this.loaded) return 'user';
+
+    if (payload.jti && this.revokedTokens.has(payload.jti)) return 'token';
+
+    const sub = subjectOf(payload);
+    if (sub === null) return null; // the planes reject this on their own
+
+    const claimed = versionOf(payload);
+    // A malformed version claim is not a zero. Refuse it rather than let a
+    // token argue its way back to the version everyone starts at.
+    if (claimed === null) return 'user';
+
+    const current = this.userVersions.get(sub) ?? 0;
+    return claimed < current ? 'user' : null;
+  }
+
+  /** Take one token out of circulation - an ordinary sign-out. */
+  async revokeToken(
+    jti: string,
+    userId: string,
+    expiresAt: Date,
+  ): Promise<void> {
+    await this.database.revokedToken.upsert({
+      where: { jti },
+      create: { jti, userId, expiresAt },
+      update: {},
+    });
+    this.revokedTokens.add(jti);
+    await this.announce({ kind: 'token', jti });
+  }
+
+  /** Stop trusting everything this user holds - sign out everywhere. */
+  async revokeAllForUser(userId: string): Promise<number> {
+    const user = await this.database.user.update({
+      where: { id: userId },
+      data: { tokenVersion: { increment: 1 } },
+      select: { tokenVersion: true },
+    });
+    this.userVersions.set(userId, user.tokenVersion);
+    await this.announce({
+      kind: 'user',
+      userId,
+      version: user.tokenVersion,
+    });
+    return user.tokenVersion;
+  }
+
+  /**
+   * Reload the snapshot from Postgres.
+   *
+   * Also the recovery path: an instance that missed a pub/sub message, or
+   * never had Redis, converges here within REFRESH_MS.
+   */
+  @Interval(REFRESH_MS)
+  async refresh(): Promise<void> {
+    try {
+      const [tokens, users] = await Promise.all([
+        this.database.revokedToken.findMany({
+          // Rows past their expiry cannot refuse anything a signature check
+          // would have accepted, so they are dead weight in memory.
+          where: { expiresAt: { gt: new Date() } },
+          select: { jti: true },
+        }),
+        this.database.user.findMany({
+          where: { tokenVersion: { gt: 0 } },
+          select: { id: true, tokenVersion: true },
+        }),
+      ]);
+
+      this.revokedTokens = new Set(tokens.map((t) => t.jti));
+      this.userVersions = new Map(users.map((u) => [u.id, u.tokenVersion]));
+      this.loaded = true;
+    } catch (err) {
+      // Keep the previous snapshot rather than emptying it. An empty
+      // snapshot trusts every revoked token; a stale one only misses
+      // revocations made since it was taken.
+      this.logger.warn(
+        `revocation refresh failed, keeping the previous snapshot: ${
+          err instanceof Error ? err.message : 'unknown'
+        }`,
+      );
+    }
+  }
+
+  /**
+   * Delete revocations for tokens that have expired anyway.
+   *
+   * Without this the table grows forever with rows that can never match: a
+   * token past its expiry is refused by the signature check before anything
+   * here is consulted.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_4AM)
+  async sweep(now: Date = new Date()): Promise<number> {
+    try {
+      const { count } = await this.database.revokedToken.deleteMany({
+        where: { expiresAt: { lt: now } },
+      });
+      if (count > 0) this.logger.log(`swept ${count} expired revocation(s)`);
+      return count;
+    } catch (err) {
+      this.logger.warn(
+        `revocation sweep failed: ${err instanceof Error ? err.message : 'unknown'}`,
+      );
+      return 0;
+    }
+  }
+
+  /** Visible for the gateway, which disconnects sockets on these events. */
+  onEvent(handler: (event: RevocationEvent) => void): void {
+    this.handlers.push(handler);
+  }
+
+  private readonly handlers: ((event: RevocationEvent) => void)[] = [];
+
+  private async announce(event: RevocationEvent): Promise<void> {
+    // Locally first and unconditionally: this instance must act on its own
+    // revocation whether or not Redis is there to tell the others.
+    this.notify(event);
+    if (!this.pub) return;
+    try {
+      await this.pub.publish(REVOCATION_CHANNEL, JSON.stringify(event));
+    } catch (err) {
+      this.logger.warn(
+        `could not announce revocation; other instances will catch up within ${REFRESH_MS}ms: ${
+          err instanceof Error ? err.message : 'unknown'
+        }`,
+      );
+    }
+  }
+
+  private applyEvent(raw: string): void {
+    let event: RevocationEvent;
+    try {
+      event = JSON.parse(raw) as RevocationEvent;
+    } catch {
+      return;
+    }
+    if (event.kind === 'token' && event.jti) {
+      this.revokedTokens.add(event.jti);
+    } else if (event.kind === 'user' && event.userId) {
+      this.userVersions.set(event.userId, event.version ?? 0);
+    } else {
+      return;
+    }
+    this.notify(event);
+  }
+
+  private notify(event: RevocationEvent): void {
+    for (const handler of this.handlers) {
+      try {
+        handler(event);
+      } catch (err) {
+        this.logger.warn(
+          `revocation handler threw: ${err instanceof Error ? err.message : 'unknown'}`,
+        );
+      }
+    }
+  }
+}

--- a/video-sync-backend/src/auth/revocation.service.ts
+++ b/video-sync-backend/src/auth/revocation.service.ts
@@ -162,7 +162,26 @@ export class RevocationService implements OnModuleInit {
    * never had Redis, converges here within REFRESH_MS.
    */
   @Interval(REFRESH_MS)
-  async refresh(): Promise<void> {
+  refresh(): Promise<void> {
+    // One at a time. The pending buffers and the `refreshing` flag are shared
+    // state, so two overlapping refreshes clear each other's buffers and the
+    // first to finish turns the flag off for the one still running - which
+    // puts back exactly the dropped-revocation bug the buffers were added to
+    // fix. A slow query and a 30s timer is all it takes to overlap.
+    //
+    // A caller who arrives mid-refresh JOINS the running one rather than
+    // starting a second: they want a fresh snapshot, and the one in flight
+    // will be that.
+    if (this.inFlight) return this.inFlight;
+    this.inFlight = this.reload().finally(() => {
+      this.inFlight = null;
+    });
+    return this.inFlight;
+  }
+
+  private inFlight: Promise<void> | null = null;
+
+  private async reload(): Promise<void> {
     this.refreshing = true;
     this.pendingTokens.clear();
     this.pendingVersions.clear();

--- a/video-sync-backend/src/auth/revocation.service.ts
+++ b/video-sync-backend/src/auth/revocation.service.ts
@@ -53,6 +53,20 @@ export class RevocationService implements OnModuleInit {
   /** false until the first load succeeds - see isRevoked. */
   private loaded = false;
 
+  /**
+   * Revocations recorded while a refresh was in flight.
+   *
+   * refresh() reads from Postgres and then REPLACES the snapshot. Anything
+   * revoked between the read and the replacement would be thrown away by
+   * that assignment and accepted until the next tick - which contradicts the
+   * one guarantee this service makes about its own instance, that a
+   * revocation takes effect here at once. So writes that land during a
+   * refresh are held here and merged in at the end.
+   */
+  private pendingTokens = new Set<string>();
+  private pendingVersions = new Map<string, number>();
+  private refreshing = false;
+
   constructor(
     private readonly database: DatabaseService,
     @Inject(REDIS_PUB) private readonly pub: Redis | null,
@@ -121,7 +135,7 @@ export class RevocationService implements OnModuleInit {
       create: { jti, userId, expiresAt },
       update: {},
     });
-    this.revokedTokens.add(jti);
+    this.rememberToken(jti);
     await this.announce({ kind: 'token', jti });
   }
 
@@ -132,7 +146,7 @@ export class RevocationService implements OnModuleInit {
       data: { tokenVersion: { increment: 1 } },
       select: { tokenVersion: true },
     });
-    this.userVersions.set(userId, user.tokenVersion);
+    this.rememberVersion(userId, user.tokenVersion);
     await this.announce({
       kind: 'user',
       userId,
@@ -149,6 +163,9 @@ export class RevocationService implements OnModuleInit {
    */
   @Interval(REFRESH_MS)
   async refresh(): Promise<void> {
+    this.refreshing = true;
+    this.pendingTokens.clear();
+    this.pendingVersions.clear();
     try {
       const [tokens, users] = await Promise.all([
         this.database.revokedToken.findMany({
@@ -163,8 +180,20 @@ export class RevocationService implements OnModuleInit {
         }),
       ]);
 
-      this.revokedTokens = new Set(tokens.map((t) => t.jti));
-      this.userVersions = new Map(users.map((u) => [u.id, u.tokenVersion]));
+      const nextTokens = new Set(tokens.map((t) => t.jti));
+      const nextVersions = new Map(users.map((u) => [u.id, u.tokenVersion]));
+
+      // Merge rather than replace, or a revocation that happened while these
+      // queries were in flight is silently undone. Versions take the HIGHER
+      // of the two: a stored version must never move backwards, because
+      // backwards means un-revoked.
+      for (const jti of this.pendingTokens) nextTokens.add(jti);
+      for (const [id, version] of this.pendingVersions) {
+        nextVersions.set(id, Math.max(nextVersions.get(id) ?? 0, version));
+      }
+
+      this.revokedTokens = nextTokens;
+      this.userVersions = nextVersions;
       this.loaded = true;
     } catch (err) {
       // Keep the previous snapshot rather than emptying it. An empty
@@ -175,6 +204,26 @@ export class RevocationService implements OnModuleInit {
           err instanceof Error ? err.message : 'unknown'
         }`,
       );
+    } finally {
+      this.refreshing = false;
+      this.pendingTokens.clear();
+      this.pendingVersions.clear();
+    }
+  }
+
+  /** Add to the live set, and to the pending one if a refresh could clobber it. */
+  private rememberToken(jti: string): void {
+    this.revokedTokens.add(jti);
+    if (this.refreshing) this.pendingTokens.add(jti);
+  }
+
+  /** Same, and never downwards: a lower version is an un-revocation. */
+  private rememberVersion(userId: string, version: number): void {
+    const current = this.userVersions.get(userId) ?? 0;
+    if (version > current) this.userVersions.set(userId, version);
+    if (this.refreshing) {
+      const pending = this.pendingVersions.get(userId) ?? 0;
+      if (version > pending) this.pendingVersions.set(userId, version);
     }
   }
 
@@ -232,9 +281,20 @@ export class RevocationService implements OnModuleInit {
       return;
     }
     if (event.kind === 'token' && event.jti) {
-      this.revokedTokens.add(event.jti);
-    } else if (event.kind === 'user' && event.userId) {
-      this.userVersions.set(event.userId, event.version ?? 0);
+      this.rememberToken(event.jti);
+    } else if (
+      event.kind === 'user' &&
+      event.userId &&
+      typeof event.version === 'number' &&
+      Number.isInteger(event.version) &&
+      event.version > 0
+    ) {
+      // A missing version is NOT a zero. Zero is the version every account
+      // starts at, so falling back to it would UN-revoke the user until the
+      // next refresh - the same reasoning versionOf applies to a token claim,
+      // applied to a message. announce() always sets it, so only a malformed
+      // or truncated message reaches this branch, and ignoring it is right.
+      this.rememberVersion(event.userId, event.version);
     } else {
       return;
     }

--- a/video-sync-backend/src/auth/token-payload.ts
+++ b/video-sync-backend/src/auth/token-payload.ts
@@ -14,6 +14,35 @@ export interface TokenPayload {
   sub: string;
   /** Display name. Carried for convenience; never trusted for access. */
   name: string;
+  /**
+   * This token's own id, so ONE session can be revoked without touching the
+   * others. Written on every token issued from now on.
+   *
+   * Optional in the type because tokens issued before revocation existed do
+   * not carry one, and they stay valid until they expire. A token with no
+   * jti simply cannot be individually revoked - `ver` still reaches it.
+   */
+  jti?: string;
+  /**
+   * The user's token version at the moment this was issued. If the user's
+   * version has moved on, this token is stale and refused - the "sign out
+   * everywhere" lever.
+   *
+   * Optional for the same reason as jti. A token with no ver is treated as
+   * version 0, which is what every account starts at, so old tokens keep
+   * working until someone actually revokes.
+   */
+  ver?: number;
+  /**
+   * Expiry, written by jsonwebtoken itself. Declared here because two things
+   * now read it - the socket sweep that closes connections whose token has
+   * died, and the revocation record that only needs keeping until then.
+   *
+   * SECONDS, not milliseconds. Everything else in this codebase is
+   * milliseconds, so the conversion is the easiest mistake available here:
+   * treating it as ms puts every token in January 1970 and expires the lot.
+   */
+  exp?: number;
 }
 
 /**
@@ -38,4 +67,21 @@ export interface AuthedUser {
 export function subjectOf(payload: TokenPayload): string | null {
   const sub = payload?.sub;
   return typeof sub === 'string' && sub.length > 0 ? sub : null;
+}
+
+/**
+ * The version a token claims, for comparison against the user's current one.
+ *
+ * Absent means 0 - the version every account starts at - so tokens minted
+ * before this claim existed keep working. A non-number is NOT treated as 0:
+ * that would let a caller who could influence the payload downgrade
+ * themselves past a revocation. There is no such caller today (we sign these
+ * ourselves), and the check costs one comparison.
+ */
+export function versionOf(payload: TokenPayload): number | null {
+  const ver = payload?.ver;
+  if (ver === undefined || ver === null) return 0;
+  return typeof ver === 'number' && Number.isInteger(ver) && ver >= 0
+    ? ver
+    : null;
 }

--- a/video-sync-backend/src/sync/socket-eviction.spec.ts
+++ b/video-sync-backend/src/sync/socket-eviction.spec.ts
@@ -1,0 +1,159 @@
+import { Logger } from '@nestjs/common';
+import type { Namespace, Socket } from 'socket.io';
+import { evictRevoked, startExpirySweep } from './socket-eviction';
+import type { AuthedSocketData } from './ws-auth';
+
+const makeSocket = (data: Partial<AuthedSocketData>) => {
+  const socket = {
+    data: data as AuthedSocketData,
+    emitted: [] as { event: string; body: unknown }[],
+    disconnected: false,
+    emit(event: string, body: unknown) {
+      socket.emitted.push({ event, body });
+      return true;
+    },
+    disconnect() {
+      socket.disconnected = true;
+      return socket as unknown as Socket;
+    },
+  };
+  return socket;
+};
+
+/**
+ * A NAMESPACE, whose sockets map is `sockets` directly.
+ *
+ * The first version of this double had `sockets: { sockets: Map }` - the
+ * shape of `Server`, not of `Namespace`. Every test passed against it, and
+ * the real thing threw on its first sweep and took the process down. A fake
+ * that agrees with the wrong belief is worse than no test.
+ */
+const nsOf = (...sockets: ReturnType<typeof makeSocket>[]) =>
+  ({
+    sockets: new Map(sockets.map((s, i) => [String(i), s])),
+  }) as unknown as Namespace;
+
+beforeEach(() => jest.useFakeTimers());
+afterEach(() => jest.useRealTimers());
+
+describe('closing connections a revocation should have closed', () => {
+  // The gap this exists for: a socket is authenticated once, at connect, and
+  // trusted while it stays open. Without eviction, signing out stops the REST
+  // calls and leaves the person watching along on the live connection.
+
+  it('closes the socket holding the revoked token, and no other', () => {
+    const revoked = makeSocket({ userId: 'u1', jti: 'j1', tokenVersion: 0 });
+    const other = makeSocket({ userId: 'u1', jti: 'j2', tokenVersion: 0 });
+
+    const closed = evictRevoked([nsOf(revoked, other)], {
+      kind: 'token',
+      jti: 'j1',
+    });
+
+    expect(closed).toBe(1);
+    jest.runAllTimers();
+    expect(revoked.disconnected).toBe(true);
+    expect(other.disconnected).toBe(false);
+  });
+
+  it('says why before it goes', () => {
+    // A disconnect with no reason is indistinguishable from a network blip,
+    // and the client will reconnect forever with the same dead token.
+    const socket = makeSocket({ userId: 'u1', jti: 'j1', tokenVersion: 0 });
+    evictRevoked([nsOf(socket)], { kind: 'token', jti: 'j1' });
+
+    expect(socket.emitted).toEqual([
+      { event: 'session-ended', body: { reason: 'session signed out' } },
+    ]);
+    // and the frame gets a tick to be written before the transport closes
+    expect(socket.disconnected).toBe(false);
+    jest.runAllTimers();
+    expect(socket.disconnected).toBe(true);
+  });
+
+  it('closes every stale session of a user on sign-out-everywhere', () => {
+    const phone = makeSocket({ userId: 'u1', jti: 'j1', tokenVersion: 0 });
+    const laptop = makeSocket({ userId: 'u1', jti: 'j2', tokenVersion: 0 });
+    const someoneElse = makeSocket({
+      userId: 'u2',
+      jti: 'j3',
+      tokenVersion: 0,
+    });
+
+    const closed = evictRevoked([nsOf(phone, laptop, someoneElse)], {
+      kind: 'user',
+      userId: 'u1',
+      version: 1,
+    });
+
+    expect(closed).toBe(2);
+    jest.runAllTimers();
+    expect(someoneElse.disconnected).toBe(false);
+  });
+
+  it('does not evict the session that did the signing out', () => {
+    // Bumping the version issues a NEW token at the new version. Closing it
+    // would sign you out of the device you just used to secure the account.
+    const fresh = makeSocket({ userId: 'u1', jti: 'j9', tokenVersion: 1 });
+    const closed = evictRevoked([nsOf(fresh)], {
+      kind: 'user',
+      userId: 'u1',
+      version: 1,
+    });
+    expect(closed).toBe(0);
+  });
+
+  it('reaches the voice namespace too', () => {
+    // /voice is a separate namespace with its own socket map, and its
+    // connections carry the same token. Evicting only the default namespace
+    // would leave voice up for someone who has just been signed out.
+    const main = makeSocket({ userId: 'u1', jti: 'j1', tokenVersion: 0 });
+    const voice = makeSocket({ userId: 'u1', jti: 'j1', tokenVersion: 0 });
+
+    const closed = evictRevoked([nsOf(main), nsOf(voice)], {
+      kind: 'token',
+      jti: 'j1',
+    });
+
+    expect(closed).toBe(2);
+  });
+});
+
+describe('closing connections whose token simply ran out', () => {
+  it('closes an expired one and leaves a live one alone', () => {
+    const now = 1_000_000;
+    const dead = makeSocket({ userId: 'u1', expiresAt: now - 1 });
+    const alive = makeSocket({ userId: 'u2', expiresAt: now + 60_000 });
+
+    const stop = startExpirySweep(
+      [nsOf(dead, alive)],
+      new Logger('test'),
+      () => now,
+    );
+    jest.advanceTimersByTime(30_000);
+    jest.runOnlyPendingTimers();
+
+    expect(dead.disconnected).toBe(true);
+    expect(alive.disconnected).toBe(false);
+    stop();
+  });
+
+  it('leaves a token with no expiry alone', () => {
+    // Nothing issues these any more, but a token from before exp was
+    // declared should not be closed on a guess.
+    const socket = makeSocket({ userId: 'u1' });
+    const stop = startExpirySweep([nsOf(socket)], new Logger('test'));
+    jest.advanceTimersByTime(60_000);
+    expect(socket.disconnected).toBe(false);
+    stop();
+  });
+
+  it('stops sweeping when told to', () => {
+    const now = 1_000_000;
+    const dead = makeSocket({ userId: 'u1', expiresAt: now - 1 });
+    const stop = startExpirySweep([nsOf(dead)], new Logger('test'), () => now);
+    stop();
+    jest.advanceTimersByTime(120_000);
+    expect(dead.disconnected).toBe(false);
+  });
+});

--- a/video-sync-backend/src/sync/socket-eviction.ts
+++ b/video-sync-backend/src/sync/socket-eviction.ts
@@ -1,0 +1,129 @@
+import { Logger } from '@nestjs/common';
+import type { Namespace, Socket } from 'socket.io';
+import type { AuthedSocketData } from './ws-auth';
+
+/**
+ * How often to look for connections whose token has died under them.
+ *
+ * A socket authenticates once, at connect. Everything after that is trusted
+ * because the connection is open, which means an expired or revoked token
+ * leaves the person watching along until they happen to disconnect - the
+ * documented limitation that made revocation half a feature.
+ */
+const SWEEP_MS = 30_000;
+
+const REASON = {
+  expired: 'token expired',
+  revoked: 'session signed out',
+  allRevoked: 'signed out everywhere',
+} as const;
+
+type Reason = (typeof REASON)[keyof typeof REASON];
+
+/**
+ * Close a connection and tell it why before the socket goes away.
+ *
+ * The client needs the reason: a disconnect with no explanation is
+ * indistinguishable from a network blip, and the reconnect logic will
+ * cheerfully try again forever with the same dead token.
+ */
+const evict = (socket: Socket, reason: Reason): void => {
+  socket.emit('session-ended', { reason });
+  // A tick, so the frame is actually written. disconnect(true) closes the
+  // underlying transport immediately, and an emit racing it is an emit the
+  // client never sees.
+  setTimeout(() => socket.disconnect(true), 50);
+};
+
+/**
+ * Every connected socket across the namespaces we own.
+ *
+ * NAMESPACES, not Servers, and the difference cost a crash: `Server.sockets`
+ * IS the default namespace, so `server.sockets.sockets` reads as a socket
+ * map - but `server.of('/voice')` returns a Namespace, whose sockets live at
+ * `namespace.sockets` directly. Casting one to the other type-checked, then
+ * threw on the first sweep and took the process down with it. The unit test
+ * did not catch it because the fake had the shape I believed in.
+ */
+const socketsOf = (namespaces: Namespace[]): Socket[] =>
+  namespaces.flatMap((ns) => Array.from(ns.sockets.values()));
+
+/**
+ * Disconnect the live connections belonging to a revocation.
+ *
+ * Called the moment a token is revoked on this instance, and again when
+ * another instance announces one - so signing out on your phone closes the
+ * tab on your laptop in about as long as a round trip, not in twelve hours.
+ */
+export const evictRevoked = (
+  namespaces: Namespace[],
+  event: {
+    kind: 'token' | 'user';
+    jti?: string;
+    userId?: string;
+    version?: number;
+  },
+): number => {
+  let closed = 0;
+  for (const socket of socketsOf(namespaces)) {
+    const data = socket.data as AuthedSocketData;
+    if (event.kind === 'token' && event.jti && data.jti === event.jti) {
+      evict(socket, REASON.revoked);
+      closed++;
+    } else if (
+      event.kind === 'user' &&
+      event.userId &&
+      data.userId === event.userId &&
+      (data.tokenVersion ?? 0) < (event.version ?? 0)
+    ) {
+      // Strictly less than: the version bump issues a NEW token, and the
+      // session that did the signing-out must not evict itself.
+      evict(socket, REASON.allRevoked);
+      closed++;
+    }
+  }
+  return closed;
+};
+
+/**
+ * Start the periodic sweep for connections whose token has simply expired.
+ *
+ * Separate from eviction-on-revocation because it answers a different
+ * question: not "was this taken away" but "did it run out". Both leave a
+ * socket trusted that nothing would trust if it arrived now.
+ */
+export const startExpirySweep = (
+  namespaces: Namespace[],
+  logger: Logger,
+  now: () => number = Date.now,
+): (() => void) => {
+  const timer = setInterval(() => {
+    // A background sweep is not worth an unhandled rejection that ends the
+    // process - which is exactly what the namespace mistake above did on its
+    // first tick, in a timer where nothing was there to catch it.
+    try {
+      let closed = 0;
+      for (const socket of socketsOf(namespaces)) {
+        const data = socket.data as AuthedSocketData;
+        if (typeof data.expiresAt === 'number' && data.expiresAt <= now()) {
+          evict(socket, REASON.expired);
+          closed++;
+        }
+      }
+      if (closed > 0)
+        logger.log(`closed ${closed} connection(s) on expired tokens`);
+    } catch (err) {
+      logger.warn(
+        `expiry sweep failed: ${err instanceof Error ? err.message : 'unknown'}`,
+      );
+    }
+  }, SWEEP_MS);
+
+  // Node keeps the process alive for a pending timer; a sweep is not a
+  // reason to refuse to shut down.
+  timer.unref?.();
+  return () => clearInterval(timer);
+};
+
+export const EVICTION_SWEEP_MS = SWEEP_MS;
+export const EVICTION_REASONS = REASON;

--- a/video-sync-backend/src/sync/sync.gateway.ts
+++ b/video-sync-backend/src/sync/sync.gateway.ts
@@ -35,6 +35,8 @@ import {
   SWEEP_INTERVAL_MS,
 } from './room-state.store';
 import { AuthedSocketData, wsAuthMiddleware } from './ws-auth';
+import { RevocationService } from '../auth/revocation.service';
+import { evictRevoked, startExpirySweep } from './socket-eviction';
 
 const CONTROL_INTENTS: ReadonlyArray<SyncControl['intent']> = [
   'play',
@@ -109,6 +111,7 @@ export class SyncGateway
     private metrics: MetricsService,
     @Inject(ROOM_STATE_STORE) private store: RoomStateStore,
     private voiceRoster: VoiceRosterService,
+    private revocations: RevocationService,
   ) {
     if (this.store instanceof ActorRoomStateStore) {
       // actor plane: intents forwarded by non-owners execute HERE, on the
@@ -154,7 +157,33 @@ export class SyncGateway
   afterInit(server: Server): void {
     // identity is derived server-side at connect; client-asserted userIds
     // in payloads are ignored by every handler below
-    server.use(wsAuthMiddleware(this.jwt));
+    server.use(wsAuthMiddleware(this.jwt, this.revocations));
+
+    // A socket is authenticated once and then trusted while it stays open,
+    // so revocation without these two would stop the REST calls and leave
+    // the live connection watching along - half a feature.
+    //
+    // Both namespaces are reachable from this server object: /voice is a
+    // namespace on the same io instance, and its sockets carry the same
+    // token, so evicting only the default namespace would leave voice up
+    // for someone who has just been signed out.
+    // of('/') and of('/voice'), because both are NAMESPACES - `server`
+    // itself is not one, and casting it to look like one type-checks and
+    // then throws on the first sweep.
+    const namespaces = [server.of('/'), server.of('/voice')];
+    this.revocations.onEvent((event) => {
+      const closed = evictRevoked(namespaces, event);
+      if (closed > 0) {
+        this.logger.log(`closed ${closed} connection(s) on revocation`);
+      }
+    });
+    this.stopExpirySweep = startExpirySweep(namespaces, this.logger);
+  }
+
+  private stopExpirySweep: (() => void) | null = null;
+
+  onModuleDestroy(): void {
+    this.stopExpirySweep?.();
   }
 
   handleConnection(client: Socket) {

--- a/video-sync-backend/src/sync/voice.gateway.ts
+++ b/video-sync-backend/src/sync/voice.gateway.ts
@@ -11,6 +11,7 @@ import {
 import { JwtService } from '@nestjs/jwt';
 import { Server, Socket } from 'socket.io';
 import { AuthedSocketData, wsAuthMiddleware } from './ws-auth';
+import { RevocationService } from '../auth/revocation.service';
 import { SyncGateway } from './sync.gateway';
 import { VoiceRosterService } from './voice-roster.service';
 
@@ -76,10 +77,13 @@ export class VoiceGateway
     private jwt: JwtService,
     private sync: SyncGateway,
     private roster: VoiceRosterService,
+    private revocations: RevocationService,
   ) {}
 
   afterInit(server: Server): void {
-    server.use(wsAuthMiddleware(this.jwt));
+    // Same check as the default namespace: a revoked token must not open a
+    // voice connection either, and this namespace has its own middleware.
+    server.use(wsAuthMiddleware(this.jwt, this.revocations));
   }
 
   /**

--- a/video-sync-backend/src/sync/ws-auth.ts
+++ b/video-sync-backend/src/sync/ws-auth.ts
@@ -3,12 +3,26 @@ import { Socket } from 'socket.io';
 // One definition, shared with the REST guard (auth/jwt-auth.guard.ts) so the
 // two planes cannot drift on what a token says.
 import { subjectOf, type TokenPayload } from '../auth/token-payload';
+import type { RevocationService } from '../auth/revocation.service';
 
 /** Shape of socket.data after the middleware accepted the connection. */
 export interface AuthedSocketData {
   userId: string;
   username: string;
   connectedAt: number;
+  /**
+   * The token this connection was accepted on, kept so the connection can
+   * be closed when that token is revoked.
+   *
+   * A socket is authenticated once, at connect, and then trusted for as
+   * long as it stays open - which is the gap that made revocation only half
+   * a feature: signing out would stop the REST calls and leave the live
+   * connection watching along. jti identifies the session, exp says when it
+   * would have died on its own.
+   */
+  jti?: string;
+  tokenVersion: number;
+  expiresAt: number;
 }
 
 /**
@@ -17,7 +31,10 @@ export interface AuthedSocketData {
  * payloads are dead from here on — handlers read socket.data.userId only.
  * Applied to both namespaces (/ and /voice).
  */
-export function wsAuthMiddleware(jwt: JwtService) {
+export function wsAuthMiddleware(
+  jwt: JwtService,
+  revocations?: RevocationService,
+) {
   return (socket: Socket, next: (err?: Error) => void): void => {
     const token = (socket.handshake.auth as { token?: string } | undefined)
       ?.token;
@@ -33,10 +50,28 @@ export function wsAuthMiddleware(jwt: JwtService) {
         next(new Error('unauthorized: token has no subject'));
         return;
       }
+      // Same check as the REST guard, against the same in-memory snapshot:
+      // a token revoked a moment ago must not be able to open a NEW
+      // connection just because the signature is still good.
+      if (revocations?.isRevoked(payload)) {
+        next(new Error('unauthorized: token revoked'));
+        return;
+      }
+
       const data = socket.data as AuthedSocketData;
       data.userId = sub;
       data.username = payload.name;
       data.connectedAt = Date.now();
+      data.jti = payload.jti;
+      data.tokenVersion = payload.ver ?? 0;
+      // jsonwebtoken puts exp in SECONDS; everything here is milliseconds,
+      // and mixing the two would make every token look 1970-expired.
+      // exp is in SECONDS (jsonwebtoken's doing); everything here is
+      // milliseconds. A token with no exp never ages out on its own.
+      data.expiresAt =
+        typeof payload.exp === 'number'
+          ? payload.exp * 1000
+          : Number.POSITIVE_INFINITY;
       next();
     } catch {
       next(new Error('unauthorized: invalid token'));

--- a/video-sync-frontend/src/contexts/AuthContext.tsx
+++ b/video-sync-frontend/src/contexts/AuthContext.tsx
@@ -41,7 +41,11 @@ interface AuthContextType {
   continueAsGuest: () => Promise<void>;
   /** True when this session has no password and no provider behind it. */
   isGuest: boolean;
-  logout: () => void;
+  /**
+   * Sign out. `everywhere` revokes every session this account has rather
+   * than just this one - the answer to a token that may have leaked.
+   */
+  logout: (options?: { everywhere?: boolean }) => void;
   isAuthenticated: boolean;
 }
 
@@ -191,13 +195,33 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     [],
   );
 
-  const logout = useCallback(() => {
+  /**
+   * Drop the local session, and tell the server to stop trusting the token.
+   *
+   * The local half happens FIRST and unconditionally. Signing out is not
+   * allowed to fail: if the network is down, the person in front of the
+   * screen still wants to be signed out of this machine, and leaving them
+   * signed in because a request failed would be the worst possible reading
+   * of "sign out".
+   *
+   * The server half is what makes it real - without it a copy of the token
+   * keeps working for the rest of its life - but it is best-effort, and the
+   * token expires on its own regardless.
+   */
+  const logout = useCallback((options?: { everywhere?: boolean }) => {
+    const revoke = options?.everywhere
+      ? apiService.logoutEverywhere()
+      : apiService.logout();
+    revoke.catch(() => undefined);
+
     setUser(null);
     localStorage.removeItem('user');
     // where you have been is as personal as who you are, and this machine
     // may not be yours
     clearRecentRooms();
-    toast.success('Signed out');
+    toast.success(
+      options?.everywhere ? 'Signed out everywhere' : 'Signed out',
+    );
   }, []);
 
   const value: AuthContextType = {

--- a/video-sync-frontend/src/contexts/SocketContext.tsx
+++ b/video-sync-frontend/src/contexts/SocketContext.tsx
@@ -1,7 +1,14 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { io, Socket } from 'socket.io-client';
 import { toast } from 'react-hot-toast';
 import { useAuth } from './AuthContext';
+import { AUTH_EXPIRED_EVENT } from '../services/api';
 
 interface SocketContextType {
   socket: Socket | null;
@@ -34,8 +41,18 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
   const [connected, setConnected] = useState(false);
   const [reconnecting, setReconnecting] = useState(false);
   const token = user?.token;
+  /**
+   * Did the SERVER end this session on purpose?
+   *
+   * A ref rather than state: it is read inside the socket handlers, which
+   * close over the value at the time the effect ran, and a stale `false`
+   * there would put the UI back into "reconnecting" for a session that can
+   * never come back.
+   */
+  const endedRef = useRef(false);
 
   useEffect(() => {
+    endedRef.current = false;
     // the gateway rejects unauthenticated sockets; without a token there is
     // nothing to connect (login/register issue one)
     if (!token) {
@@ -79,6 +96,27 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
       hasConnected = true;
     });
 
+    // The server closed this connection on purpose - the token behind it was
+    // signed out or expired. Without this, socket.io would reconnect forever
+    // with the same dead token and the person would see an unexplained
+    // "reconnecting" chip that never resolves.
+    socketInstance.on(
+      'session-ended',
+      ({ reason }: { reason?: string } = {}) => {
+        endedRef.current = true;
+        // Stop the retry loop before it starts; the token cannot come back.
+        socketInstance.disconnect();
+        toast.error(
+          reason === 'token expired'
+            ? 'Your session expired - sign in again'
+            : reason === 'signed out everywhere'
+              ? 'You were signed out everywhere'
+              : 'This session was signed out',
+        );
+        window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT));
+      },
+    );
+
     socketInstance.on('disconnect', () => {
       console.log('Disconnected from server');
       setConnected(false);
@@ -86,7 +124,9 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
       // TO. No toast: socket.io retries by itself, the status chip carries
       // it, and a red toast on every brief blip trains people to ignore
       // toasts entirely.
-      setReconnecting(hasConnected);
+      // A session that ENDED is not a session that is reconnecting. Saying
+      // "reconnecting" here would promise something that cannot happen.
+      setReconnecting(hasConnected && !endedRef.current);
     });
 
     socketInstance.on('connect_error', (error: Error) => {

--- a/video-sync-frontend/src/pages/HomePage.tsx
+++ b/video-sync-frontend/src/pages/HomePage.tsx
@@ -776,7 +776,7 @@ export const HomePage: React.FC = () => {
               Keep this account
             </ClaimTrigger>
           )}
-          <SecondarySmButton type="button" onClick={logout}>
+          <SecondarySmButton type="button" onClick={() => logout()}>
             Sign out
           </SecondarySmButton>
         </TopBarRight>

--- a/video-sync-frontend/src/services/api.interceptor.test.ts
+++ b/video-sync-frontend/src/services/api.interceptor.test.ts
@@ -1,0 +1,74 @@
+import { api } from './api';
+import type { InternalAxiosRequestConfig } from 'axios';
+
+/**
+ * Which requests carry the bearer token.
+ *
+ * This exists because the answer was wrong for three shipped features at
+ * once. The rule was "never attach to /auth/*", written when every /auth
+ * endpoint was unauthenticated. Then claim, google/link-start and logout
+ * arrived - all guarded - and the rule silently stripped their credentials.
+ * They 401'd, which is to say they did not work from a browser at all.
+ *
+ * Nothing caught it: every live check built its own headers and never went
+ * through this file. So the check belongs here, at the layer that decides.
+ */
+const run = (url: string): InternalAxiosRequestConfig => {
+  const handler = (
+    api.interceptors.request as unknown as {
+      handlers: {
+        fulfilled: (c: InternalAxiosRequestConfig) => InternalAxiosRequestConfig;
+      }[];
+    }
+  ).handlers[0].fulfilled;
+  return handler({
+    url,
+    headers: {},
+  } as unknown as InternalAxiosRequestConfig);
+};
+
+const authHeader = (url: string) =>
+  (run(url).headers as Record<string, unknown>).Authorization;
+
+beforeEach(() => {
+  localStorage.setItem('user', JSON.stringify({ id: 'u1', token: 'tok-123' }));
+});
+
+afterEach(() => localStorage.clear());
+
+describe('endpoints that need the token', () => {
+  // Every one of these is behind JwtAuthGuard. Without the header they 401.
+  it.each([
+    ['/auth/logout'],
+    ['/auth/logout-all'],
+    ['/auth/claim'],
+    ['/auth/google/link-start'],
+    ['/rooms'],
+    ['/rooms/abc'],
+  ])('%s carries it', (url) => {
+    expect(authHeader(url)).toBe('Bearer tok-123');
+  });
+});
+
+describe('endpoints where a token is meaningless', () => {
+  // The original reasoning, still right: sending a token to login makes a
+  // bad-password 401 indistinguishable from an expired-session 401 in the
+  // response interceptor, which would wipe a good session over a typo.
+  it.each([
+    ['/auth/login'],
+    ['/auth/register'],
+    ['/auth/guest'],
+    ['/auth/providers'],
+    ['/auth/google/start'],
+  ])('%s does not', (url) => {
+    expect(authHeader(url)).toBeUndefined();
+  });
+});
+
+describe('with no stored session', () => {
+  it('sends nothing rather than the word undefined', () => {
+    localStorage.clear();
+    expect(authHeader('/auth/logout')).toBeUndefined();
+    expect(authHeader('/rooms')).toBeUndefined();
+  });
+});

--- a/video-sync-frontend/src/services/api.ts
+++ b/video-sync-frontend/src/services/api.ts
@@ -86,6 +86,18 @@ export const apiService = {
   register: (username: string, email: string, password: string) =>
     api.post('/auth/register', { username, email, password }),
 
+  /**
+   * Tell the server to stop trusting this token.
+   *
+   * Signing out used to be a client-side event only - the browser dropped
+   * the token and the server never heard, so any copy of it kept working
+   * for the rest of its life.
+   */
+  logout: () => api.post('/auth/logout'),
+
+  /** Stop trusting every session this account has, anywhere. */
+  logoutEverywhere: () => api.post<{ version: number }>('/auth/logout-all'),
+
   /** A way in for someone who followed an invite link and wants no account. */
   guest: () => api.post('/auth/guest'),
 

--- a/video-sync-frontend/src/services/api.ts
+++ b/video-sync-frontend/src/services/api.ts
@@ -51,11 +51,37 @@ const clearStoredUser = () => {
   window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT));
 };
 
+/**
+ * The auth endpoints where a token is meaningless.
+ *
+ * This used to be the whole of `/auth/*`, and the reasoning was sound for
+ * the endpoints that existed at the time: sending a token to login or
+ * register makes a bad-password 401 indistinguishable from an
+ * expired-session 401 in the response interceptor below.
+ *
+ * Then `/auth` grew endpoints that REQUIRE a token - claim, google/link-start,
+ * logout, logout-all - and the blanket rule silently stripped it from every
+ * one of them. They called guarded routes with no Authorization header and
+ * got 401s, which is to say those features did not work from the browser at
+ * all. Nothing caught it: every live check sent its own headers and never
+ * went through this file.
+ *
+ * So the list is now the exception rather than the prefix, and a new guarded
+ * endpoint under /auth works by default instead of failing by default.
+ */
+const NO_TOKEN_NEEDED = [
+  '/auth/login',
+  '/auth/register',
+  '/auth/guest',
+  '/auth/providers',
+  '/auth/google/start',
+  '/auth/google/callback',
+];
+
 api.interceptors.request.use(config => {
-  // Never attach to /auth/*: a token is meaningless to login/register, and
-  // sending one there makes a bad-password 401 indistinguishable from an
-  // expired-session 401 in the response interceptor below.
-  if (config.url?.startsWith('/auth/')) return config;
+  if (NO_TOKEN_NEEDED.some(path => config.url?.startsWith(path))) {
+    return config;
+  }
   const token = readStoredToken();
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;


### PR DESCRIPTION
The largest remaining gap in `docs/AUTH.md`: a token was good for its full lifetime whatever happened. Signing out was a **client-side event only** — the browser dropped the token, the server never heard, and any copy of it kept working for the rest of the twelve hours.

## Two levers

| | `POST /auth/logout` | `POST /auth/logout-all` |
|---|---|---|
| Scope | this one session | every session the account has |
| Mechanism | the token's `jti` is recorded | the user's `tokenVersion` is bumped past what existing tokens claim |
| For | "I'm done on this laptop" | "my token leaked" |

## The guard still does no IO

Both planes check revocation on every request and every handshake, and both were deliberately built to do **no database lookup at all**. Buying revocation with a query per request would be paying in the wrong currency.

So `RevocationService` holds an in-memory snapshot — the jtis revoked in the last twelve hours, and the users who have ever revoked everything. Both small by construction; for most deployments the second set is empty. The check is a `Set.has` and a `Map.get`.

**Postgres is the truth; Redis is only the news.** Revocation that forgets on restart isn't revocation, and this deployment treats Redis as a cache that may be absent. When the pub/sub message doesn't arrive, the honest staleness bound is **30 seconds**, not twelve hours. That's in the docs, not just here.

## Sockets are closed, not merely refused

A connection authenticates once and is then trusted while it stays open — so without this, signing out stopped the REST calls and left the person **watching along**. That's the documented limitation that made revocation half a feature. The client gets `session-ended` with a reason before the close, because a silent disconnect is indistinguishable from a blip and the retry loop would reconnect forever with a dead token.

## Two bugs I wouldn't have found by reasoning

**`issueToken` now *requires* `tokenVersion`.** A token minted carrying version 0 for a user whose version has moved on is refused the instant it's used — sign in, get a token, get signed out again, logs saying only "revoked". Making the type demand it meant the compiler found the call site I'd missed instead of production finding it.

**`server.of('/voice')` returns a `Namespace`, not a `Server`.** `Server.sockets` *is* the default namespace, so `server.sockets.sockets` reads as a socket map; a Namespace's sockets are at `namespace.sockets`. My cast type-checked, threw on the first sweep, and **took the process down**. Eight unit tests passed against a fake with the shape I believed in — the live check crashed in ten seconds. The fake is corrected and the sweep is now wrapped, because a background task shouldn't be able to end the process.

## Verified against a real database and real sockets

`scripts/live-checks/revocation-check.mjs`, 16 checks, all passing — the already-open connection closes and says why, the other session is untouched, a revoked token can't open a *new* socket, and signing in afterwards returns a token that actually works (the check that would catch a fresh token born already-revoked).

416 backend tests, 118 frontend, verified by exit code.

## Worth arguing with

- **`relay-go` doesn't check revocation.** It verifies the signature and nothing else, so a revoked token satisfies the relay until it expires. Closing that means giving the relay a view of the snapshot, which it has no database or Redis connection for. Written down rather than quietly carried.
- **The 30-second window is real.** An instance that misses the pub/sub message honours a revoked token until its next refresh.
- **Tokens with no `jti`** (issued before this) can't be revoked individually — `logout` returns `{revoked: false}` rather than claiming a success that did nothing.
- **The boot window refuses everything.** Before the first snapshot loads, `isRevoked` answers "revoked" rather than guessing from an empty set. Safe, but it means a booting instance rejects valid tokens for a moment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session-specific sign-out and “sign out everywhere” controls.
  * Signed-out sessions are immediately blocked from API and WebSocket access.
  * Active connections are closed with clear session-ended notifications.
  * Other active sessions remain available when signing out of one session.
  * Authentication state and local session data are cleared after sign-out.

* **Documentation**
  * Documented sign-out behavior, refresh timing, connection closure, and known limitations.

* **Tests**
  * Added comprehensive coverage for session revocation, global sign-out, socket eviction, and token expiry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->