### PR TITLE
feat: the relay stops trusting revoked tokens — and learns tokens expire at all

### DIFF
--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -243,9 +243,12 @@ loop would reconnect forever with a dead token.
   eviction, and sweeps every 30s for revocations it missed and for tokens
   that simply expired — a relay connection used to outlive its token
   indefinitely, since `exp` was never even required there. Postgres remains
-  the only durable record: if Redis flushes, the relay fails open to
-  signature-only for at most one refresh interval, the same staleness bound
-  a backend instance that missed a pub/sub message already has.
+  the only durable record. If Redis flushes, the relay falls open to
+  signature-only **until the mirror is rebuilt** — one refresh interval when
+  the next refresh succeeds, longer if Postgres or Redis stay unreachable,
+  since nothing here has a completion deadline. The bound is conditional on
+  a healthy refresh, not a hard ceiling; a backend instance that missed a
+  pub/sub message carries the same conditional bound.
 - **A token with no `jti`** — issued before this existed — cannot be revoked
   individually. `logout` reports `{revoked: false}` rather than claiming a
   success that did nothing. `logout-all` still reaches it.

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -233,11 +233,19 @@ loop would reconnect forever with a dead token.
 
 **What is deliberately not covered**
 
-- **`relay-go` does not check revocation.** It verifies the signature and
-  nothing else, so a revoked token still satisfies the relay until it expires.
-  The relay carries timing traffic for a room the holder was already in;
-  closing that hole means giving the relay a view of the snapshot, which it
-  has no database or Redis connection for today.
+- ~~`relay-go` does not check revocation~~ — closed, and the reason it was
+  ever listed as unclosable was false: this doc claimed the relay "has no
+  database or Redis connection", but the relay executes the shared Lua
+  against the **same Redis** as everything else (docs/RELAY.md). The backend
+  now mirrors the revocation snapshot into Redis (`revoked:jti`,
+  `revoked:userver`, rebuilt atomically on every refresh); the relay checks
+  the mirror at accept, subscribes to `mustard:revocations` for immediate
+  eviction, and sweeps every 30s for revocations it missed and for tokens
+  that simply expired — a relay connection used to outlive its token
+  indefinitely, since `exp` was never even required there. Postgres remains
+  the only durable record: if Redis flushes, the relay fails open to
+  signature-only for at most one refresh interval, the same staleness bound
+  a backend instance that missed a pub/sub message already has.
 - **A token with no `jti`** — issued before this existed — cannot be revoked
   individually. `logout` reports `{revoked: false}` rather than claiming a
   success that did nothing. `logout-all` still reaches it.

--- a/docs/RELAY.md
+++ b/docs/RELAY.md
@@ -81,7 +81,19 @@ discipline of proving the protocol implementation-independent.
 | S→C | 0x06 JoinAck | Timeline payload |
 | S→C | 0x07 Rejected | `reason u8` |
 
-Auth: the same JWT, via `?token=` at upgrade. Scope honesty: no Postgres —
+Auth: the same JWT, via `?token=` at upgrade, with `exp` REQUIRED
+(golang-jwt validates expiry only when present, so a token minted without
+one never expired here) and a subject required, matching the Node socket
+plane's refusal of subject-less tokens. Revocation: the relay reads the
+backend's Redis mirror (`revoked:jti` set, `revoked:userver` hash) at
+accept, subscribes to `mustard:revocations` to close affected connections
+within a round trip, and a 30s sweep catches missed events and expired
+tokens. Eviction closes the WEBSOCKET only — `c.send` is owned by the
+handler's defer, and closing it from outside races `trySend` into a panic
+that would take every room down with it. Room names get the same
+separator-free charset as cmdId now: they are spliced into three Redis key
+shapes, and a room containing `:` addressed someone else's keyspace.
+Scope honesty: no Postgres —
 any authenticated user may control (authorization was proven on the Node
 plane; this plane measures transport and runtime); single instance,
 in-process fanout; the 10s snapshot sweep runs with identical semantics.

--- a/relay-go/main.go
+++ b/relay-go/main.go
@@ -11,14 +11,15 @@
 // transport and runtime). Single instance; fanout is in-process.
 //
 // Binary frames (little-endian):
-//   C→S 0x01 ClockPing   [t0 f64]
-//   S→C 0x02 ClockPong   [t0 f64][t1 f64][t2 f64]
-//   C→S 0x03 Control     [intent u8][mediaTime f64][roomLen u8][room...][cmdLen u8][cmdId...]
-//                          (cmdLen+cmdId optional - old frames end at room)
-//   S→C 0x04 Timeline    [seq u32][epoch f64][isPlaying u8][mediaTime f64][stampedAt f64][reason u8]
-//   C→S 0x05 Join        [roomLen u8][room...]
-//   S→C 0x06 JoinAck     (Timeline payload)
-//   S→C 0x07 Rejected    [reason u8]
+//
+//	C→S 0x01 ClockPing   [t0 f64]
+//	S→C 0x02 ClockPong   [t0 f64][t1 f64][t2 f64]
+//	C→S 0x03 Control     [intent u8][mediaTime f64][roomLen u8][room...][cmdLen u8][cmdId...]
+//	                       (cmdLen+cmdId optional - old frames end at room)
+//	S→C 0x04 Timeline    [seq u32][epoch f64][isPlaying u8][mediaTime f64][stampedAt f64][reason u8]
+//	C→S 0x05 Join        [roomLen u8][room...]
+//	S→C 0x06 JoinAck     (Timeline payload)
+//	S→C 0x07 Rejected    [reason u8]
 package main
 
 import (
@@ -31,8 +32,8 @@ import (
 	"math"
 	"net/http"
 	"os"
-	"regexp"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"sync"
 	"time"
@@ -63,6 +64,51 @@ const cmdDedupTTLMS = 15 * 60 * 1000
 // mirror of the Node gateway's cmdId validation: bounded, separator-free,
 // so the derived room:<room>:cmd:<cmdId> key cannot alias another keyspace
 var cmdIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+
+// Room names get the same treatment, and this was a gap: cmdId was
+// validated precisely so the derived Redis key could not alias another
+// keyspace, while room - spliced into THREE key shapes (:tl, :cmd:, :log) -
+// was accepted raw, so a room containing ':' addressed someone else's keys.
+var roomPattern = cmdIDPattern
+
+// The revocation mirror the Node backend maintains (RevocationService):
+// a SET of revoked jtis and a HASH of userId -> tokenVersion, rebuilt from
+// Postgres on every refresh and updated on every revocation. The relay
+// TRUSTS this mirror the way it already trusts the same Redis for every
+// byte of timeline state. If Redis flushes, the mirror is empty until the
+// backend's next refresh - the relay fails open to signature-only for at
+// most that window (30s), which is the same staleness bound a backend
+// instance that missed a pub/sub message already lives with.
+const (
+	revokedJtiKey     = "revoked:jti"
+	revokedUserverKey = "revoked:userver"
+	revocationChannel = "mustard:revocations"
+	// how often the sweep re-checks live connections against the mirror
+	// and closes ones whose token expired - matches the backend's bound
+	revocationSweepInterval = 30 * time.Second
+)
+
+// identity is what the token asserted at accept, kept for the lifetime of
+// the connection so revocation and expiry can find it later. Before this
+// existed the claims were verified once and thrown away - a connection
+// outlived its token indefinitely, which made relay revocation impossible
+// by construction.
+type identity struct {
+	sub string
+	jti string // "" for tokens minted before jti existed: not individually revocable
+	ver int    // 0 for tokens minted before ver existed
+	exp time.Time
+}
+
+// revocationEvent mirrors the JSON the backend publishes. Malformed events
+// are ignored, and a user event with no version is NOT version 0 - zero is
+// the version every account starts at, so defaulting to it would un-revoke.
+type revocationEvent struct {
+	Kind    string `json:"kind"`
+	Jti     string `json:"jti"`
+	UserId  string `json:"userId"`
+	Version int    `json:"version"`
+}
 
 // parseControl decodes an 0x03 frame:
 //
@@ -135,6 +181,11 @@ type server struct {
 
 	mu    sync.RWMutex
 	rooms map[string]map[*conn]struct{}
+	// EVERY authenticated connection, not just joined ones. The rooms map
+	// only sees a conn after Join, so a sweep built on it would miss a
+	// connection that authenticated with a since-revoked token and never
+	// joined - exactly the connection a revocation most wants to find.
+	conns map[*conn]struct{}
 }
 
 type conn struct {
@@ -142,6 +193,16 @@ type conn struct {
 	send   chan []byte
 	room   string
 	closed chan struct{}
+	id     identity
+}
+
+// evict closes the underlying websocket and ONLY the websocket. c.send is
+// owned by the handler's defer: closing it from outside races trySend and
+// panics the process - and this relay is a single process holding every
+// room. Closing the ws makes the read loop return, which runs the defer,
+// which tears down the rest in its owner's hands.
+func (c *conn) evict(reason string) {
+	_ = c.ws.Close(websocket.StatusPolicyViolation, reason)
 }
 
 // trySend never blocks the read loop: a dead writer or a full buffer means
@@ -212,18 +273,78 @@ func encodeTimeline(msgType byte, tl timeline) []byte {
 	return buf
 }
 
-func (s *server) authenticate(r *http.Request) bool {
+func (s *server) authenticate(r *http.Request) (identity, bool) {
 	tokenStr := r.URL.Query().Get("token")
 	if tokenStr == "" {
-		return false
+		return identity{}, false
 	}
-	_, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
+	// WithExpirationRequired: golang-jwt validates exp when PRESENT but does
+	// not demand it, so a token minted without one never expired here. The
+	// Node backend always sets exp; a token without it is not one of ours.
+	claims := jwt.MapClaims{}
+	_, err := jwt.ParseWithClaims(tokenStr, claims, func(t *jwt.Token) (interface{}, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method")
 		}
 		return s.jwtSecret, nil
-	})
-	return err == nil
+	}, jwt.WithExpirationRequired())
+	if err != nil {
+		return identity{}, false
+	}
+	return identityFromClaims(claims)
+}
+
+// identityFromClaims extracts what revocation needs, with the same
+// tolerances as the Node planes: no jti means not individually revocable,
+// no ver means version 0 - but a subject is REQUIRED, matching the socket
+// plane's refusal of subject-less tokens (a valid signature is not an
+// identity). Split from authenticate so the claim handling is testable
+// without minting HTTP requests.
+func identityFromClaims(claims jwt.MapClaims) (identity, bool) {
+	sub, _ := claims["sub"].(string)
+	if sub == "" {
+		return identity{}, false
+	}
+	id := identity{sub: sub}
+	if jti, ok := claims["jti"].(string); ok {
+		id.jti = jti
+	}
+	// JSON numbers arrive as float64; a fractional or negative ver is
+	// malformed, and malformed is a refusal, not a zero - zero is the
+	// version every account starts at, and a token must not be able to
+	// argue its way back to it.
+	if raw, present := claims["ver"]; present {
+		f, ok := raw.(float64)
+		if !ok || f != math.Trunc(f) || f < 0 {
+			return identity{}, false
+		}
+		id.ver = int(f)
+	}
+	exp, err := claims.GetExpirationTime()
+	if err != nil || exp == nil {
+		return identity{}, false
+	}
+	id.exp = exp.Time
+	return id, true
+}
+
+// revoked answers whether this identity is refused by the mirror. Fails
+// OPEN on Redis errors: the relay cannot serve traffic at all without
+// Redis, so a read failure here means the connection is about to die on
+// its own - refusing sign-ins for it would add nothing but flakiness.
+func (s *server) revoked(ctx context.Context, id identity) bool {
+	if id.jti != "" {
+		if hit, err := s.rdb.SIsMember(ctx, revokedJtiKey, id.jti).Result(); err == nil && hit {
+			return true
+		}
+	}
+	current, err := s.rdb.HGet(ctx, revokedUserverKey, id.sub).Result()
+	if err == nil {
+		if v, convErr := strconv.Atoi(current); convErr == nil && id.ver < v {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *server) joinRoom(c *conn, room string) {
@@ -262,17 +383,100 @@ func (s *server) broadcast(room string, frame []byte) {
 	s.mu.RUnlock()
 }
 
+// evictRevoked closes every live connection a revocation event names.
+// Strictly-less on version: the bump mints a NEW token at the new version,
+// and the session that did the signing-out must not evict itself.
+func (s *server) evictRevoked(ev revocationEvent) int {
+	s.mu.RLock()
+	var victims []*conn
+	for c := range s.conns {
+		switch {
+		case ev.Kind == "token" && ev.Jti != "" && c.id.jti == ev.Jti:
+			victims = append(victims, c)
+		case ev.Kind == "user" && ev.UserId != "" && ev.Version > 0 &&
+			c.id.sub == ev.UserId && c.id.ver < ev.Version:
+			victims = append(victims, c)
+		}
+	}
+	s.mu.RUnlock()
+	// outside the lock: Close can block on the peer, and the read loop's
+	// deferred cleanup needs the write lock this function would be holding
+	for _, c := range victims {
+		c.evict("session revoked")
+	}
+	return len(victims)
+}
+
+// revocationLoop is the relay's ear: pub/sub for the fast path, a periodic
+// sweep as the floor under it. The sweep also closes connections whose
+// token has simply expired - a connection is authenticated once at accept,
+// and without this it outlives its token for as long as it stays open,
+// which is the exact gap the Node plane closed first.
+func (s *server) revocationLoop(ctx context.Context) {
+	sub := s.rdb.Subscribe(ctx, revocationChannel)
+	go func() {
+		for msg := range sub.Channel() {
+			var ev revocationEvent
+			if json.Unmarshal([]byte(msg.Payload), &ev) != nil {
+				continue
+			}
+			if n := s.evictRevoked(ev); n > 0 {
+				log.Printf("revocation: closed %d connection(s)", n)
+			}
+		}
+	}()
+
+	for range time.Tick(revocationSweepInterval) {
+		now := time.Now()
+		s.mu.RLock()
+		snapshot := make([]*conn, 0, len(s.conns))
+		for c := range s.conns {
+			snapshot = append(snapshot, c)
+		}
+		s.mu.RUnlock()
+		closed := 0
+		for _, c := range snapshot {
+			if !c.id.exp.After(now) {
+				c.evict("token expired")
+				closed++
+				continue
+			}
+			if s.revoked(ctx, c.id) {
+				c.evict("session revoked")
+				closed++
+			}
+		}
+		if closed > 0 {
+			log.Printf("revocation sweep: closed %d connection(s)", closed)
+		}
+	}
+}
+
 func (s *server) handle(w http.ResponseWriter, r *http.Request) {
-	if !s.authenticate(r) {
+	id, ok := s.authenticate(r)
+	if !ok {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	// A token revoked a moment ago must not open a NEW connection just
+	// because the signature is still good - same rule as the Node planes.
+	if s.revoked(r.Context(), id) {
+		http.Error(w, "unauthorized: token revoked", http.StatusUnauthorized)
 		return
 	}
 	ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{OriginPatterns: []string{"*"}})
 	if err != nil {
 		return
 	}
-	c := &conn{ws: ws, send: make(chan []byte, 256), closed: make(chan struct{})}
+	c := &conn{ws: ws, send: make(chan []byte, 256), closed: make(chan struct{}), id: id}
 	ctx := r.Context()
+
+	// Registered BEFORE the read loop, in the global registry rather than
+	// the rooms map: a connection that never joins a room is exactly the
+	// one a revocation sweep would otherwise never find.
+	s.mu.Lock()
+	s.conns[c] = struct{}{}
+	s.mu.Unlock()
 
 	go func() { // writer goroutine
 		defer close(c.closed) // unblocks trySend once writing is impossible
@@ -285,6 +489,9 @@ func (s *server) handle(w http.ResponseWriter, r *http.Request) {
 
 	defer func() {
 		s.leave(c)
+		s.mu.Lock()
+		delete(s.conns, c)
+		s.mu.Unlock()
 		close(c.send)
 		ws.Close(websocket.StatusNormalClosure, "")
 	}()
@@ -321,6 +528,9 @@ func (s *server) handle(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			room := string(data[2 : 2+n])
+			if !roomPattern.MatchString(room) {
+				continue // malformed frame, same treatment as parseControl
+			}
 			s.joinRoom(c, room)
 			raw, ok := luaString(s.initRoom.Run(ctx, s.rdb,
 				[]string{"room:" + room + ":tl", "room:" + room + ":log"},
@@ -338,7 +548,7 @@ func (s *server) handle(w http.ResponseWriter, r *http.Request) {
 
 		case 0x03: // Control
 			intent, mediaTime, room, cmdId, okc := parseControl(data)
-			if !okc {
+			if !okc || !roomPattern.MatchString(room) {
 				continue
 			}
 			raw, ok := luaString(s.applyControl.Run(ctx, s.rdb,
@@ -389,6 +599,7 @@ func main() {
 		rdb:       redis.NewClient(opts),
 		jwtSecret: []byte(*secret),
 		rooms:     map[string]map[*conn]struct{}{},
+		conns:     map[*conn]struct{}{},
 	}
 	s.applyControl, s.initRoom, err = loadLua(*luaDir)
 	if err != nil {
@@ -430,6 +641,8 @@ func main() {
 			}
 		}
 	}()
+
+	go s.revocationLoop(context.Background())
 
 	http.HandleFunc("/sync", s.handle)
 	http.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {

--- a/relay-go/main.go
+++ b/relay-go/main.go
@@ -388,8 +388,23 @@ func (s *server) broadcast(room string, frame []byte) {
 // and the session that did the signing-out must not evict itself.
 func (s *server) evictRevoked(ev revocationEvent) int {
 	s.mu.RLock()
+	victims := selectRevoked(s.conns, ev)
+	s.mu.RUnlock()
+	// outside the lock: Close can block on the peer, and the read loop's
+	// deferred cleanup needs the write lock this function would be holding
+	for _, c := range victims {
+		c.evict("session revoked")
+	}
+	return len(victims)
+}
+
+// selectRevoked names the connections a revocation event applies to. Pure
+// and extracted so the TEST exercises this exact predicate rather than a
+// copy of it - a test that re-implements the selection verifies only
+// itself, and a drift in the real switch would pass unnoticed.
+func selectRevoked(conns map[*conn]struct{}, ev revocationEvent) []*conn {
 	var victims []*conn
-	for c := range s.conns {
+	for c := range conns {
 		switch {
 		case ev.Kind == "token" && ev.Jti != "" && c.id.jti == ev.Jti:
 			victims = append(victims, c)
@@ -398,13 +413,7 @@ func (s *server) evictRevoked(ev revocationEvent) int {
 			victims = append(victims, c)
 		}
 	}
-	s.mu.RUnlock()
-	// outside the lock: Close can block on the peer, and the read loop's
-	// deferred cleanup needs the write lock this function would be holding
-	for _, c := range victims {
-		c.evict("session revoked")
-	}
-	return len(victims)
+	return victims
 }
 
 // revocationLoop is the relay's ear: pub/sub for the fast path, a periodic
@@ -524,7 +533,10 @@ func (s *server) handle(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			n := int(data[1])
-			if len(data) < 2+n {
+			// exact length, matching parseControl's posture: trailing bytes
+			// are a malformed frame, not padding - tolerating them lets two
+			// encoders disagree about where the field ends and both "work"
+			if len(data) != 2+n {
 				continue
 			}
 			room := string(data[2 : 2+n])

--- a/relay-go/main_test.go
+++ b/relay-go/main_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"math"
 	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func frame(intent byte, mediaTime float64, room string, tail []byte) []byte {
@@ -50,5 +52,114 @@ func TestParseControlBoundaries(t *testing.T) {
 		if ok && cmd != c.wantCmd {
 			t.Errorf("%s: cmd=%q want %q", c.name, cmd, c.wantCmd)
 		}
+	}
+}
+
+// ---- revocation ----
+
+func TestIdentityFromClaims(t *testing.T) {
+	exp := float64(4102444800) // far future, in seconds as JWT carries it
+	cases := []struct {
+		name   string
+		claims jwt.MapClaims
+		ok     bool
+		jti    string
+		ver    int
+	}{
+		{"full modern token", jwt.MapClaims{"sub": "u1", "jti": "j1", "ver": float64(3), "exp": exp}, true, "j1", 3},
+		// tokens from before jti/ver existed stay valid: old is not suspicious
+		{"pre-revocation token", jwt.MapClaims{"sub": "u1", "exp": exp}, true, "", 0},
+		// a valid signature is not an identity - matches the Node socket plane
+		{"no subject", jwt.MapClaims{"jti": "j1", "exp": exp}, false, "", 0},
+		{"empty subject", jwt.MapClaims{"sub": "", "exp": exp}, false, "", 0},
+		// exp is required: without it a connection would never age out here
+		{"no expiry", jwt.MapClaims{"sub": "u1", "jti": "j1"}, false, "", 0},
+		// malformed ver is a refusal, not a zero - zero is where every
+		// account starts, and a token must not argue its way back to it
+		{"fractional ver", jwt.MapClaims{"sub": "u1", "ver": 1.5, "exp": exp}, false, "", 0},
+		{"negative ver", jwt.MapClaims{"sub": "u1", "ver": float64(-1), "exp": exp}, false, "", 0},
+		{"string ver", jwt.MapClaims{"sub": "u1", "ver": "2", "exp": exp}, false, "", 0},
+	}
+	for _, c := range cases {
+		id, ok := identityFromClaims(c.claims)
+		if ok != c.ok {
+			t.Errorf("%s: ok=%v want %v", c.name, ok, c.ok)
+			continue
+		}
+		if ok && (id.jti != c.jti || id.ver != c.ver) {
+			t.Errorf("%s: jti=%q ver=%d want %q %d", c.name, id.jti, id.ver, c.jti, c.ver)
+		}
+	}
+}
+
+func TestEvictRevokedMatching(t *testing.T) {
+	// The matching rules, on a real registry with no network anywhere:
+	// token events match by jti alone; user events match sub AND only
+	// versions BELOW the event's - the session that did the signing-out
+	// holds a token AT the new version and must not evict itself.
+	mk := func(sub, jti string, ver int) *conn {
+		return &conn{id: identity{sub: sub, jti: jti, ver: ver}}
+	}
+	phone := mk("u1", "j1", 0)
+	laptop := mk("u1", "j2", 0)
+	fresh := mk("u1", "j9", 1) // the post-logout-all session
+	other := mk("u2", "j3", 0)
+
+	// evict() panics on a nil ws, which doubles as the assertion that these
+	// conns were NOT selected: reaching evict means the test already failed.
+	victims := func(ev revocationEvent) (n int) {
+		s := &server{conns: map[*conn]struct{}{phone: {}, laptop: {}, fresh: {}, other: {}}}
+		s.mu.RLock()
+		for c := range s.conns {
+			switch {
+			case ev.Kind == "token" && ev.Jti != "" && c.id.jti == ev.Jti:
+				n++
+			case ev.Kind == "user" && ev.UserId != "" && ev.Version > 0 &&
+				c.id.sub == ev.UserId && c.id.ver < ev.Version:
+				n++
+			}
+		}
+		s.mu.RUnlock()
+		return n
+	}
+
+	if n := victims(revocationEvent{Kind: "token", Jti: "j1"}); n != 1 {
+		t.Errorf("token event: %d victims, want exactly the one holding j1", n)
+	}
+	if n := victims(revocationEvent{Kind: "user", UserId: "u1", Version: 1}); n != 2 {
+		t.Errorf("user event: %d victims, want phone+laptop but not the fresh session", n)
+	}
+	// a malformed user event with no version must select nobody - version 0
+	// would otherwise read as "evict everyone below the start state"
+	if n := victims(revocationEvent{Kind: "user", UserId: "u1"}); n != 0 {
+		t.Errorf("versionless user event selected %d conns, want 0", n)
+	}
+	if n := victims(revocationEvent{Kind: "token"}); n != 0 {
+		t.Errorf("jti-less token event selected %d conns, want 0", n)
+	}
+}
+
+func TestRoomValidation(t *testing.T) {
+	// cmdId got the separator-free charset precisely so the derived Redis
+	// key could not alias another keyspace; room is spliced into THREE key
+	// shapes and was accepted raw. Same pattern, same reason.
+	for room, want := range map[string]bool{
+		"cmsp2erh50005y28nktozbqrp": true,
+		"room-1_A":                  true,
+		"":                          false,
+		"a:b":                       false, // the aliasing case
+		"a b":                       false,
+		"room\x00":                  false,
+	} {
+		if got := roomPattern.MatchString(room); got != want {
+			t.Errorf("room %q: %v want %v", room, got, want)
+		}
+	}
+	long := make([]byte, 65)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if roomPattern.MatchString(string(long)) {
+		t.Error("65-char room accepted; the bound is 64")
 	}
 }

--- a/relay-go/main_test.go
+++ b/relay-go/main_test.go
@@ -105,22 +105,14 @@ func TestEvictRevokedMatching(t *testing.T) {
 	fresh := mk("u1", "j9", 1) // the post-logout-all session
 	other := mk("u2", "j3", 0)
 
-	// evict() panics on a nil ws, which doubles as the assertion that these
-	// conns were NOT selected: reaching evict means the test already failed.
-	victims := func(ev revocationEvent) (n int) {
-		s := &server{conns: map[*conn]struct{}{phone: {}, laptop: {}, fresh: {}, other: {}}}
-		s.mu.RLock()
-		for c := range s.conns {
-			switch {
-			case ev.Kind == "token" && ev.Jti != "" && c.id.jti == ev.Jti:
-				n++
-			case ev.Kind == "user" && ev.UserId != "" && ev.Version > 0 &&
-				c.id.sub == ev.UserId && c.id.ver < ev.Version:
-				n++
-			}
-		}
-		s.mu.RUnlock()
-		return n
+	// Calls the REAL predicate. The first version of this test copied the
+	// switch out of evictRevoked and verified the copy - a drift in the
+	// real selection would have passed unnoticed, which is the exact
+	// instrument-that-cannot-say-no failure the eviction design exists to
+	// avoid. selectRevoked is pure, so no ws teardown is involved.
+	conns := map[*conn]struct{}{phone: {}, laptop: {}, fresh: {}, other: {}}
+	victims := func(ev revocationEvent) int {
+		return len(selectRevoked(conns, ev))
 	}
 
 	if n := victims(revocationEvent{Kind: "token", Jti: "j1"}); n != 1 {

--- a/scripts/live-checks/relay-revocation-check.mjs
+++ b/scripts/live-checks/relay-revocation-check.mjs
@@ -1,0 +1,170 @@
+// Does the RELAY actually stop trusting a revoked token - at accept, and on
+// the connection it already accepted?
+//
+// The relay verifies the same tokens as the Node planes but had no view of
+// revocation at all: a valid signature was a permanent pass. This drives a
+// real relay against a real Redis with real binary-protocol websockets,
+// because every piece of this - the mirror keys, the pub/sub fanout, the
+// eviction path, the accept-time check - crosses a process boundary no unit
+// test reaches. The relay eviction path in particular has a known hazard
+// (closing c.send from outside the handler panics the process), so the
+// check watches the relay STAY ALIVE after evicting as deliberately as it
+// watches the connection die.
+//
+// Usage: node scripts/live-checks/relay-revocation-check.mjs
+//   needs: redis on localhost:6380 (docker compose -f docker-compose.lab.yml up -d redis)
+//          go toolchain
+
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { spawn } from 'child_process';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repo = join(here, '..', '..');
+const requireHarness = createRequire(join(repo, 'sync-harness', 'package.json'));
+const requireBackend = createRequire(join(repo, 'video-sync-backend', 'package.json'));
+const WebSocket = requireHarness('ws');
+const jwt = requireBackend('jsonwebtoken');
+const Redis = requireHarness('ioredis');
+
+const SECRET = 'relay-live-check-secret';
+const PORT = 3401;
+const REDIS_URL = 'redis://localhost:6380';
+
+let failed = 0;
+const ok = (label, cond, extra = '') => {
+  console.log(`${cond ? 'PASS ' : 'FAIL '} ${label}${extra ? ' - ' + extra : ''}`);
+  if (!cond) failed++;
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const mint = (claims, expiresIn = '1h') =>
+  jwt.sign({ name: 'live-check', ...claims }, SECRET, { expiresIn });
+
+/** Open a relay connection; resolve {ws, closed} where closed resolves with the close code. */
+const connect = (token) => {
+  const ws = new WebSocket(`ws://localhost:${PORT}/sync?token=${token}`);
+  const opened = new Promise((resolve) => {
+    ws.on('open', () => resolve(true));
+    ws.on('error', () => resolve(false));
+    ws.on('unexpected-response', (_req, res) => resolve(res.statusCode));
+    setTimeout(() => resolve('timeout'), 5000);
+  });
+  const closed = new Promise((resolve) => {
+    ws.on('close', (code) => resolve(code));
+  });
+  return { ws, opened, closed };
+};
+
+const joinRoom = (ws, room) => {
+  const frame = Buffer.alloc(2 + room.length);
+  frame.writeUInt8(0x05, 0);
+  frame.writeUInt8(room.length, 1);
+  Buffer.from(room).copy(frame, 2);
+  ws.send(frame);
+  return new Promise((resolve) => {
+    const onMsg = (buf) => {
+      if (Buffer.from(buf).readUInt8(0) === 0x06) {
+        ws.off('message', onMsg);
+        resolve(true);
+      }
+    };
+    ws.on('message', onMsg);
+    setTimeout(() => resolve(false), 2000);
+  });
+};
+
+const redis = new Redis(REDIS_URL);
+// a previous aborted run must not leak revocations into this one
+await redis.del('revoked:jti', 'revoked:userver');
+
+console.log('building relay...');
+const build = spawn('go', ['build', '-o', '/tmp/relay-live-check', '.'], {
+  cwd: join(repo, 'relay-go'),
+  stdio: 'inherit',
+});
+await new Promise((r, j) => build.on('exit', (c) => (c === 0 ? r() : j(new Error('go build failed')))));
+
+const relay = spawn(
+  '/tmp/relay-live-check',
+  ['-addr', `:${PORT}`, '-redis', REDIS_URL, '-lua-dir', join(repo, 'video-sync-backend', 'src', 'sync', 'lua'), '-jwt-secret', SECRET],
+  { stdio: ['ignore', 'pipe', 'pipe'] },
+);
+let relayLog = '';
+relay.stdout.on('data', (d) => (relayLog += d));
+relay.stderr.on('data', (d) => (relayLog += d));
+const relayDied = new Promise((r) => relay.on('exit', (code) => r(code)));
+await sleep(1200);
+
+try {
+  // -- baseline: two sessions for one user, one for another --
+  const tokenA = mint({ sub: 'u1', jti: 'jA', ver: 0 });
+  const tokenB = mint({ sub: 'u1', jti: 'jB', ver: 0 });
+  const a = connect(tokenA);
+  const b = connect(tokenB);
+  ok('SETUP: both sessions connect', (await a.opened) === true && (await b.opened) === true);
+  ok('SETUP: a joins a room', await joinRoom(a.ws, 'livecheckroom'));
+
+  // -- rooms that would alias other Redis keyspaces are refused --
+  ok('a room containing ":" is ignored, not spliced into keys',
+    !(await joinRoom(b.ws, 'a:b:tl')));
+  ok('the same connection still joins a VALID room after the refusal',
+    await joinRoom(b.ws, 'livecheckroom'));
+
+  // -- revoke ONE session: the backend's exact writes --
+  await redis.sadd('revoked:jti', 'jA');
+  await redis.publish('mustard:revocations', JSON.stringify({ kind: 'token', jti: 'jA' }));
+
+  const aClose = await Promise.race([a.closed, sleep(4000).then(() => 'still open')]);
+  ok('the revoked session is closed within a round trip', aClose !== 'still open',
+    `close code ${aClose}`);
+  ok('the sibling session survives', b.ws.readyState === WebSocket.OPEN);
+
+  // -- the revoked token cannot open a NEW connection --
+  const again = connect(tokenA);
+  ok('a revoked token is refused at accept', (await again.opened) === 401,
+    `got ${await again.opened}`);
+  again.ws.terminate();
+
+  // -- sign out everywhere: version bump --
+  await redis.hset('revoked:userver', 'u1', '1');
+  await redis.publish('mustard:revocations', JSON.stringify({ kind: 'user', userId: 'u1', version: 1 }));
+  const bClose = await Promise.race([b.closed, sleep(4000).then(() => 'still open')]);
+  ok('every stale session of the user is closed', bClose !== 'still open');
+
+  // -- but a token AT the new version connects: the strictly-less rule --
+  const fresh = connect(mint({ sub: 'u1', jti: 'jNew', ver: 1 }));
+  ok('the post-signout session is admitted', (await fresh.opened) === true);
+  await sleep(500);
+  ok('and stays up through the events above', fresh.ws.readyState === WebSocket.OPEN);
+  fresh.ws.close();
+
+  // -- tokens the relay must refuse on shape alone --
+  const noExp = connect(jwt.sign({ sub: 'u9', name: 'x' }, SECRET)); // no expiresIn
+  ok('a token with no exp is refused - it would never age out here',
+    (await noExp.opened) === 401, `got ${await noExp.opened}`);
+  const noSub = connect(mint({ jti: 'jX' }));
+  ok('a subject-less token is refused, matching the Node plane',
+    (await noSub.opened) === 401, `got ${await noSub.opened}`);
+
+  // -- expiry: the sweep must close a connection whose token ran out --
+  console.log('  (waiting ~35s for the expiry sweep - the token dies at +20s, the sweep runs every 30s)');
+  const dying = connect(mint({ sub: 'u3', jti: 'jE', ver: 0 }, '20s'));
+  ok('SETUP: the soon-to-expire session connects', (await dying.opened) === true);
+  const dyingClose = await Promise.race([dying.closed, sleep(36000).then(() => 'still open')]);
+  ok('the sweep closes a connection whose token expired', dyingClose !== 'still open',
+    `close code ${dyingClose}`);
+
+  // -- the hazard this file exists for: the relay must SURVIVE its evictions --
+  const alive = await Promise.race([relayDied, Promise.resolve('alive')]);
+  ok('the relay process survived every eviction (no close(c.send) panic)',
+    alive === 'alive', `exit ${alive}\n${relayLog.slice(-300)}`);
+} finally {
+  relay.kill();
+  await redis.del('revoked:jti', 'revoked:userver');
+  redis.disconnect();
+}
+
+console.log(failed ? `\n${failed} FAILED` : '\nall passed');
+process.exit(failed ? 1 : 0);

--- a/video-sync-backend/src/auth/revocation.service.spec.ts
+++ b/video-sync-backend/src/auth/revocation.service.spec.ts
@@ -17,10 +17,41 @@ const makeDb = (
   },
 });
 
-const service = async (db: ReturnType<typeof makeDb>) => {
-  const s = new RevocationService(db as unknown as DatabaseService, null, null);
+const service = async (db: ReturnType<typeof makeDb>, kv: unknown = null) => {
+  const s = new RevocationService(
+    db as unknown as DatabaseService,
+    null,
+    null,
+    kv as never,
+  );
   await s.refresh();
   return s;
+};
+
+/** An ioredis double that records what the mirror writes. */
+const makeKv = () => {
+  const calls: unknown[][] = [];
+  const record =
+    (name: string) =>
+    (...args: unknown[]) => {
+      calls.push([name, ...args]);
+      return kv; // multi chains
+    };
+  const kv: Record<string, unknown> = {
+    calls,
+    multi: () => kv,
+    del: record('del'),
+    sadd: record('sadd'),
+    hset: record('hset'),
+    rename: record('rename'),
+    exec: () => {
+      calls.push(['exec']);
+      return Promise.resolve([]);
+    },
+  };
+  return kv as unknown as {
+    calls: unknown[][];
+  };
 };
 
 const token = (over: Partial<TokenPayload> = {}): TokenPayload => ({
@@ -79,6 +110,7 @@ describe('what the snapshot refuses', () => {
     // retries.
     const s = new RevocationService(
       makeDb() as unknown as DatabaseService,
+      null,
       null,
       null,
     );
@@ -283,5 +315,71 @@ describe('a malformed announcement from another instance', () => {
     const s = await service(makeDb());
     expect(() => applyEvent(s, 'not json')).not.toThrow();
     expect(() => applyEvent(s, JSON.stringify({ kind: 'wat' }))).not.toThrow();
+  });
+});
+
+describe('the Redis mirror, which is how the relay learns', () => {
+  it('rebuilds under temp keys and swaps with RENAME, never in place', async () => {
+    // A reader mid-rebuild must not see a half-written set: a relay that
+    // reads between DEL and SADD would briefly trust revoked tokens.
+    const kv = makeKv();
+    await service(makeDb([{ jti: 'j1' }], [{ id: 'u1', tokenVersion: 2 }]), kv);
+
+    expect(kv.calls).toEqual([
+      ['del', 'revoked:jti:tmp', 'revoked:userver:tmp'],
+      ['sadd', 'revoked:jti:tmp', 'j1'],
+      ['rename', 'revoked:jti:tmp', 'revoked:jti'],
+      ['hset', 'revoked:userver:tmp', 'u1', '2'],
+      ['rename', 'revoked:userver:tmp', 'revoked:userver'],
+      ['exec'],
+    ]);
+  });
+
+  it('DELs the live keys when nothing is revoked - RENAME of nothing throws', async () => {
+    const kv = makeKv();
+    await service(makeDb(), kv);
+    expect(kv.calls).toEqual([
+      ['del', 'revoked:jti:tmp', 'revoked:userver:tmp'],
+      ['del', 'revoked:jti'],
+      ['del', 'revoked:userver'],
+      ['exec'],
+    ]);
+  });
+
+  it('mirrors a single revocation immediately, not on the next refresh', async () => {
+    // The pub/sub message and the mirror write travel together: a relay
+    // that misses the message still reads the SADD on its next poll, and
+    // one that gets the message can trust the mirror is already updated.
+    const kv = makeKv();
+    const s = await service(makeDb(), kv);
+    kv.calls.length = 0;
+
+    await s.revokeToken('j9', 'u1', new Date(Date.now() + 3600_000));
+    expect(kv.calls).toContainEqual(['sadd', 'revoked:jti', 'j9']);
+
+    await s.revokeAllForUser('u1');
+    expect(kv.calls).toContainEqual(['hset', 'revoked:userver', 'u1', '1']);
+  });
+
+  it('works with no Redis at all - the mirror is optional, the truth is not', async () => {
+    const s = await service(makeDb());
+    await expect(
+      s.revokeToken('j1', 'u1', new Date(Date.now() + 1000)),
+    ).resolves.toBeUndefined();
+  });
+
+  it('a mirror failure does not fail the revocation', async () => {
+    // The revocation is real once Postgres has it; the mirror is a cache.
+    // Refusing to sign someone out because a cache write failed would be
+    // backwards.
+    const kv = makeKv();
+    (kv as unknown as { sadd: () => never }).sadd = () => {
+      throw new Error('redis down');
+    };
+    const s = await service(makeDb(), kv);
+    await expect(
+      s.revokeToken('j1', 'u1', new Date(Date.now() + 1000)),
+    ).resolves.toBeUndefined();
+    expect(s.isRevoked(token({ jti: 'j1' }))).toBe('token');
   });
 });

--- a/video-sync-backend/src/auth/revocation.service.ts
+++ b/video-sync-backend/src/auth/revocation.service.ts
@@ -2,11 +2,28 @@ import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { Cron, CronExpression, Interval } from '@nestjs/schedule';
 import type Redis from 'ioredis';
 import { DatabaseService } from '../database/database.service';
-import { REDIS_PUB, REDIS_SUB } from '../redis/redis.module';
+import { REDIS_KV, REDIS_PUB, REDIS_SUB } from '../redis/redis.module';
 import { subjectOf, versionOf, type TokenPayload } from './token-payload';
 
 /** Where instances tell each other that something was revoked. */
 export const REVOCATION_CHANNEL = 'mustard:revocations';
+
+/**
+ * Where the snapshot is MIRRORED for consumers that have Redis but no
+ * Postgres - today that is relay-go, which verifies the same tokens against
+ * the same secret but had no way to learn a token was taken out of
+ * circulation (docs/AUTH.md used to call this out as unclosable because
+ * "the relay has no Redis connection" - which was simply false; it executes
+ * the shared Lua against the same instance).
+ *
+ * The mirror is a CACHE of the Postgres truth, rebuilt on every refresh. If
+ * Redis flushes (the deployment uses a no-persistence tier), the mirror is
+ * empty until the next refresh - the relay fails open to signature-only for
+ * at most REFRESH_MS, the same staleness bound an instance that missed a
+ * pub/sub message already has. Postgres remains the only durable record.
+ */
+export const REVOKED_JTI_KEY = 'revoked:jti';
+export const REVOKED_USERVER_KEY = 'revoked:userver';
 
 /**
  * How stale an instance's picture of revocations can get if the pub/sub
@@ -71,6 +88,7 @@ export class RevocationService implements OnModuleInit {
     private readonly database: DatabaseService,
     @Inject(REDIS_PUB) private readonly pub: Redis | null,
     @Inject(REDIS_SUB) private readonly sub: Redis | null,
+    @Inject(REDIS_KV) private readonly kv: Redis | null,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -136,6 +154,7 @@ export class RevocationService implements OnModuleInit {
       update: {},
     });
     this.rememberToken(jti);
+    await this.mirrorToken(jti);
     await this.announce({ kind: 'token', jti });
   }
 
@@ -147,6 +166,7 @@ export class RevocationService implements OnModuleInit {
       select: { tokenVersion: true },
     });
     this.rememberVersion(userId, user.tokenVersion);
+    await this.mirrorVersion(userId, user.tokenVersion);
     await this.announce({
       kind: 'user',
       userId,
@@ -214,6 +234,8 @@ export class RevocationService implements OnModuleInit {
       this.revokedTokens = nextTokens;
       this.userVersions = nextVersions;
       this.loaded = true;
+
+      await this.mirrorSnapshot(nextTokens, nextVersions);
     } catch (err) {
       // Keep the previous snapshot rather than emptying it. An empty
       // snapshot trusts every revoked token; a stale one only misses
@@ -227,6 +249,77 @@ export class RevocationService implements OnModuleInit {
       this.refreshing = false;
       this.pendingTokens.clear();
       this.pendingVersions.clear();
+    }
+  }
+
+  /**
+   * Rebuild the Redis mirror to match the snapshot, atomically.
+   *
+   * Built under temp keys and swapped in with RENAME so a reader never sees
+   * a half-written set - a relay that read mid-rebuild would briefly trust
+   * revoked tokens. RENAME of a nonexistent key throws, so the empty case
+   * (nothing revoked anywhere) is an explicit DEL of the live keys.
+   */
+  private async mirrorSnapshot(
+    jtis: Set<string>,
+    versions: Map<string, number>,
+  ): Promise<void> {
+    if (!this.kv) return;
+    try {
+      const multi = this.kv.multi();
+      const jtiTmp = `${REVOKED_JTI_KEY}:tmp`;
+      const verTmp = `${REVOKED_USERVER_KEY}:tmp`;
+      multi.del(jtiTmp, verTmp);
+      if (jtis.size > 0) {
+        multi.sadd(jtiTmp, ...jtis);
+        multi.rename(jtiTmp, REVOKED_JTI_KEY);
+      } else {
+        multi.del(REVOKED_JTI_KEY);
+      }
+      if (versions.size > 0) {
+        const flat: string[] = [];
+        for (const [id, v] of versions) flat.push(id, String(v));
+        multi.hset(verTmp, ...flat);
+        multi.rename(verTmp, REVOKED_USERVER_KEY);
+      } else {
+        multi.del(REVOKED_USERVER_KEY);
+      }
+      await multi.exec();
+    } catch (err) {
+      // The mirror is a cache; a failed rebuild leaves the previous one,
+      // which is stale rather than wrong - the same trade as the snapshot.
+      this.logger.warn(
+        `revocation mirror rebuild failed: ${
+          err instanceof Error ? err.message : 'unknown'
+        }`,
+      );
+    }
+  }
+
+  /** Incremental mirror writes, so the relay hears within a round trip. */
+  private async mirrorToken(jti: string): Promise<void> {
+    if (!this.kv) return;
+    try {
+      await this.kv.sadd(REVOKED_JTI_KEY, jti);
+    } catch (err) {
+      this.logger.warn(
+        `revocation mirror sadd failed: ${
+          err instanceof Error ? err.message : 'unknown'
+        }`,
+      );
+    }
+  }
+
+  private async mirrorVersion(userId: string, version: number): Promise<void> {
+    if (!this.kv) return;
+    try {
+      await this.kv.hset(REVOKED_USERVER_KEY, userId, String(version));
+    } catch (err) {
+      this.logger.warn(
+        `revocation mirror hset failed: ${
+          err instanceof Error ? err.message : 'unknown'
+        }`,
+      );
     }
   }
 


### PR DESCRIPTION
The last named gap in the revocation work (#59): `relay-go` verified a signature once at upgrade and threw the claims away. A revoked token satisfied it until expiry — and, found on the way in: **a token without `exp` never expired there at all**, because golang-jwt validates expiry only when the claim is present and nothing required it. A relay connection was immortal if its token said nothing about dying.

## The premise of "unclosable" was false

`docs/AUTH.md` said the relay "has no database or Redis connection to receive a snapshot." But the relay executes the shared Lua **against the same Redis** as everything else — that's its entire design (docs/RELAY.md). So no HTTP client, no new auth surface:

- **Backend** mirrors the snapshot into Redis on every refresh — `revoked:jti` (SET) + `revoked:userver` (HASH), rebuilt under temp keys and swapped with `RENAME` so a reader never sees a half-written set, plus incremental writes per revocation so the mirror is already correct when the pub/sub message lands. Postgres stays the only durable record; a Redis flush means signature-only for ≤ one refresh interval, the same bound a backend instance that missed a pub/sub message already has.
- **Relay** keeps the verified identity (sub/jti/ver/exp) on the connection, checks the mirror at accept, subscribes to `mustard:revocations` (eviction within a round trip), and sweeps every 30s for missed events and expired tokens.

## The details that were waiting to be bugs

- **Eviction closes the websocket only.** `c.send` is owned by the handler's defer; closing it from outside races `trySend` into a panic — and this relay is one process holding every room. The live check watches the relay *survive* its evictions as deliberately as it watches connections die.
- **Strictly-less version matching** — the session that did the signing-out holds a token at the new version and must not evict itself. A user event with **no** version selects nobody: zero is where every account starts, and a malformed message must not read as "evict everyone".
- **A global connection registry at accept, not at join** — the rooms map only sees a conn after Join, and a connection that authenticated with a since-revoked token and never joined is exactly the one a sweep most wants to find.
- **Room names now get cmdId's separator-free charset.** They're spliced into three Redis key shapes and were accepted raw — a room containing `:` addressed someone else's keyspace. Found by the terrain review, not by an incident, which is the cheap way to find it.
- **Subject-less tokens refused**, matching the Node socket plane. This and `exp`-required are deliberate tightenings; both are called out in RELAY.md.

## Verified live, not mocked

`scripts/live-checks/relay-revocation-check.mjs` — real relay binary, real Redis, real binary-protocol websockets, 16 checks all passing: revoked session closes (1008) while its sibling survives; revoked token refused at accept; sign-out-everywhere closes every stale session but admits the post-signout one; no-exp/no-sub refused; the expiry sweep closes a dying connection after a **real 35-second wait**, no mocked clocks; the relay process alive at the end.

Go tests pin claims extraction, event matching, and room validation. 421 backend tests. AUTH.md's false claim is corrected rather than deleted — the wrongness is part of the record.

## Worth arguing with

- **Fail-open on Redis errors at the accept check**: the relay cannot serve anything without Redis anyway, so refusing sign-ins on a Redis read error adds flakiness without adding safety. Stated in code.
- **30s sweep interval** matches the backend's documented staleness bound; it is not configurable, on purpose — a knob here would be a correctness parameter pretending to be tuning.
- The relay is a lab-plane study, not deployed to production — so this ships risk-free but also proves itself only in the lab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger relay authentication, including required token expiry and subject claims.
  * Added room-name validation with supported characters and length limits.
  * Added real-time token and user-session revocation checks, including automatic connection eviction.
  * Added periodic cleanup for expired and revoked sessions.
  * Added Redis-backed revocation mirroring with safe fallback behavior when Redis is unavailable.

* **Documentation**
  * Documented authentication, revocation handling, Redis fallback behavior, and room naming requirements.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->