### PR TITLE
feat: reorder injection with a witness that can call its own bluff — the exactly-once program closes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -143,6 +143,23 @@ jobs:
         # transition legal, newest entry identical to live state, drift rate 0
         run: npx tsx src/replay-check.ts --redis redis://localhost:6380 --gate
         working-directory: sync-harness
+      - name: chaos fleet - duplicated AND reordered controls (gated)
+        # The live half of the exactly-once battery. Every control is sent
+        # twice with the same cmdId, and a seek pair minted (A,B) is emitted
+        # (B,A). Injected at the APP layer because TCP toxics cannot produce
+        # either fault - TCP dedupes and re-sequences its own stream
+        # (docs/measurements/exactly-once/README.md). Gates: exact
+        # commit-count equality both directions, and a fleet-wide witness
+        # that the first-minted seek committed LAST - which fails loudly if
+        # the injection itself ever dies.
+        run: npx tsx src/bots/run-bots.ts --n 10 --duration 120 --ws http://localhost:3300 --gate --dup-controls --reorder-controls
+        working-directory: sync-harness
+      - name: replay reconciliation AFTER the chaos
+        # the strongest single assertion in the battery: with duplicates and
+        # reordering injected, every room's log still replays exactly to
+        # live state - nosnaplog's live analogue, under fault injection
+        run: npx tsx src/replay-check.ts --redis redis://localhost:6380 --gate
+        working-directory: sync-harness
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -51,10 +51,18 @@ directory is written, so the figure is reproducible but not citable.
   is in Redis, so playback state survives with the same `storeEpoch` — no
   reset, no snap to zero.
 - **Redis restart/flush**: the store rehydrates from the debounced Postgres
-  copy — always paused (P5) — under a **fresh random `storeEpoch`**.
-  Clients treat any new epoch as newer, so they can never be stranded at a
-  high stale seq. This is also why the free-tier production Redis needs no
-  persistence: losing it is a designed-for event.
+  copy — always paused (P5) — under a **fresh `storeEpoch` minted from redis
+  TIME**, so epochs are totally ordered by birth. The wording that used to
+  live here — "random epoch, clients treat any new epoch as newer" — is the
+  exact rule `formal/SyncTimeline.tla` REFUTES (`SyncTimeline_naive.cfg`): a
+  client that accepts any different epoch can be dragged backwards by a
+  stale broadcast from the old epoch. The client rule is a total order,
+  epoch first then seq (`shared/sync-core/timeline.ts isNewer`), and it is
+  sound only because mint-time epochs are comparable at all. The
+  implementation was always the ordered one; this paragraph was written
+  before the model check and never corrected. This is also why the
+  free-tier production Redis needs no persistence: losing it is a
+  designed-for event.
 - **Redis down**: control events fail fast with a typed error (the KV
   client has no offline queue); `/health` should surface degradation. No
   silent split-brain fallback.

--- a/docs/measurements/exactly-once/README.md
+++ b/docs/measurements/exactly-once/README.md
@@ -22,6 +22,7 @@ duplicate or reordering.
 |---|---|---|---|---|---|
 | `node-25bots-dup-injection.json` | node / 3-instance lab / nginx | 25 | 4 | **0** | 4 |
 | `relay-5bots-dup-injection.json` | relay-go / raw-WS binary | 5 | 4 | **0** | 4 |
+| `node-10bots-dup-reorder-chaos.json` | node / single instance | 10 | 6 | **0** | 6 + 1 swapped pair |
 
 What "absorbed" means, per plane:
 
@@ -37,7 +38,16 @@ What "absorbed" means, per plane:
   that otherwise produces none), through the extended binary control frame
   — same Lua, same dedup, cross-language.
 
-Both summaries carry `gitSha` (clean — the stamp appends `-dirty` when the
+The chaos run composes both modes: every control's same-`cmdId` twin AND a
+swapped seek pair in one fleet. Its gates: exact commit-count equality both
+directions (6 commands, 6 commits - the pair's members each committed once,
+their twins never), and the fleet-wide witness that the FIRST-minted seek
+committed last (every bot's `lastSeekMediaTime` at 500). `replay-check`
+ran immediately after and PASSED: with duplicates and reordering injected,
+every room's log still replays exactly to live state. Nightly now runs this
+same chaos fleet and post-chaos reconciliation on every build.
+
+All summaries carry `gitSha` (clean — the stamp appends `-dirty` when the
 tree does not match) and hardware. A failed double-apply would surface as a
 phantom seq: a commit consumed by the duplicate that the room's clients
 observe as a gap. Before this design, the ioredis resend path produced

--- a/docs/measurements/exactly-once/README.md
+++ b/docs/measurements/exactly-once/README.md
@@ -1,11 +1,22 @@
-# Exactly-once: duplicate-injection proof runs
+# Exactly-once: duplicate- and reorder-injection proof runs
 
 The idempotency-key design (SYNC_DESIGN §2a, `formal/SyncExactlyOnce.tla`)
-proven end-to-end by **app-level injection**: the bot fleet's
-`--dup-controls` mode sends every scripted control **twice with the same
-`cmdId`**. Injection is the only honest way to test this — netem's
-`duplicate` toxic copies TCP segments, which TCP itself dedupes, so no
-transport toxic can ever produce an application-level duplicate.
+proven end-to-end by **app-level injection**, two modes composable in one
+run:
+
+- `--dup-controls`: every scripted control sent **twice with the same
+  `cmdId`**.
+- `--reorder-controls`: a seek pair minted **(A=500, B=520)** and emitted
+  **(B, A)**. The store serializes by arrival, so A must commit LAST — and
+  every bot's `lastSeekMediaTime` is gated to sit at A's position,
+  fleet-wide. The witness doubles as the injection's own liveness check:
+  if the swap is ever "fixed" upstream, the witness lands on B and the
+  gate names the injection as dead instead of silently measuring nothing.
+
+Injection is the only honest way to test either — netem's `duplicate` and
+`reorder` toxics operate on TCP segments, which TCP itself dedupes and
+re-sequences, so no transport toxic can ever produce an application-level
+duplicate or reordering.
 
 | run | plane | bots | injected dups | seq gaps | dups absorbed |
 |---|---|---|---|---|---|

--- a/docs/measurements/exactly-once/node-10bots-dup-reorder-chaos.json
+++ b/docs/measurements/exactly-once/node-10bots-dup-reorder-chaos.json
@@ -1,0 +1,28 @@
+{
+  "runId": "bots-msrtzmk8",
+  "gitSha": "059fc3c8f6cfad5f94d186a9a9ab206bf1d850da",
+  "hardware": "10 cores (Apple M2 Pro)",
+  "controller": "reactive",
+  "plane": "node",
+  "n": 10,
+  "durationS": 120,
+  "steadySamples": 3327,
+  "driftMs": {
+    "p50": 75.08657532385143,
+    "p95": 113.56394670117353,
+    "p99": 299.72561519861074
+  },
+  "slopeMsPerMin": -5.107583223298207,
+  "thetaErrorP95Ms": 2.3714599609375,
+  "seqGaps": 0,
+  "seqReorders": 0,
+  "seqDuplicates": 6,
+  "reconnects": 0,
+  "rejoinFailures": 0,
+  "dupControlsSent": 6,
+  "reorderPairsSent": 1,
+  "scriptedControls": 6,
+  "controlCommitsObserved": 6,
+  "handlerErrors": 0,
+  "rejectedControls": 0
+}

--- a/sync-harness/src/bots/bot-client.ts
+++ b/sync-harness/src/bots/bot-client.ts
@@ -73,6 +73,18 @@ export interface BotReport {
   rejoinFailures: number;
   /** duplicate-injection mode: how many extra same-cmdId sends this bot made */
   dupControlsSent: number;
+  /** reorder-injection mode: how many swapped pairs this bot emitted */
+  reorderPairsSent: number;
+  /**
+   * The commanded position of the last seek-reason commit this bot applied.
+   *
+   * This is the reorder proof's witness: after a swapped pair (mint A then
+   * B, emit B then A), arrival-order serialization means A commits LAST, so
+   * every bot's last seek must sit at A's position. If someone "fixes" the
+   * emission order upstream, the witness lands on B and the gate names the
+   * injection as dead - an instrument that can say no.
+   */
+  lastSeekMediaTime: number | null;
   /** distinct (epoch,seq) of committed control transitions this bot saw */
   controlCommits: string[];
   handlerErrors: string[];
@@ -97,6 +109,8 @@ export class BotClient {
   private reconnects = 0;
   private rejoinFailures = 0;
   private dupControlsSent = 0;
+  private reorderPairsSent = 0;
+  private lastSeekMediaTime: number | null = null;
   /** every distinct committed CONTROL transition observed: (epoch, seq) of
    *  timelines whose reason is play/pause/seek. Snapshot commits excluded.
    *  A double-applied duplicate mints an EXTRA one of these - contiguous
@@ -191,6 +205,13 @@ export class BotClient {
 
     if (tl.reason === 'play' || tl.reason === 'pause' || tl.reason === 'seek') {
       this.controlCommits.add(`${tl.storeEpoch}:${tl.seq}`);
+    }
+    // Applied in ARRIVAL order deliberately, not isNewer order: the reorder
+    // witness asks "which seek did the store commit last", and the commit
+    // broadcast order carries that answer. A seek's mediaTime is the
+    // commanded position (restamp semantics), so this is exact.
+    if (tl.reason === 'seek' && isNewer(tl, this.timeline)) {
+      this.lastSeekMediaTime = tl.mediaTime;
     }
     if (isNewer(tl, this.timeline)) {
       this.timeline = tl;
@@ -289,6 +310,37 @@ export class BotClient {
     }
   }
 
+  /**
+   * The reorder-injection mode: TWO distinct commands, minted in the order
+   * (first, second) a user would mean them, EMITTED second-then-first.
+   *
+   * App-layer on purpose, same reasoning as the duplicate twin below: netem
+   * reorder operates on TCP segments and TCP re-sequences its own stream,
+   * so no transport toxic can make the app see B before A. The store
+   * serializes by arrival, so the swap must land the FIRST-minted command
+   * last - the fleet-wide lastSeekMediaTime witness pins exactly that, and
+   * both commands must commit (distinct cmdIds; the exact-count gate keeps
+   * holding).
+   */
+  sendIntentSwappedPair(
+    roomCode: string,
+    intent: ControlIntent,
+    firstMediaTime: number,
+    secondMediaTime: number,
+  ): void {
+    const firstId = randomUUID();
+    const secondId = randomUUID();
+    this.transport.sendControl(roomCode, intent, secondMediaTime, secondId);
+    this.transport.sendControl(roomCode, intent, firstMediaTime, firstId);
+    this.reorderPairsSent += 1;
+    if (this.cfg.duplicateControls) {
+      // chaos composes: the pair's twins ride the same dedup contract
+      this.transport.sendControl(roomCode, intent, secondMediaTime, secondId);
+      this.transport.sendControl(roomCode, intent, firstMediaTime, firstId);
+      this.dupControlsSent += 2;
+    }
+  }
+
   sendIntent(roomCode: string, intent: ControlIntent, mediaTime: number): void {
     const cmdId = randomUUID();
     this.transport.sendControl(roomCode, intent, mediaTime, cmdId);
@@ -330,6 +382,8 @@ export class BotClient {
       reconnects: this.reconnects,
       rejoinFailures: this.rejoinFailures,
       dupControlsSent: this.dupControlsSent,
+      reorderPairsSent: this.reorderPairsSent,
+      lastSeekMediaTime: this.lastSeekMediaTime,
       controlCommits: [...this.controlCommits],
       handlerErrors: this.handlerErrors,
       rejected: this.rejected,

--- a/sync-harness/src/bots/run-bots.ts
+++ b/sync-harness/src/bots/run-bots.ts
@@ -25,6 +25,7 @@ interface Args {
   controller: 'reactive' | 'predictive';
   plane: 'node' | 'relay';
   dupControls: boolean;
+  reorderControls: boolean;
 }
 
 function parseArgs(): Args {
@@ -41,6 +42,8 @@ function parseArgs(): Args {
     plane: (get('--plane') ?? 'node') as 'node' | 'relay',
     // exactly-once proof mode: every control sent twice with the same cmdId
     dupControls: process.argv.includes('--dup-controls'),
+    // reordering proof mode: a seek pair minted (A,B), emitted (B,A)
+    reorderControls: process.argv.includes('--reorder-controls'),
   };
 }
 
@@ -107,6 +110,13 @@ async function main(): Promise<void> {
   // guaranteed-quiet segment - that's where the growth gate measures.
   // pause freezes at the projected position, resume continues from it
   // (P4 semantics; a resume-from-0 would be a teleport, not a resume).
+  if (args.reorderControls && args.durationS < 75) {
+    // the pair fires at t=60; a shorter run reports success without ever
+    // injecting anything, which is exactly the silent-instrument failure
+    // this session of work exists to prevent
+    console.error('[bots] --reorder-controls needs --duration >= 75');
+    process.exit(1);
+  }
   const commander = bots[0];
   const t0 = Date.now();
   const projectedNow = (): number => {
@@ -122,12 +132,35 @@ async function main(): Promise<void> {
     scriptedControls += 1;
     commander.sendIntent(room.code, intent, mediaTime);
   };
+  // The reorder pair's positions. Constants rather than projections so the
+  // witness assertion has an exact target: after the swap, the FIRST-minted
+  // seek (500) must be the store's LAST commit, fleet-wide.
+  const REORDER_FIRST = 500;
+  const REORDER_SECOND = 520;
   const events: Array<{ atS: number; run: () => void }> = [
     { atS: 5, run: () => command('play', 0) },
     { atS: 30, run: () => command('seek', 300) },
     { atS: 40, run: () => bots[Math.min(2, bots.length - 1)].scriptedStall(4000) },
     { atS: 50, run: () => command('pause', projectedNow()) },
     { atS: 55, run: () => command('play', projectedNow()) },
+    ...(args.reorderControls
+      ? [
+          {
+            atS: 60,
+            run: () => {
+              // two commands, so the ground-truth counter moves by two;
+              // the swap happens inside the pair sender
+              scriptedControls += 2;
+              commander.sendIntentSwappedPair(
+                room.code,
+                'seek',
+                REORDER_FIRST,
+                REORDER_SECOND,
+              );
+            },
+          },
+        ]
+      : []),
   ];
   for (const e of events) {
     const wait = t0 + e.atS * 1000 - Date.now();
@@ -243,6 +276,7 @@ async function main(): Promise<void> {
     // these produce ZERO extra seqs - any double-apply shows as a phantom
     // seq in the integrity counters
     dupControlsSent,
+    reorderPairsSent: reports.reduce((sum, r) => sum + r.reorderPairsSent, 0),
     scriptedControls,
     controlCommitsObserved,
     handlerErrors: handlerErrors.length,
@@ -279,6 +313,27 @@ async function main(): Promise<void> {
       failures.push(
         `${controlCommitsObserved} control commits for ${scriptedControls} commands - a command was LOST`,
       );
+    if (args.reorderControls) {
+      // The witness: the pair was minted (500, 520) and emitted (520, 500),
+      // so arrival-order serialization commits 500 LAST. Every bot's last
+      // seek must sit there. This is also the injection's own liveness
+      // check - if the swap upstream is ever "fixed" into order, the
+      // witness lands on 520 and this names the injection as dead, rather
+      // than the run silently measuring nothing.
+      const pairs = reports.reduce((sum, r) => sum + r.reorderPairsSent, 0);
+      if (pairs < 1) failures.push('reorder mode on but no pair was sent');
+      const offWitness = reports.filter(
+        (r) =>
+          r.lastSeekMediaTime === null ||
+          Math.abs(r.lastSeekMediaTime - 500) > 1,
+      );
+      if (offWitness.length > 0)
+        failures.push(
+          `${offWitness.length}/${reports.length} bots' last seek is not at the ` +
+            `first-minted position (saw ${offWitness[0].lastSeekMediaTime}) - ` +
+            'either the swap died or arrival-order serialization broke',
+        );
+    }
     if (failures.length > 0) {
       console.error('[gate] FAILED:\n  ' + failures.join('\n  '));
       process.exit(1);

--- a/sync-harness/src/bots/transport.ts
+++ b/sync-harness/src/bots/transport.ts
@@ -56,6 +56,16 @@ export class SocketIOTransport implements SyncTransport {
       reconnectionAttempts: Infinity,
     });
     const socket = this.socket;
+    // Same enforcement as the real client (SocketContext): an emit that
+    // raced a dying transport sits in socket.io's sendBuffer, and the
+    // buffer flushes on reconnect BEFORE app handlers run - so the stray
+    // is dropped at the moment the death is detected, not "cleared" after
+    // it has already flushed. The bots must exercise the contract the
+    // production client actually lives under, or the fleet proves a
+    // different system than the one deployed.
+    socket.on('disconnect', () => {
+      socket.sendBuffer = [];
+    });
     this.pending.forEach((fn) => fn(socket));
     this.pending = [];
     return new Promise((resolve, reject) => {

--- a/sync-harness/src/bots/transport.ts
+++ b/sync-harness/src/bots/transport.ts
@@ -64,7 +64,12 @@ export class SocketIOTransport implements SyncTransport {
     // production client actually lives under, or the fleet proves a
     // different system than the one deployed.
     socket.on('disconnect', () => {
-      socket.sendBuffer = [];
+      // controls only, like the real client: a stale control re-commands
+      // the room from the past; everything else (clock pings, join-room)
+      // is harmless or idempotent late and keeps its place
+      socket.sendBuffer = socket.sendBuffer.filter(
+        (p: { data?: unknown[] }) => p?.data?.[0] !== SYNC_EVENTS.control,
+      );
     });
     this.pending.forEach((fn) => fn(socket));
     this.pending = [];

--- a/video-sync-frontend/src/contexts/SocketContext.tsx
+++ b/video-sync-frontend/src/contexts/SocketContext.tsx
@@ -119,6 +119,16 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
 
     socketInstance.on('disconnect', () => {
       console.log('Disconnected from server');
+      // Enforce the no-buffering contract the dedup TTL's soundness rests
+      // on (docs/SYNC_DESIGN.md, formal/SyncExactlyOnce.tla RetryWindow):
+      // an emit that raced a dying transport - connected still true, socket
+      // half-open - sits in socket.io's sendBuffer, and socket.io flushes
+      // that buffer on reconnect BEFORE app-level connect handlers run, so
+      // clearing on reconnect is too late. Cleared here, at the moment the
+      // death is detected, the stray is dropped instead of arriving
+      // arbitrarily late. A dropped gesture stays dropped; the user clicks
+      // again - the invariant sendIntent already documents.
+      socketInstance.sendBuffer = [];
       setConnected(false);
       // Only claim to be reconnecting once there is something to reconnect
       // TO. No toast: socket.io retries by itself, the status chip carries

--- a/video-sync-frontend/src/contexts/SocketContext.tsx
+++ b/video-sync-frontend/src/contexts/SocketContext.tsx
@@ -9,6 +9,7 @@ import { io, Socket } from 'socket.io-client';
 import { toast } from 'react-hot-toast';
 import { useAuth } from './AuthContext';
 import { AUTH_EXPIRED_EVENT } from '../services/api';
+import { dropStaleControls } from '../sync/drop-stale-controls';
 
 interface SocketContextType {
   socket: Socket | null;
@@ -124,11 +125,15 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
       // an emit that raced a dying transport - connected still true, socket
       // half-open - sits in socket.io's sendBuffer, and socket.io flushes
       // that buffer on reconnect BEFORE app-level connect handlers run, so
-      // clearing on reconnect is too late. Cleared here, at the moment the
-      // death is detected, the stray is dropped instead of arriving
-      // arbitrarily late. A dropped gesture stays dropped; the user clicks
-      // again - the invariant sendIntent already documents.
-      socketInstance.sendBuffer = [];
+      // clearing on reconnect is too late. Filtered here, at the moment the
+      // death is detected: a stale CONTROL is dropped instead of arriving
+      // arbitrarily late (a dropped gesture stays dropped; the user clicks
+      // again), while everything else - a chat message someone typed, whose
+      // input was already cleared and which has no recovery path - keeps
+      // its place and flushes on reconnect like it should. The first
+      // version of this cleared the whole buffer and would have eaten
+      // exactly those chat messages.
+      socketInstance.sendBuffer = dropStaleControls(socketInstance.sendBuffer);
       setConnected(false);
       // Only claim to be reconnecting once there is something to reconnect
       // TO. No toast: socket.io retries by itself, the status chip carries

--- a/video-sync-frontend/src/sync/drop-stale-controls.test.ts
+++ b/video-sync-frontend/src/sync/drop-stale-controls.test.ts
@@ -1,0 +1,41 @@
+import { dropStaleControls } from './drop-stale-controls';
+import { SYNC_EVENTS } from '../shared/sync-protocol';
+
+// The predicate the disconnect handler applies to socket.io's sendBuffer.
+// The first version cleared the WHOLE buffer, which enforced the control
+// no-buffering contract by also eating any chat message typed during a
+// half-open socket - ChatPanel clears its input on emit and has no
+// recovery, so those were lost permanently. Caught in review.
+
+const packet = (event: string, ...args: unknown[]) => ({
+  type: 2,
+  data: [event, ...args],
+});
+
+test('drops queued sync controls - the stale re-command hazard', () => {
+  const buffer = [
+    packet(SYNC_EVENTS.control, { intent: 'play', mediaTime: 3 }),
+    packet(SYNC_EVENTS.control, { intent: 'seek', mediaTime: 500 }),
+  ];
+  expect(dropStaleControls(buffer)).toEqual([]);
+});
+
+test('keeps everything that is not a control', () => {
+  // the chat message is the case that was being eaten; clock pings are
+  // matched by echoed t0 and harmless late; join-room is idempotent
+  const chat = packet('send-message', { message: 'typed during the blip' });
+  const clock = packet(SYNC_EVENTS.clock, { t0: 123 });
+  const join = packet('join-room', { roomCode: 'r1' });
+  const control = packet(SYNC_EVENTS.control, { intent: 'pause' });
+
+  expect(dropStaleControls([chat, control, clock, join])).toEqual([
+    chat,
+    clock,
+    join,
+  ]);
+});
+
+test('keeps packets with no recognizable shape rather than guessing', () => {
+  const odd = [{ type: 2 }, { data: [] }, {}] as { data?: unknown[] }[];
+  expect(dropStaleControls(odd)).toEqual(odd);
+});

--- a/video-sync-frontend/src/sync/drop-stale-controls.ts
+++ b/video-sync-frontend/src/sync/drop-stale-controls.ts
@@ -1,0 +1,27 @@
+import { SYNC_EVENTS } from '../shared/sync-protocol';
+
+/**
+ * Remove queued SYNC CONTROL packets from a socket.io send buffer, keeping
+ * everything else.
+ *
+ * The no-buffering contract the dedup TTL's soundness rests on applies to
+ * control traffic and control traffic only: a play/pause/seek that flushes
+ * arbitrarily late re-commands the room from the past, which is the exact
+ * hazard formal/SyncExactlyOnce.tla's RetryWindow bounds. A CHAT message
+ * flushing late is the opposite case - it is the message the person typed,
+ * arriving; ChatPanel clears its input on emit and has no recovery, so
+ * dropping it loses it permanently. The first version of this cleared the
+ * whole buffer and would have eaten exactly those messages.
+ *
+ * Clock pings may also sit here; they are kept because they are harmless
+ * late - each pong is matched by its echoed t0, and an unmatched pong is
+ * ignored.
+ *
+ * socket.io buffer entries are packets whose data array starts with the
+ * event name; anything shaped differently is not a control and is kept.
+ */
+export function dropStaleControls<T extends { data?: unknown[] }>(
+  buffer: T[],
+): T[] {
+  return buffer.filter((packet) => packet?.data?.[0] !== SYNC_EVENTS.control);
+}


### PR DESCRIPTION
The last open piece of the five-item exactly-once program. A terrain review established that four of the five items (spec, idempotency keys, command log + reconciliation, fencing) were already built and CI-enforced — the TLC battery was re-verified green locally today, all four teeth configs failing on exactly their named invariants. What was genuinely missing: **app-level reorder injection**, and CI wiring so the dup proof runs nightly instead of manually.

## Why injection must be app-level

The repo already documents it: netem's `duplicate` and `reorder` toxics operate on TCP segments, and TCP dedupes and re-sequences its own stream — the app never sees either fault from a transport toxic. S8/S9 are honestly labeled TCP-pathology-only. So reordering is injected where duplicates already are: at the bot's send seam.

## The witness

`--reorder-controls` mints a seek pair **(A=500, B=520)** in the order a user would mean and emits it **(B, A)**. The store serializes by arrival, so A must commit **last** — and the gate asserts every bot's last-applied seek sits at 500, fleet-wide. Two things fall out:

- **It proves the right property**: convergence and arrival-order serialization under reordering, with exact commit-count equality (both pair members commit once; their `--dup-controls` twins never do).
- **It can call its own bluff**: if anyone ever "fixes" the emission into minted order, the witness lands on 520 and the gate says the injection died — instead of the run silently measuring nothing. This session produced five instruments that couldn't say no; every new gate now gets built with a way to.

A guard refuses the flag on runs under 75s: the pair fires at t=60, and a shorter run would report success without injecting anything.

## Nightly gets the chaos fleet

After the clean 50-bot run: a 10-bot fleet with **both injections composed**, then `replay-check` **again** — with duplicates and reordering injected, every room's log must still replay exactly to live state. That post-chaos reconciliation is the live analogue of the spec's `nosnaplog` teeth config and the strongest single assertion in the battery.

## The no-buffering contract, actually enforced

The dedup TTL's soundness rests on "controls are never buffered" — and there was a hole: an emit racing a dying transport (connected still true, socket half-open) lands in socket.io's `sendBuffer` and flushes on reconnect. The subtle part: socket.io flushes that buffer **before** app-level connect handlers run, so the obvious fix — clear on reconnect — reads correct and does nothing. Cleared on **disconnect** instead, in the production client and the bot fleet both, because a harness that buffers where the client doesn't proves a different system than the one shipped.

## Docs stopped contradicting the model checker

`SCALING.md` described Redis-flush rehydration as minting a "fresh **random** `storeEpoch`" with "clients treat any new epoch as newer" — the exact client rule `SyncTimeline_naive.cfg` **refutes**. The implementation always minted ordered epochs from redis TIME (`init.lua`); the paragraph predated the model check. It now states the ordered rule and names the refuted one, so the next reader implements against the proof rather than the prose.

## Provenance

Committed proof run `node-10bots-dup-reorder-chaos.json`: n=10, 6 commands → 6 commits exactly, 6 twins absorbed, witness held fleet-wide, 0 gaps, P95 114ms, replay-check green immediately after. `gitSha 059fc3c`, clean — the first artifact attempt stamped `-dirty` because edits landed mid-run, which is the provenance convention catching precisely what it exists to catch.

## Worth arguing with

- The reorder pair is **one pair, at one scripted moment** — deliberate (a deterministic witness beats a probabilistic spray for gating), but it exercises one interleaving, not many.
- The chaos fleet runs at n=10, not 50 — the injection proof doesn't need fleet scale, and nightly minutes aren't free.
- `seqDuplicates` is deliberately not gated (it also counts legitimate repair-sweep duplicates); the commit-count equality is the dedup proof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated control messages from being sent after a connection drops and reconnects, improving playback synchronization reliability.

* **Testing**
  * Added expanded validation for duplicated and reordered control commands, including multi-bot chaos scenarios and replay consistency checks.

* **Documentation**
  * Updated scaling and exactly-once delivery guidance with restart recovery behavior, ordering guarantees, limitations, and new measurement results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->