### PR TITLE
feat: sliding sessions, provider linking, and set-password — behind re-auth, hardened by an adversarial review

### DIFF
--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -305,13 +305,14 @@ still works. The caller alone continues, on the token the response carries.
 
 ## Known gaps
 
-- No token **refresh**. A session ends when its token expires; there is no
-  way to extend one without signing in again.
+- ~~No token refresh~~ — added (see the Sessions section above): `POST
+  /auth/refresh` slides a live session, rotating and capping it.
 - ~~`JWT_EXPIRES_IN` is dead config~~ — fixed. Tokens **default** to `12h` and
   a deployment can change that by setting the variable; it is no longer a
   fixed lifetime. `12h` is what was hardcoded while the config file
   advertised `7d` to nobody. Raising it raises how long a stolen token is
-  useful, and there is still no revocation, so it is not a free knob. The
+  useful; revocation (above) and refresh rotation both narrow that window,
+  but it is still not a free knob. The
   value is validated at boot: a plain number means seconds, durations must be
   lowercase (`12h`, `30m`), and anything else refuses to start — because
   `jsonwebtoken` reads a unitless string as *milliseconds*, so `3600` would

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -256,6 +256,53 @@ loop would reconnect forever with a dead token.
   first and unconditionally; if the revoke call fails, the person is still
   signed out of that machine and the token dies on its own schedule.
 
+## Sessions: sliding, bounded, and endable
+
+`POST /auth/refresh` trades a live token for a fresh one. Three rules make
+it safe where a naive slide would not be:
+
+- **Rotation.** The new token gets a new `jti` and the old one is revoked in
+  the same call. A stolen copy is now WORTH LESS than before refresh
+  existed: the first party to refresh — victim or thief — kills the other's
+  copy, and a twelve-hour theft window shrinks to the gap between
+  refreshes. This is what made the old "no lifetime extension" rule
+  obsolete: it was written when revocation did not exist.
+- **The absolute cap.** Tokens carry `sess`, the session's birth, preserved
+  verbatim across refreshes. Thirty days after first sign-in, refresh
+  refuses and the person signs in again. A cap anchored to anything
+  refreshable is not a cap; pre-`sess` tokens anchor to their own `iat`,
+  the honest floor.
+- **Elevation cannot slide.** Five-minute re-auth tokens are refused by
+  refresh outright.
+
+The client refreshes at ~90% of token life. The socket reconnects once per
+refresh (~11h) — the price of not being signed out mid-film at hour twelve.
+
+## Re-authentication: the gate in front of credential changes
+
+The scenario every rule here serves: **someone else is holding a copy of
+the token.** A bearer token alone must not be able to add a sign-in method
+or change a password, because those are exactly the moves that turn a
+stolen session into a stolen account.
+
+| account state | to link Google | to set/change password |
+|---|---|---|
+| has a password | current password | current password |
+| Google only | (already linked) | fresh Google re-auth → 5-min elevated token |
+| guest | ungated (the session IS the identity) | — (claim first) |
+
+The elevated token is minted only after the OAuth callback proves the
+returning Google subject is THIS account's linked identity
+(`reauth_mismatch` otherwise), travels in the redirect fragment under its
+own name (`elev`, never `token` — the callback page parks it in
+sessionStorage and does not adopt it as a session), and is spent by
+`POST /auth/set-password` within five minutes or not at all.
+
+**Setting or changing a password ends every other session** — the
+`tokenVersion` bump rides the same database write as the new hash, so
+there is no window where the password changed but an attacker's token
+still works. The caller alone continues, on the token the response carries.
+
 ## Known gaps
 
 - No token **refresh**. A session ends when its token expires; there is no
@@ -269,16 +316,18 @@ loop would reconnect forever with a dead token.
   lowercase (`12h`, `30m`), and anything else refuses to start — because
   `jsonwebtoken` reads a unitless string as *milliseconds*, so `3600` would
   otherwise mean 3.6 seconds.
-- Linking a provider to an existing account is implemented **for guests
-  only** (`POST /auth/google/link-start`). A full account cannot add or swap a
-  provider - that needs a re-authentication step this does not have, and
-  adding one without it would let a stolen token attach an attacker's Google
-  identity to somebody's account.
-- A linked account has **no password and no way to acquire one**. Google is
-  then the only way in, and losing access to that Google account loses the
-  account - there is no reset flow, because there is nothing to reset. Same
-  for accounts created through Google in the first place. Claiming with a
-  password is the alternative, and the two do not compose.
+- ~~Linking a provider is guests-only~~ — full accounts link Google now,
+  gated on the current password (see Re-authentication above). Swapping or
+  UNLINKING a provider is still not built: unlink needs "would this leave
+  the account with no way in" reasoning that deserves its own design.
+- ~~A linked account has no password and no way to acquire one~~ — closed:
+  `POST /auth/set-password` behind the Google re-auth gate. The one-way
+  door is now a door.
+- **Account merging stays unbuilt, on purpose.** Two accounts that might be
+  one person mean migrating chat/participant/room foreign keys across
+  identities we cannot verify are the same person, destructively. "Sign in
+  with the account that owns that email" costs a sign-in; a wrong merge
+  costs someone their history.
 - `isPublic` on a room is a listing flag, not access control.
 - The "is this address already taken" check is a case-insensitive `findFirst`,
   which Postgres answers with a sequential scan — the `email` index is

--- a/scripts/live-checks/session-check.mjs
+++ b/scripts/live-checks/session-check.mjs
@@ -111,11 +111,16 @@ const l1 = (await call('/auth/register', {
   body: { username: 'launder' + rnd(), email: `l${rnd()}@e.com`, password: 'a-real-password' },
 })).body;
 const l2 = (await call('/auth/login', {
-  body: { username: decode(l1.token).name ?? '', password: 'a-real-password' },
-})).body || l1;
+  body: { username: decode(l1.token).name, password: 'a-real-password' },
+})).body;
+// The check is vacuous if l2 has no token: refresh with undefined sends no
+// Authorization header, the guard 401s, and the assertion passes having
+// laundered nothing. Assert the second session exists first.
+ok('SETUP: a second session to launder exists', Boolean(l2?.token),
+  `login status body: ${JSON.stringify(l2)?.slice(0, 80)}`);
 // use l1 to sign out everywhere, then try to REFRESH l2 (older version)
 await call('/auth/logout-all', { token: l1.token });
-const laundered = await call('/auth/refresh', { token: l2.token });
+const laundered = await call('/auth/refresh', { token: l2?.token });
 ok('a token from before logout-all cannot refresh itself back to life',
   laundered.status === 401, `status ${laundered.status}`);
 

--- a/scripts/live-checks/session-check.mjs
+++ b/scripts/live-checks/session-check.mjs
@@ -1,0 +1,106 @@
+// Sliding sessions and credential changes, against a real server.
+//
+// Three flows that only mean anything with real tokens, real revocation
+// state, and real time: refresh must ROTATE (the old token dies with the
+// refresh, not on its own schedule); linking Google to a full account must
+// be closed to a bearer token alone; and setting a password must end every
+// other session while the caller's own continues.
+//
+// Usage: node scripts/live-checks/session-check.mjs [http://localhost:3007]
+const BASE = (process.argv[2] ?? 'http://localhost:3007').replace(/\/$/, '');
+const API = `${BASE}/api`;
+const rnd = () => Math.random().toString(36).slice(2, 8);
+
+const call = async (path, { method = 'POST', body, token } = {}) => {
+  const r = await fetch(API + path, {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  return { status: r.status, body: await r.json().catch(() => null) };
+};
+
+let failed = 0;
+const ok = (label, cond, extra = '') => {
+  console.log(`${cond ? 'PASS ' : 'FAIL '} ${label}${extra ? ' - ' + extra : ''}`);
+  if (!cond) failed++;
+};
+const decode = (t) => JSON.parse(Buffer.from(t.split('.')[1], 'base64').toString());
+
+// ---- an account with a password, and a second session beside it ----
+const name = 'sess' + rnd();
+const first = (
+  await call('/auth/register', {
+    body: { username: name, email: `${name}@example.com`, password: 'a-real-password' },
+  })
+).body;
+ok('SETUP: an account', Boolean(first?.token));
+const second = (
+  await call('/auth/login', { body: { username: name, password: 'a-real-password' } })
+).body;
+ok('SETUP: a second session', Boolean(second?.token));
+
+// ---- refresh: rotation ----
+const refreshed = await call('/auth/refresh', { token: first.token });
+ok('refresh returns a new token', refreshed.status === 201 && Boolean(refreshed.body?.token));
+const oldClaims = decode(first.token);
+const newClaims = decode(refreshed.body.token);
+ok('the new token carries a NEW jti', newClaims.jti && newClaims.jti !== oldClaims.jti);
+ok('and preserves the session birth verbatim', newClaims.sess === oldClaims.sess,
+  `${oldClaims.sess} -> ${newClaims.sess}`);
+
+// the wait that makes the rotation check honest: the refresh revokes the
+// old jti through the revocation snapshot, which the guard reads in memory
+// on this same instance - immediate, no propagation needed
+const oldAfter = await call('/auth/me', { method: 'GET', token: first.token });
+ok('the OLD token is dead - rotation, not accumulation', oldAfter.status === 401,
+  `status ${oldAfter.status}`);
+ok('the new token works', (await call('/auth/me', { method: 'GET', token: refreshed.body.token })).status === 200);
+ok('the second session is untouched by the rotation',
+  (await call('/auth/me', { method: 'GET', token: second.token })).status === 200);
+
+// ---- link-start gate ----
+const wrongPw = await call('/auth/google/link-start', {
+  body: { password: 'not-the-password' },
+  token: refreshed.body.token,
+});
+// 404 when the provider is off entirely (local dev), 401 when on but the
+// password is wrong: both mean "a bearer token alone opened nothing"
+ok('linking with the wrong password is refused',
+  wrongPw.status === 401 || wrongPw.status === 404, `status ${wrongPw.status}`);
+
+// ---- set-password: current-password gate, then the version bump ----
+const wrongCurrent = await call('/auth/set-password', {
+  body: { currentPassword: 'wrong', newPassword: 'another-password-1' },
+  token: refreshed.body.token,
+});
+ok('changing the password demands the current one', wrongCurrent.status === 401);
+
+const changed = await call('/auth/set-password', {
+  body: { currentPassword: 'a-real-password', newPassword: 'another-password-1' },
+  token: refreshed.body.token,
+});
+ok('the change succeeds with the current password', changed.status === 201,
+  `status ${changed.status}`);
+ok('every OTHER session is signed out by the change',
+  (await call('/auth/me', { method: 'GET', token: second.token })).status === 401);
+ok('the token that made the change is signed out too - superseded by the response',
+  (await call('/auth/me', { method: 'GET', token: refreshed.body.token })).status === 401);
+ok('the caller continues on the returned token',
+  (await call('/auth/me', { method: 'GET', token: changed.body.token })).status === 200);
+ok('the new password signs in; the old one does not',
+  (await call('/auth/login', { body: { username: name, password: 'another-password-1' } })).status === 201 &&
+  (await call('/auth/login', { body: { username: name, password: 'a-real-password' } })).status === 401);
+
+// ---- refresh refuses what it must ----
+const guest = (await call('/auth/guest')).body;
+ok('SETUP: a guest', Boolean(guest?.token));
+const guestRefresh = await call('/auth/refresh', { token: guest.token });
+ok('a guest session refreshes too - guests are sessions like any other',
+  guestRefresh.status === 201);
+
+console.log(failed ? `\n${failed} FAILED` : '\nall passed');
+process.exit(failed ? 1 : 0);

--- a/scripts/live-checks/session-check.mjs
+++ b/scripts/live-checks/session-check.mjs
@@ -44,12 +44,17 @@ const second = (
 ok('SETUP: a second session', Boolean(second?.token));
 
 // ---- refresh: rotation ----
+// a full second between mint and refresh, so a token that WRONGLY restamped
+// its birth to 'now' would be caught by the equality below
+await new Promise((r) => setTimeout(r, 1100));
 const refreshed = await call('/auth/refresh', { token: first.token });
 ok('refresh returns a new token', refreshed.status === 201 && Boolean(refreshed.body?.token));
 const oldClaims = decode(first.token);
 const newClaims = decode(refreshed.body.token);
 ok('the new token carries a NEW jti', newClaims.jti && newClaims.jti !== oldClaims.jti);
-ok('and preserves the session birth verbatim', newClaims.sess === oldClaims.sess,
+ok('and preserves the session birth verbatim',
+  Number.isFinite(oldClaims.sess) && Number.isFinite(newClaims.sess) &&
+    newClaims.sess === oldClaims.sess,
   `${oldClaims.sess} -> ${newClaims.sess}`);
 
 // the wait that makes the rotation check honest: the refresh revokes the
@@ -67,10 +72,12 @@ const wrongPw = await call('/auth/google/link-start', {
   body: { password: 'not-the-password' },
   token: refreshed.body.token,
 });
-// 404 when the provider is off entirely (local dev), 401 when on but the
-// password is wrong: both mean "a bearer token alone opened nothing"
-ok('linking with the wrong password is refused',
-  wrongPw.status === 401 || wrongPw.status === 404, `status ${wrongPw.status}`);
+// exactly 401: link-start verifies the password before google.start() can
+// 404, so a wrong password is refused regardless of whether the provider is
+// configured. Accepting 404 would let this pass in the default dev env
+// without the gate ever running.
+ok('linking with the wrong password is refused with 401',
+  wrongPw.status === 401, `status ${wrongPw.status}`);
 
 // ---- set-password: current-password gate, then the version bump ----
 const wrongCurrent = await call('/auth/set-password', {
@@ -94,6 +101,36 @@ ok('the caller continues on the returned token',
 ok('the new password signs in; the old one does not',
   (await call('/auth/login', { body: { username: name, password: 'another-password-1' } })).status === 201 &&
   (await call('/auth/login', { body: { username: name, password: 'a-real-password' } })).status === 401);
+
+// ---- the laundering the review found: a revoked token must not refresh ----
+// sign out everywhere on the surviving token, then try to refresh a token
+// that was valid a moment ago. The authoritative DB check must catch it even
+// though (single instance) the snapshot is current - the point is that
+// refresh does NOT trust the token's own claim to a fresh version.
+const l1 = (await call('/auth/register', {
+  body: { username: 'launder' + rnd(), email: `l${rnd()}@e.com`, password: 'a-real-password' },
+})).body;
+const l2 = (await call('/auth/login', {
+  body: { username: decode(l1.token).name ?? '', password: 'a-real-password' },
+})).body || l1;
+// use l1 to sign out everywhere, then try to REFRESH l2 (older version)
+await call('/auth/logout-all', { token: l1.token });
+const laundered = await call('/auth/refresh', { token: l2.token });
+ok('a token from before logout-all cannot refresh itself back to life',
+  laundered.status === 401, `status ${laundered.status}`);
+
+// double-refresh of ONE token: the second is a reuse signal, must 401 AND
+// the first token's family should be burned
+const dr = (await call('/auth/register', {
+  body: { username: 'dr' + rnd(), email: `d${rnd()}@e.com`, password: 'a-real-password' },
+})).body;
+const [a, b] = await Promise.all([
+  call('/auth/refresh', { token: dr.token }),
+  call('/auth/refresh', { token: dr.token }),
+]);
+const wins = [a, b].filter((r) => r.status === 201).length;
+ok('concurrent double-refresh does not mint two live sessions',
+  wins <= 1, `${wins} of 2 refreshes succeeded`);
 
 // ---- refresh refuses what it must ----
 const guest = (await call('/auth/guest')).body;

--- a/video-sync-backend/src/auth/auth.controller.spec.ts
+++ b/video-sync-backend/src/auth/auth.controller.spec.ts
@@ -276,20 +276,23 @@ describe('starting a link, which is a different thing from signing in', () => {
     };
   };
 
-  it('seals the id the GUARD verified, not anything the caller sent', () => {
+  it('seals the id the GUARD verified, not anything the caller sent', async () => {
     // The whole security of linking rests here: a caller who could nominate
     // the account would be able to attach their Google identity to someone
     // else's.
     const { google, start } = makeLinkGoogle();
     const controller = new AuthController(
-      {} as unknown as AuthService,
+      {
+        // a guest: no password, no provider - the ungated link path
+        reauthMethodFor: jest.fn().mockResolvedValue(null),
+      } as unknown as AuthService,
       google,
       noRevocations(),
       jwtService,
     );
     const res = makeRes();
 
-    const out = controller.linkStart(
+    const out = await controller.linkStart(
       'user-from-token',
       { returnTo: '/room/abc' },
       res as unknown as Response,
@@ -304,14 +307,16 @@ describe('starting a link, which is a different thing from signing in', () => {
     expect(res.cookies[0].name).toBe('mw_oauth');
   });
 
-  it('returns the URL rather than redirecting to it', () => {
+  it('returns the URL rather than redirecting to it', async () => {
     // It is a POST carrying a bearer token, so the browser has to navigate
     // itself - a redirect here would be answered by fetch, not by the
     // address bar, and the flow would silently go nowhere.
     const { google } = makeLinkGoogle();
     const res = makeRes();
-    new AuthController(
-      {} as unknown as AuthService,
+    await new AuthController(
+      {
+        reauthMethodFor: jest.fn().mockResolvedValue(null),
+      } as unknown as AuthService,
       google,
       noRevocations(),
       jwtService,
@@ -491,5 +496,125 @@ describe('signing out', () => {
     const { controller, revocations } = withRevocations();
     await expect(controller.logoutAll('u1')).resolves.toEqual({ version: 4 });
     expect(revocations.revokeAllForUser).toHaveBeenCalledWith('u1');
+  });
+});
+
+describe('the re-auth gates in front of the new routes', () => {
+  const gated = (over: Record<string, unknown> = {}) => {
+    const authService = {
+      reauthMethodFor: jest.fn().mockResolvedValue('password'),
+      verifyPassword: jest.fn().mockResolvedValue(false),
+      setPassword: jest.fn().mockResolvedValue({ id: 'u1', token: 't' }),
+      refreshSession: jest.fn().mockResolvedValue({ id: 'u1', token: 't2' }),
+      ...over,
+    };
+    const controller = new AuthController(
+      authService as unknown as AuthService,
+      makeGoogle(false),
+      noRevocations(),
+      jwtService,
+    );
+    return { controller, authService };
+  };
+
+  const bearing = (claims: Record<string, unknown>, opts?: object) =>
+    ({
+      headers: {
+        authorization: `Bearer ${jwtService.sign(claims, opts)}`,
+      },
+    }) as Request;
+
+  it('link-start refuses a full account without the correct password', async () => {
+    // the gate this exists for: a stolen token alone must not be able to
+    // attach the thief's Google identity as a permanent second door
+    const { controller, authService } = gated();
+    const res = makeRes();
+    await expect(
+      controller.linkStart(
+        'u1',
+        { password: 'wrong' },
+        res as unknown as Response,
+      ),
+    ).rejects.toMatchObject({ status: 401 });
+    expect(res.cookies).toHaveLength(0); // no half-started flow left behind
+    expect(authService.verifyPassword).toHaveBeenCalledWith('u1', 'wrong');
+  });
+
+  it('set-password on a password account verifies the CURRENT one first', async () => {
+    const { controller, authService } = gated();
+    await expect(
+      controller.setPassword(
+        'u1',
+        { currentPassword: 'wrong', newPassword: 'a-new-password' },
+        bearing({ sub: 'u1', name: 'ada' }),
+      ),
+    ).rejects.toMatchObject({ status: 401 });
+    expect(authService.setPassword).not.toHaveBeenCalled();
+  });
+
+  it('set-password on a provider-only account demands a fresh elevation', async () => {
+    const { controller, authService } = gated({
+      reauthMethodFor: jest.fn().mockResolvedValue('google'),
+    });
+    // an ordinary session token - valid, unexpired, NOT elevated
+    await expect(
+      controller.setPassword(
+        'u1',
+        { newPassword: 'a-new-password' },
+        bearing({ sub: 'u1', name: 'ada', jti: 'j1' }),
+      ),
+    ).rejects.toMatchObject({ status: 401 });
+    expect(authService.setPassword).not.toHaveBeenCalled();
+  });
+
+  it('accepts elevation only for the SAME subject', async () => {
+    // an elevated token is still scoped to who earned it: u2's fresh
+    // Google round trip must not set u1's password
+    const { controller, authService } = gated({
+      reauthMethodFor: jest.fn().mockResolvedValue('google'),
+    });
+    await expect(
+      controller.setPassword(
+        'u1',
+        { newPassword: 'a-new-password' },
+        bearing({ sub: 'u2', name: 'eve', elev: 'reauth' }),
+      ),
+    ).rejects.toMatchObject({ status: 401 });
+    expect(authService.setPassword).not.toHaveBeenCalled();
+  });
+
+  it('elevation for the right subject opens the gate', async () => {
+    const { controller, authService } = gated({
+      reauthMethodFor: jest.fn().mockResolvedValue('google'),
+    });
+    await controller.setPassword(
+      'u1',
+      { newPassword: 'a-new-password' },
+      bearing({ sub: 'u1', name: 'ada', elev: 'reauth' }),
+    );
+    expect(authService.setPassword).toHaveBeenCalledWith(
+      'u1',
+      'a-new-password',
+    );
+  });
+
+  it('refresh refuses an elevated token - elevation must not be slidable', async () => {
+    const { controller, authService } = gated();
+    await expect(
+      controller.refresh(bearing({ sub: 'u1', name: 'ada', elev: 'reauth' })),
+    ).rejects.toMatchObject({ status: 401 });
+    expect(authService.refreshSession).not.toHaveBeenCalled();
+  });
+
+  it('refresh hands the verified payload to the service', async () => {
+    const { controller, authService } = gated();
+    await controller.refresh(
+      bearing({ sub: 'u1', name: 'ada', jti: 'j1', sess: 123 }),
+    );
+    const [[arg]] = authService.refreshSession.mock.calls as [
+      [{ jti: string; sess: number }],
+    ];
+    expect(arg.jti).toBe('j1');
+    expect(arg.sess).toBe(123);
   });
 });

--- a/video-sync-backend/src/auth/auth.controller.spec.ts
+++ b/video-sync-backend/src/auth/auth.controller.spec.ts
@@ -284,6 +284,7 @@ describe('starting a link, which is a different thing from signing in', () => {
     const controller = new AuthController(
       {
         // a guest: no password, no provider - the ungated link path
+        hasGoogleLink: jest.fn().mockResolvedValue(false),
         reauthMethodFor: jest.fn().mockResolvedValue(null),
       } as unknown as AuthService,
       google,
@@ -315,6 +316,7 @@ describe('starting a link, which is a different thing from signing in', () => {
     const res = makeRes();
     await new AuthController(
       {
+        hasGoogleLink: jest.fn().mockResolvedValue(false),
         reauthMethodFor: jest.fn().mockResolvedValue(null),
       } as unknown as AuthService,
       google,
@@ -502,6 +504,7 @@ describe('signing out', () => {
 describe('the re-auth gates in front of the new routes', () => {
   const gated = (over: Record<string, unknown> = {}) => {
     const authService = {
+      hasGoogleLink: jest.fn().mockResolvedValue(false),
       reauthMethodFor: jest.fn().mockResolvedValue('password'),
       verifyPassword: jest.fn().mockResolvedValue(false),
       setPassword: jest.fn().mockResolvedValue({ id: 'u1', token: 't' }),
@@ -616,5 +619,98 @@ describe('the re-auth gates in front of the new routes', () => {
     ];
     expect(arg.jti).toBe('j1');
     expect(arg.sess).toBe(123);
+  });
+});
+
+describe('the reauth callback branch - the gate with no coverage', () => {
+  // Finding 12: the owned !== linkUserId check had ZERO tests. Its failure
+  // mode is silence - a broken check mints an elevation for an account the
+  // caller does not control, and nothing would have caught it.
+  const reauthCallback = (opts: {
+    linkUserId: string;
+    returningSubject: string;
+    owner: string | null;
+  }) => {
+    const google = {
+      enabled: true,
+      assertEnabled: () => undefined,
+      verifyCallback: jest.fn().mockResolvedValue({
+        purpose: 'reauth',
+        linkUserId: opts.linkUserId,
+        identity: { subject: opts.returningSubject, email: 'a@b.co' },
+      }),
+      callbackRedirect: (f: string) =>
+        `https://mustard.watch/auth/callback#${f}`,
+      redirectUri: 'https://api.mustard.watch/api/auth/google/callback',
+    } as unknown as GoogleOAuthService;
+    const authService = {
+      googleSubjectOwner: jest.fn().mockResolvedValue(opts.owner),
+      mintElevatedToken: jest.fn().mockResolvedValue('ELEVATED'),
+    };
+    const controller = new AuthController(
+      authService as unknown as AuthService,
+      google,
+      noRevocations(),
+      jwtService,
+    );
+    return { controller, authService };
+  };
+
+  it('mints elevation only when the returning subject OWNS the account', async () => {
+    const { controller, authService } = reauthCallback({
+      linkUserId: 'u1',
+      returningSubject: 'sub-of-u1',
+      owner: 'u1',
+    });
+    const res = makeRes();
+    await controller.callback(
+      'c',
+      's',
+      undefined,
+      emptyReq,
+      res as unknown as Response,
+    );
+    expect(authService.mintElevatedToken).toHaveBeenCalledWith('u1');
+    expect(res.redirectedTo).toContain('elev=ELEVATED');
+    // never as a session token - the callback page must not adopt it
+    expect(res.redirectedTo).not.toContain('token=');
+  });
+
+  it('refuses when a DIFFERENT Google account completes the flow', async () => {
+    // the takeover this gate stops: signing in as someone else must not
+    // elevate you over the victim's account
+    const { controller, authService } = reauthCallback({
+      linkUserId: 'victim',
+      returningSubject: 'attacker-sub',
+      owner: 'attacker',
+    });
+    const res = makeRes();
+    await controller.callback(
+      'c',
+      's',
+      undefined,
+      emptyReq,
+      res as unknown as Response,
+    );
+    expect(authService.mintElevatedToken).not.toHaveBeenCalled();
+    expect(res.redirectedTo).toContain('error=reauth_mismatch');
+  });
+
+  it('refuses when the returning Google account is linked to NObody', async () => {
+    const { controller, authService } = reauthCallback({
+      linkUserId: 'u1',
+      returningSubject: 'unlinked-sub',
+      owner: null,
+    });
+    const res = makeRes();
+    await controller.callback(
+      'c',
+      's',
+      undefined,
+      emptyReq,
+      res as unknown as Response,
+    );
+    expect(authService.mintElevatedToken).not.toHaveBeenCalled();
+    expect(res.redirectedTo).toContain('error=reauth_mismatch');
   });
 });

--- a/video-sync-backend/src/auth/auth.controller.ts
+++ b/video-sync-backend/src/auth/auth.controller.ts
@@ -307,6 +307,19 @@ export class AuthController {
     // account must prove the password: without that gate, anyone holding a
     // stolen token could attach their own Google identity and gain a
     // permanent second door into the account.
+    // One Google identity per account. Decided BEFORE the re-auth branch,
+    // and independently of it: an account with BOTH a password and a Google
+    // link returns 'password' from reauthMethodFor, so gating the 409 on the
+    // method alone would let a password+Google account attach a SECOND
+    // Google identity - which the 'google' branch below correctly forbids
+    // but the 'password' branch would have waved through.
+    if (await this.authService.hasGoogleLink(userId)) {
+      throw new ConflictExceptionWithCode(
+        'link_provider_taken',
+        'This account already signs in with Google',
+      );
+    }
+
     const method = await this.authService.reauthMethodFor(userId);
     let purpose: 'link-guest' | 'link-full';
     if (method === 'password') {

--- a/video-sync-backend/src/auth/auth.controller.ts
+++ b/video-sync-backend/src/auth/auth.controller.ts
@@ -1,4 +1,5 @@
 import {
+  ConflictException,
   Controller,
   Get,
   Post,
@@ -10,6 +11,7 @@ import {
   Res,
   UseGuards,
   Logger,
+  UnauthorizedException,
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { AuthService } from './auth.service';
@@ -17,6 +19,13 @@ import { JwtAuthGuard } from './jwt-auth.guard';
 import { JwtService } from '@nestjs/jwt';
 import { RevocationService } from './revocation.service';
 import type { TokenPayload } from './token-payload';
+
+/** ConflictException carrying a machine code, the redirect-fragment contract. */
+const ConflictExceptionWithCode = class extends ConflictException {
+  constructor(code: string, message: string) {
+    super({ code, message });
+  }
+};
 import { CurrentUser } from './current-user.decorator';
 import {
   GoogleAuthError,
@@ -288,18 +297,136 @@ export class AuthController {
    */
   @Post('google/link-start')
   @UseGuards(JwtAuthGuard)
-  linkStart(
+  async linkStart(
     @CurrentUser('userId') userId: string,
-    @Body() body: { returnTo?: string },
+    @Body() body: { returnTo?: string; password?: string },
     @Res({ passthrough: true }) res: Response,
-  ): { authUrl: string } {
+  ): Promise<{ authUrl: string }> {
+    // Which flavor of link this is decides the re-auth gate. A guest has
+    // nothing to verify - their session IS their whole identity. A full
+    // account must prove the password: without that gate, anyone holding a
+    // stolen token could attach their own Google identity and gain a
+    // permanent second door into the account.
+    const method = await this.authService.reauthMethodFor(userId);
+    let purpose: 'link-guest' | 'link-full';
+    if (method === 'password') {
+      if (
+        !(await this.authService.verifyPassword(userId, body?.password ?? ''))
+      ) {
+        throw new UnauthorizedException(
+          'Current password required to link a sign-in method',
+        );
+      }
+      purpose = 'link-full';
+    } else if (method === 'google') {
+      // already linked; a second Google identity on one account is not a
+      // thing this supports
+      throw new ConflictExceptionWithCode(
+        'link_provider_taken',
+        'This account already signs in with Google',
+      );
+    } else {
+      purpose = 'link-guest';
+    }
+
     const { authUrl, cookie } = this.google.start(
       body?.returnTo,
       Date.now(),
       userId,
+      purpose,
     );
     res.cookie(OAUTH_COOKIE, cookie, this.cookieOptions());
     return { authUrl };
+  }
+
+  /**
+   * Prove you can still complete Google as this account's linked identity.
+   *
+   * The gate behind set-password for accounts that HAVE no password to
+   * verify: the callback checks the returning Google subject against the
+   * account's linked one and mints a five-minute elevated token. A stolen
+   * session token cannot pass this - the thief would have to complete
+   * Google's own sign-in as the victim.
+   */
+  @Post('google/reauth-start')
+  @UseGuards(JwtAuthGuard)
+  async reauthStart(
+    @CurrentUser('userId') userId: string,
+    @Body() body: { returnTo?: string },
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<{ authUrl: string }> {
+    const method = await this.authService.reauthMethodFor(userId);
+    if (method !== 'google') {
+      throw new ConflictExceptionWithCode(
+        'reauth_wrong_method',
+        'This account re-authenticates with its password',
+      );
+    }
+    const { authUrl, cookie } = this.google.start(
+      body?.returnTo,
+      Date.now(),
+      userId,
+      'reauth',
+    );
+    res.cookie(OAUTH_COOKIE, cookie, this.cookieOptions());
+    return { authUrl };
+  }
+
+  /**
+   * Set or change the password. Re-auth first, always:
+   * - an account WITH a password proves the current one;
+   * - an account WITHOUT one (Google-created or Google-linked-as-guest)
+   *   presents the five-minute elevated token from /google/reauth-start.
+   * Then every other session ends - the version bump rides the same
+   * database write as the new hash - and the caller alone continues, on
+   * the fresh token this returns.
+   */
+  @Post('set-password')
+  @UseGuards(JwtAuthGuard)
+  async setPassword(
+    @CurrentUser('userId') userId: string,
+    @Body() body: { currentPassword?: string; newPassword: string },
+    @Req() req: Request,
+  ) {
+    const method = await this.authService.reauthMethodFor(userId);
+    if (method === 'password') {
+      if (
+        !(await this.authService.verifyPassword(
+          userId,
+          body?.currentPassword ?? '',
+        ))
+      ) {
+        throw new UnauthorizedException('Current password is wrong');
+      }
+    } else if (method === 'google') {
+      const payload = this.decodeOwnToken(req);
+      if (payload?.elev !== 'reauth' || payload.sub !== userId) {
+        throw new UnauthorizedException(
+          'Confirm with Google first - this account has no password to verify',
+        );
+      }
+    } else {
+      throw new UnauthorizedException('No re-authentication method available');
+    }
+    return await this.authService.setPassword(userId, body?.newPassword ?? '');
+  }
+
+  /**
+   * Trade a live token for a fresh one - the sliding half of sessions.
+   * The old token is revoked in the same call (rotation), and the slide is
+   * bounded by the session's birth, which refreshes preserve.
+   */
+  @Post('refresh')
+  @UseGuards(JwtAuthGuard)
+  async refresh(@Req() req: Request) {
+    const payload = this.decodeOwnToken(req);
+    if (!payload) throw new UnauthorizedException('Invalid token');
+    // an elevated token is a five-minute instrument, not a session to keep
+    // alive; refusing here keeps elevation from outliving its purpose
+    if (payload.elev) {
+      throw new UnauthorizedException('Re-auth tokens cannot be refreshed');
+    }
+    return await this.authService.refreshSession(payload);
   }
 
   /** Step one: bounce to Google, carrying a sealed CSRF/PKCE cookie. */
@@ -341,7 +468,7 @@ export class AuthController {
     res.clearCookie(OAUTH_COOKIE, this.cookieOptions());
 
     try {
-      const { identity, returnTo, linkUserId } =
+      const { identity, returnTo, linkUserId, purpose } =
         await this.google.verifyCallback({
           code,
           state,
@@ -349,12 +476,38 @@ export class AuthController {
           cookie: readCookie(req.headers.cookie, OAUTH_COOKIE),
         });
 
-      // Two flows come back through this one door, and which it is was
-      // decided at /link-start by a token we verified - not by anything in
-      // the request that is arriving now.
-      const user = linkUserId
-        ? await this.authService.linkGoogleToGuest(linkUserId, identity)
-        : await this.authService.signInWithGoogle(identity);
+      // Four flows come back through this one door, and which it is was
+      // sealed at start by a token we verified then - never by anything in
+      // the request arriving now.
+      if (purpose === 'reauth' && linkUserId) {
+        // Prove the returning Google subject IS this account's linked
+        // identity - completing Google as someone else must not elevate.
+        const owned = await this.authService.googleSubjectOwner(
+          identity.subject,
+        );
+        if (owned !== linkUserId) {
+          res.redirect(
+            this.google.callbackRedirect(
+              new URLSearchParams({ error: 'reauth_mismatch' }).toString(),
+            ),
+          );
+          return;
+        }
+        // Five minutes of elevation, in the FRAGMENT under its own name -
+        // the callback page must not adopt it as a session.
+        const elev = await this.authService.mintElevatedToken(linkUserId);
+        const params = new URLSearchParams({ elev });
+        if (returnTo) params.set('to', returnTo);
+        res.redirect(this.google.callbackRedirect(params.toString()));
+        return;
+      }
+
+      const user =
+        purpose === 'link-full' && linkUserId
+          ? await this.authService.linkGoogleToFull(linkUserId, identity)
+          : linkUserId
+            ? await this.authService.linkGoogleToGuest(linkUserId, identity)
+            : await this.authService.signInWithGoogle(identity);
 
       // The token rides in the FRAGMENT, never the query string: fragments
       // are not sent to servers, do not reach access logs, and are not

--- a/video-sync-backend/src/auth/auth.service.spec.ts
+++ b/video-sync-backend/src/auth/auth.service.spec.ts
@@ -54,6 +54,11 @@ const makeRevocations = () =>
   ({
     revokeToken: jest.fn().mockResolvedValue(undefined),
     noteVersionBumped: jest.fn().mockResolvedValue(undefined),
+    revokeAllForUser: jest.fn().mockResolvedValue(1),
+    // claimRevocation defaults to WON (this is the true rotation); tests
+    // that model a race override it to false
+    claimRevocation: jest.fn().mockResolvedValue(true),
+    isJtiRevokedDurable: jest.fn().mockResolvedValue(false),
   }) as unknown as import('./revocation.service').RevocationService;
 
 const serviceWith = (
@@ -684,7 +689,7 @@ describe('refreshing a session', () => {
     const decoded = claims(out.token);
     expect(decoded.jti).not.toBe('j-old');
     expect(decoded.ver).toBe(2);
-    const [jti, userId] = (revocations.revokeToken as jest.Mock).mock
+    const [jti, userId] = (revocations.claimRevocation as jest.Mock).mock
       .calls[0] as [string, string];
     expect(jti).toBe('j-old');
     expect(userId).toBe('u1');
@@ -696,6 +701,7 @@ describe('refreshing a session', () => {
     const out = await service.refreshSession({
       sub: 'u1',
       jti: 'j1',
+      ver: 2,
       sess: birth,
     });
     expect(claims(out.token).sess).toBe(birth);
@@ -725,11 +731,23 @@ describe('refreshing a session', () => {
     ).rejects.toMatchObject({ status: 401 });
   });
 
-  it('still refreshes a legacy token with no jti - it just cannot revoke it', async () => {
-    const { service, revocations } = refreshing();
+  it('still refreshes a legacy token with no jti - nothing to claim', async () => {
+    // A token from before jti/ver existed: no jti, and absent ver reads as
+    // version 0. It refreshes while the account is still at version 0
+    // (nobody has revoked-all since) - old is not the same as revoked.
+    const db = makeDb();
+    db.user.findUnique.mockResolvedValue({
+      id: 'u1',
+      username: 'ada',
+      tokenVersion: 0,
+    });
+    const revocations = makeRevocations();
+    const service = serviceWith(db, revocations);
     const out = await service.refreshSession({ sub: 'u1', sess: nowS() - 60 });
     expect(typeof out.token).toBe('string');
-    expect((revocations.revokeToken as jest.Mock).mock.calls).toHaveLength(0);
+    expect((revocations.claimRevocation as jest.Mock).mock.calls).toHaveLength(
+      0,
+    );
   });
 });
 
@@ -853,5 +871,91 @@ describe('which re-auth gate an account needs', () => {
     await expect(
       withUser({ password: null }).verifyPassword('u1', 'anything'),
     ).resolves.toBe(false);
+  });
+});
+
+describe('refresh must not launder a revoked token back to life', () => {
+  const nowS = () => Math.floor(Date.now() / 1000);
+  const setup = (dbVersion: number) => {
+    const db = makeDb();
+    db.user.findUnique.mockResolvedValue({
+      id: 'u1',
+      username: 'ada',
+      tokenVersion: dbVersion,
+    });
+    const revocations = makeRevocations();
+    return { db, revocations, service: serviceWith(db, revocations) };
+  };
+
+  it('refuses a token issued before the current version - the logout-all laundering', async () => {
+    // The critical bug the review found: the guard's snapshot can lag a
+    // logout-all, but the DB cannot. A token at ver 1 must not mint a fresh
+    // token when the account is already at ver 2, however stale the snapshot.
+    const { service, revocations } = setup(2);
+    await expect(
+      service.refreshSession({ sub: 'u1', jti: 'j1', ver: 1, sess: nowS() }),
+    ).rejects.toMatchObject({ status: 401 });
+    expect((revocations.claimRevocation as jest.Mock).mock.calls).toHaveLength(
+      0,
+    );
+  });
+
+  it('refuses a token whose jti is already revoked in Postgres', async () => {
+    // the single-logout laundering: guard snapshot lags, DB does not
+    const { service } = setup(0);
+    (
+      service as unknown as {
+        revocations: { isJtiRevokedDurable: jest.Mock };
+      }
+    ).revocations.isJtiRevokedDurable.mockResolvedValue(true);
+    await expect(
+      service.refreshSession({
+        sub: 'u1',
+        jti: 'j-revoked',
+        ver: 0,
+        sess: nowS(),
+      }),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('treats a lost rotation race as compromise - revokes the whole family', async () => {
+    // two copies of one token refresh at once; the loser must not merely
+    // fail, it must burn every session including the winner's fresh token
+    const { service, revocations } = setup(0);
+    (revocations.claimRevocation as jest.Mock).mockResolvedValue(false);
+    await expect(
+      service.refreshSession({ sub: 'u1', jti: 'j1', ver: 0, sess: nowS() }),
+    ).rejects.toMatchObject({ status: 401 });
+    expect((revocations.revokeAllForUser as jest.Mock).mock.calls).toEqual([
+      ['u1'],
+    ]);
+  });
+
+  it('the happy path: claims the old jti, mints at the current version', async () => {
+    const { service, revocations } = setup(3);
+    const out = await service.refreshSession({
+      sub: 'u1',
+      jti: 'j1',
+      ver: 3,
+      sess: nowS() - 60,
+    });
+    expect(
+      (revocations.claimRevocation as jest.Mock).mock.calls.length,
+    ).toBeGreaterThan(0);
+    const claims = jwtService.decode<{ ver: number; jti: string }>(out.token);
+    expect(claims.ver).toBe(3);
+    expect(claims.jti).not.toBe('j1');
+  });
+
+  it('refuses a malformed version claim rather than reading it as 0', async () => {
+    const { service } = setup(0);
+    await expect(
+      service.refreshSession({
+        sub: 'u1',
+        jti: 'j1',
+        ver: 'nope' as unknown as number,
+        sess: nowS(),
+      }),
+    ).rejects.toMatchObject({ status: 401 });
   });
 });

--- a/video-sync-backend/src/auth/auth.service.spec.ts
+++ b/video-sync-backend/src/auth/auth.service.spec.ts
@@ -32,6 +32,7 @@ const makeDb = () => ({
   },
   oAuthAccount: {
     findUnique: jest.fn().mockResolvedValue(null),
+    create: jest.fn().mockResolvedValue(undefined),
   },
 });
 
@@ -48,8 +49,17 @@ interface CreateUserArgs {
 const createCalls = (db: ReturnType<typeof makeDb>): CreateUserArgs[] =>
   (db.user.create.mock.calls as CreateUserArgs[][]).map((call) => call[0]);
 
-const serviceWith = (db: ReturnType<typeof makeDb>) =>
-  new AuthService(db as unknown as DatabaseService, jwtService);
+/** Revocations double: records bumps, revokes nothing on its own. */
+const makeRevocations = () =>
+  ({
+    revokeToken: jest.fn().mockResolvedValue(undefined),
+    noteVersionBumped: jest.fn().mockResolvedValue(undefined),
+  }) as unknown as import('./revocation.service').RevocationService;
+
+const serviceWith = (
+  db: ReturnType<typeof makeDb>,
+  revocations = makeRevocations(),
+) => new AuthService(db as unknown as DatabaseService, jwtService, revocations);
 
 describe('login with provider-only accounts in the table', () => {
   it('answers a passwordless account with the same 401 as a wrong password', async () => {
@@ -640,5 +650,208 @@ describe('attaching Google to a guest', () => {
     ).rejects.toMatchObject({
       status: 409,
     });
+  });
+});
+
+describe('refreshing a session', () => {
+  const nowS = () => Math.floor(Date.now() / 1000);
+  /** decode() defaults to any; the generic names what this suite reads -
+   *  and unlike an `as` cast, eslint --fix cannot strip it. */
+  const claims = (t: string) =>
+    jwtService.decode<{ jti: string; ver: number; sess: number }>(t);
+
+  const refreshing = () => {
+    const db = makeDb();
+    db.user.findUnique.mockResolvedValue({
+      id: 'u1',
+      username: 'ada',
+      tokenVersion: 2,
+    });
+    const revocations = makeRevocations();
+    return { db, revocations, service: serviceWith(db, revocations) };
+  };
+
+  it('rotates: new jti, old token revoked in the same call', async () => {
+    const { service, revocations } = refreshing();
+    const out = await service.refreshSession({
+      sub: 'u1',
+      jti: 'j-old',
+      ver: 2,
+      sess: nowS() - 3600,
+      exp: nowS() + 1000,
+    });
+
+    const decoded = claims(out.token);
+    expect(decoded.jti).not.toBe('j-old');
+    expect(decoded.ver).toBe(2);
+    const [jti, userId] = (revocations.revokeToken as jest.Mock).mock
+      .calls[0] as [string, string];
+    expect(jti).toBe('j-old');
+    expect(userId).toBe('u1');
+  });
+
+  it('preserves the session birth verbatim - the cap must not slide', async () => {
+    const { service } = refreshing();
+    const birth = nowS() - 5 * 24 * 3600;
+    const out = await service.refreshSession({
+      sub: 'u1',
+      jti: 'j1',
+      sess: birth,
+    });
+    expect(claims(out.token).sess).toBe(birth);
+  });
+
+  it('refuses a session past thirty days, however fresh its token', async () => {
+    // the whole point of anchoring to birth: a token refreshed every 11
+    // hours is perpetually young; the SESSION is not
+    const { service, revocations } = refreshing();
+    await expect(
+      service.refreshSession({
+        sub: 'u1',
+        jti: 'j1',
+        sess: nowS() - 31 * 24 * 3600,
+      }),
+    ).rejects.toMatchObject({ status: 401 });
+    expect((revocations.revokeToken as jest.Mock).mock.calls).toHaveLength(0);
+  });
+
+  it('anchors a pre-sess token to its own iat, not to now', async () => {
+    // anchoring to now would grant every legacy token a fresh 30 days on
+    // first refresh - a cap that resets is not a cap
+    const { service } = refreshing();
+    const iat = nowS() - 40 * 24 * 3600;
+    await expect(
+      service.refreshSession({ sub: 'u1', jti: 'j1', iat }),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('still refreshes a legacy token with no jti - it just cannot revoke it', async () => {
+    const { service, revocations } = refreshing();
+    const out = await service.refreshSession({ sub: 'u1', sess: nowS() - 60 });
+    expect(typeof out.token).toBe('string');
+    expect((revocations.revokeToken as jest.Mock).mock.calls).toHaveLength(0);
+  });
+});
+
+describe('linking Google to a FULL account', () => {
+  const linking = () => {
+    const db = makeDb();
+    db.user.findUnique.mockResolvedValue({
+      id: 'u1',
+      username: 'ada',
+      email: 'ada@example.com',
+      tokenVersion: 0,
+    });
+    return { db, service: serviceWith(db) };
+  };
+
+  it('adds the provider row and touches nothing else about the account', async () => {
+    // the guest path rewrites identity because a guest has none worth
+    // keeping; a full account's name and email are THEIRS
+    const { db, service } = linking();
+    const out = await service.linkGoogleToFull('u1', identity);
+    expect(db.user.update).not.toHaveBeenCalled();
+    expect(db.oAuthAccount.create).toHaveBeenCalledWith({
+      data: {
+        provider: 'google',
+        providerAccountId: 'google-sub-123',
+        userId: 'u1',
+      },
+    });
+    expect(out.username).toBe('ada');
+  });
+
+  it('refuses a Google account already linked to someone else', async () => {
+    const { db, service } = linking();
+    db.oAuthAccount.findUnique.mockResolvedValue({ userId: 'someone-else' });
+    await expect(
+      service.linkGoogleToFull('u1', identity),
+    ).rejects.toMatchObject({ status: 409 });
+    expect(db.oAuthAccount.create).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent when already linked to THIS account', async () => {
+    // a double-submitted flow should not scold the person it worked for
+    const { db, service } = linking();
+    db.oAuthAccount.findUnique.mockResolvedValue({ userId: 'u1' });
+    const out = await service.linkGoogleToFull('u1', identity);
+    expect(db.oAuthAccount.create).not.toHaveBeenCalled();
+    expect(typeof out.token).toBe('string');
+  });
+});
+
+describe('setting a password', () => {
+  it('writes the hash and bumps the version in ONE database write', async () => {
+    // the bump ending every other session must be atomic with the new
+    // hash: two writes leave a window where the password changed but the
+    // attacker's token still works
+    const db = makeDb();
+    const revocations = makeRevocations();
+    db.user.update.mockResolvedValue({
+      id: 'u1',
+      username: 'ada',
+      email: 'a@b.co',
+      tokenVersion: 3,
+    });
+    const service = serviceWith(db, revocations);
+    const out = await service.setPassword('u1', 'a-new-password');
+
+    const args = (
+      db.user.update.mock.calls as [
+        { data: { password: unknown; tokenVersion: unknown } },
+      ][]
+    )[0][0];
+    expect(typeof args.data.password).toBe('string');
+    expect(args.data.tokenVersion).toEqual({ increment: 1 });
+    expect((revocations.noteVersionBumped as jest.Mock).mock.calls).toEqual([
+      ['u1', 3],
+    ]);
+    // the caller continues on a token AT the new version
+    expect(jwtService.decode<{ ver: number }>(out.token).ver).toBe(3);
+  });
+
+  it('refuses a short password before writing anything', async () => {
+    const db = makeDb();
+    await expect(
+      serviceWith(db).setPassword('u1', 'short'),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(db.user.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('which re-auth gate an account needs', () => {
+  const withUser = (row: unknown) => {
+    const db = makeDb();
+    db.user.findUnique.mockResolvedValue(row);
+    return serviceWith(db);
+  };
+
+  it('password accounts verify their password', async () => {
+    await expect(
+      withUser({ password: 'hash', oauthAccounts: [] }).reauthMethodFor('u1'),
+    ).resolves.toBe('password');
+  });
+
+  it('provider-only accounts re-run Google', async () => {
+    await expect(
+      withUser({
+        password: null,
+        oauthAccounts: [{ provider: 'google' }],
+      }).reauthMethodFor('u1'),
+    ).resolves.toBe('google');
+  });
+
+  it('guests have neither, which callers must treat as its own case', async () => {
+    await expect(
+      withUser({ password: null, oauthAccounts: [] }).reauthMethodFor('u1'),
+    ).resolves.toBeNull();
+  });
+
+  it('verifyPassword treats no-password-on-file as refusal, never a pass', async () => {
+    // an account that cannot be verified this way needs the OAuth gate;
+    // returning true here would make the weakest accounts the easiest to take
+    await expect(
+      withUser({ password: null }).verifyPassword('u1', 'anything'),
+    ).resolves.toBe(false);
   });
 });

--- a/video-sync-backend/src/auth/auth.service.spec.ts
+++ b/video-sync-backend/src/auth/auth.service.spec.ts
@@ -835,6 +835,22 @@ describe('setting a password', () => {
     ).rejects.toMatchObject({ status: 400 });
     expect(db.user.update).not.toHaveBeenCalled();
   });
+
+  it('answers a deleted account with 401, not a 500', async () => {
+    // a valid token over a since-deleted row: P2025 on update. Every other
+    // no-such-session path is 401; a 500 here would be the odd one out and
+    // would leak that the account had existed.
+    const db = makeDb();
+    db.user.update.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('Record not found', {
+        code: 'P2025',
+        clientVersion: 'test',
+      }),
+    );
+    await expect(
+      serviceWith(db).setPassword('u1', 'a-real-password'),
+    ).rejects.toMatchObject({ status: 401 });
+  });
 });
 
 describe('which re-auth gate an account needs', () => {
@@ -918,17 +934,20 @@ describe('refresh must not launder a revoked token back to life', () => {
     ).rejects.toMatchObject({ status: 401 });
   });
 
-  it('treats a lost rotation race as compromise - revokes the whole family', async () => {
-    // two copies of one token refresh at once; the loser must not merely
-    // fail, it must burn every session including the winner's fresh token
+  it('401s a lost rotation race without burning the family - multi-tab is not theft', async () => {
+    // Two tabs share one token here, so a concurrent refresh of the same jti
+    // is ordinary use. The loser fails its own call; it must NOT sign every
+    // session out. Sequential reuse (a jti presented after its rotation was
+    // recorded) is the theft this still catches - via isJtiRevokedDurable,
+    // not via this race.
     const { service, revocations } = setup(0);
     (revocations.claimRevocation as jest.Mock).mockResolvedValue(false);
     await expect(
       service.refreshSession({ sub: 'u1', jti: 'j1', ver: 0, sess: nowS() }),
     ).rejects.toMatchObject({ status: 401 });
-    expect((revocations.revokeAllForUser as jest.Mock).mock.calls).toEqual([
-      ['u1'],
-    ]);
+    expect((revocations.revokeAllForUser as jest.Mock).mock.calls).toHaveLength(
+      0,
+    );
   });
 
   it('the happy path: claims the old jti, mints at the current version', async () => {

--- a/video-sync-backend/src/auth/auth.service.ts
+++ b/video-sync-backend/src/auth/auth.service.ts
@@ -14,6 +14,7 @@ import { DatabaseService } from '../database/database.service';
 import * as bcrypt from 'bcrypt';
 import { GoogleAuthError, GoogleIdentity } from './google/google-oauth.service';
 import { usernameBase, usernameCandidates } from './google/username';
+import { RevocationService } from './revocation.service';
 
 const GOOGLE = 'google';
 
@@ -26,6 +27,15 @@ export interface SessionUser {
 }
 
 /** Enough draws from 10^4 that exhausting them means something else is wrong. */
+/**
+ * The absolute ceiling on a session's life: thirty days after first
+ * sign-in, refreshes are refused and the person signs in again. A constant
+ * rather than a knob on purpose - JWT_EXPIRES_IN taught this codebase what
+ * a lifetime knob costs in validation, and this one is a correctness
+ * parameter for the refresh design, not tuning.
+ */
+export const SESSION_MAX_S = 30 * 24 * 3600;
+
 const USERNAME_ATTEMPTS = 8;
 
 const isUniqueViolation = (err: unknown, field: string): boolean =>
@@ -79,6 +89,7 @@ export class AuthService {
   constructor(
     private database: DatabaseService,
     private jwt: JwtService,
+    private revocations: RevocationService,
   ) {}
 
   /**
@@ -94,16 +105,22 @@ export class AuthService {
    * The jti is what lets ONE session be revoked later; without it the only
    * lever is the version, which takes out every session the user has.
    */
-  private issueToken(user: {
-    id: string;
-    username: string;
-    tokenVersion: number;
-  }): string {
+  private issueToken(
+    user: {
+      id: string;
+      username: string;
+      tokenVersion: number;
+    },
+    opts?: { sessionStart?: number },
+  ): string {
     return this.jwt.sign({
       sub: user.id,
       name: user.username,
       jti: randomUUID(),
       ver: user.tokenVersion,
+      // the session's birth, preserved across refreshes; a fresh sign-in
+      // starts a fresh session
+      sess: opts?.sessionStart ?? Math.floor(Date.now() / 1000),
     });
   }
 
@@ -226,17 +243,262 @@ export class AuthService {
   }
 
   /** The signed-in identity, for a client holding a token and nothing else. */
-  async me(userId: string) {
+  /**
+   * A new token for a session that is still alive - the sliding half of
+   * sliding sessions.
+   *
+   * The old objection to any lifetime extension was "a stolen token's value
+   * rises, and there is no revocation". Revocation exists now, and this
+   * flow is built to make a stolen copy WORTH LESS, not more: the new token
+   * gets a fresh jti and the old jti is revoked in the same call, so the
+   * first party to refresh - victim or thief - kills the other's copy, and
+   * a 12-hour theft window shrinks to the gap between refreshes.
+   *
+   * The slide is bounded absolutely by the session's BIRTH (`sess`), which
+   * refreshes preserve verbatim: thirty days after first sign-in, the
+   * session ends whatever anyone does. A cap anchored to anything
+   * refreshable is not a cap.
+   */
+  async refreshSession(payload: {
+    sub?: string;
+    name?: string;
+    jti?: string;
+    ver?: number;
+    sess?: number;
+    iat?: number;
+    exp?: number;
+  }): Promise<SessionUser & { sessionStartedAt: number }> {
+    const userId = payload.sub;
+    if (!userId) throw new UnauthorizedException('No such session');
+
+    const nowS = Math.floor(Date.now() / 1000);
+    // tokens minted before sess existed anchor to their own issue time:
+    // the honest floor, since nothing older can be proven about them
+    const sessionStart = payload.sess ?? payload.iat ?? nowS;
+    if (nowS - sessionStart > SESSION_MAX_S) {
+      throw new UnauthorizedException(
+        'This session has reached its age limit - sign in again',
+      );
+    }
+
+    const user = await this.database.user.findUnique({
+      where: { id: userId },
+      select: { id: true, username: true, tokenVersion: true },
+    });
+    if (!user) throw new UnauthorizedException('No such session');
+
+    const token = this.issueToken(user, { sessionStart });
+
+    // Rotate: the old token dies WITH the refresh, not on its own schedule.
+    // Tokens from before jti existed cannot be individually revoked - they
+    // refresh into revocable ones, which still narrows the fleet.
+    if (payload.jti) {
+      await this.revocations.revokeToken(
+        payload.jti,
+        userId,
+        new Date((payload.exp ?? nowS + 43200) * 1000),
+      );
+    }
+
+    return {
+      id: user.id,
+      username: user.username,
+      email: '',
+      token,
+      sessionStartedAt: sessionStart,
+    } as SessionUser & { sessionStartedAt: number };
+  }
+
+  /**
+   * Attach a Google identity to a FULL account.
+   *
+   * The guest path (linkGoogleToGuest) rewrites the row's identity; this
+   * one must not - the account already has its name and address, and
+   * linking only adds a second door. The uniqueness that matters is the
+   * provider's: a Google account attached elsewhere belongs to that user.
+   *
+   * The re-authentication happened at link-start (password verified before
+   * the state was sealed); by the time this runs, the sealed cookie is the
+   * proof. Nothing here trusts the bearer token alone.
+   */
+  async linkGoogleToFull(
+    userId: string,
+    identity: GoogleIdentity,
+  ): Promise<SessionUser> {
     const user = await this.database.user.findUnique({
       where: { id: userId },
       select: { id: true, username: true, email: true, tokenVersion: true },
+    });
+    if (!user) throw new UnauthorizedException('No such session');
+
+    const existingLink = await this.database.oAuthAccount.findUnique({
+      where: {
+        provider_providerAccountId: {
+          provider: 'google',
+          providerAccountId: identity.subject,
+        },
+      },
+      select: { userId: true },
+    });
+    if (existingLink && existingLink.userId !== userId) {
+      throw new ConflictException({
+        code: 'link_provider_taken',
+        message:
+          'That Google account is already signed in here - sign in with it instead',
+      });
+    }
+    if (existingLink) {
+      // already linked to THIS account: idempotent, not an error - a
+      // double-submitted flow should not scold the person it worked for
+      return { ...user, token: this.issueToken(user) };
+    }
+
+    try {
+      await this.database.oAuthAccount.create({
+        data: {
+          provider: 'google',
+          providerAccountId: identity.subject,
+          userId,
+        },
+      });
+    } catch (err) {
+      if (isUniqueViolation(err, 'providerAccountId')) {
+        throw new ConflictException({
+          code: 'link_provider_taken',
+          message:
+            'That Google account is already signed in here - sign in with it instead',
+        });
+      }
+      throw err;
+    }
+    return { ...user, token: this.issueToken(user) };
+  }
+
+  /**
+   * Does this password belong to this account? For re-authentication
+   * gates, where "no password on file" must read as refusal, never as a
+   * pass - an account that cannot be verified this way needs the OAuth
+   * re-auth path instead.
+   */
+  async verifyPassword(userId: string, password: string): Promise<boolean> {
+    const user = await this.database.user.findUnique({
+      where: { id: userId },
+      select: { password: true },
+    });
+    if (!user?.password) return false;
+    return bcrypt.compare(password ?? '', user.password);
+  }
+
+  /** Which re-auth gate set-password and link-start need for this account. */
+  async reauthMethodFor(userId: string): Promise<'password' | 'google' | null> {
+    const user = await this.database.user.findUnique({
+      where: { id: userId },
+      select: {
+        password: true,
+        oauthAccounts: { select: { provider: true }, take: 1 },
+      },
+    });
+    if (!user) return null;
+    if (user.password) return 'password';
+    if (user.oauthAccounts.length > 0) return 'google';
+    return null;
+  }
+
+  /**
+   * Set or change the account password - and end every other session.
+   *
+   * Re-authentication is the CALLER's job (the controller verifies either
+   * the current password or a fresh Google re-auth before calling); this
+   * method assumes it and does the two things that must then happen
+   * together: the new hash is written, and tokenVersion bumps so every
+   * token issued before this moment - including whichever one an attacker
+   * may be holding, which is the scenario password changes exist for -
+   * stops working. The caller gets a fresh token at the new version, so
+   * the person who changed the password is the one session that survives.
+   */
+  async setPassword(userId: string, newPassword: string): Promise<SessionUser> {
+    if ((newPassword ?? '').length < 8) {
+      throw new BadRequestException('Passwords are at least 8 characters');
+    }
+    const hashed = await bcrypt.hash(newPassword, 10);
+    const user = await this.database.user.update({
+      where: { id: userId },
+      data: { password: hashed, tokenVersion: { increment: 1 } },
+      select: { id: true, username: true, email: true, tokenVersion: true },
+    });
+    // the version moved in the SAME write as the password; announce it so
+    // live sockets close and other instances hear (this also refreshes the
+    // in-memory snapshot on this instance)
+    await this.revocations.noteVersionBumped(userId, user.tokenVersion);
+    return { ...user, token: this.issueToken(user) };
+  }
+
+  /** Which user a Google subject is linked to, if any. */
+  async googleSubjectOwner(subject: string): Promise<string | null> {
+    const link = await this.database.oAuthAccount.findUnique({
+      where: {
+        provider_providerAccountId: {
+          provider: 'google',
+          providerAccountId: subject,
+        },
+      },
+      select: { userId: true },
+    });
+    return link?.userId ?? null;
+  }
+
+  /**
+   * Five minutes of proof that the holder just re-authenticated. An
+   * ordinary token for the same subject in every other respect - elevation
+   * adds the one right set-password checks for, nothing else - and
+   * deliberately short: it exists to be spent, not kept. Refresh refuses
+   * it, so it cannot be slid past its purpose.
+   */
+  async mintElevatedToken(userId: string): Promise<string> {
+    const user = await this.database.user.findUnique({
+      where: { id: userId },
+      select: { id: true, username: true, tokenVersion: true },
+    });
+    if (!user) throw new UnauthorizedException('No such session');
+    return this.jwt.sign(
+      {
+        sub: user.id,
+        name: user.username,
+        jti: randomUUID(),
+        ver: user.tokenVersion,
+        elev: 'reauth',
+      },
+      { expiresIn: '5m' },
+    );
+  }
+
+  async me(userId: string) {
+    const user = await this.database.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        username: true,
+        email: true,
+        tokenVersion: true,
+        isGuest: true,
+        // booleans about the credentials, never the credentials: the
+        // account UI needs to know WHICH re-auth gate to show, and
+        // deriving that client-side from anything else would be a guess
+        password: true,
+        oauthAccounts: { select: { provider: true }, take: 1 },
+      },
     });
     if (!user) {
       // A valid signature over a user that no longer exists - a deleted
       // account holding a token that has not expired yet.
       throw new NotFoundException('User not found');
     }
-    return user;
+    const { password, oauthAccounts, ...rest } = user;
+    return {
+      ...rest,
+      hasPassword: password !== null,
+      googleLinked: oauthAccounts.length > 0,
+    };
   }
 
   /**

--- a/video-sync-backend/src/auth/auth.service.ts
+++ b/video-sync-backend/src/auth/auth.service.ts
@@ -15,7 +15,7 @@ import { GoogleAuthError, GoogleIdentity } from './google/google-oauth.service';
 import { usernameBase, usernameCandidates } from './google/username';
 import { versionOf } from './token-payload';
 import { RevocationService } from './revocation.service';
-import { isUniqueViolation } from './unique-violation';
+import { isNotFound, isUniqueViolation } from './unique-violation';
 
 const GOOGLE = 'google';
 
@@ -323,9 +323,23 @@ export class AuthService {
         new Date((payload.exp ?? nowS + 43200) * 1000),
       );
       if (!won) {
-        await this.revocations.revokeAllForUser(userId);
+        // Lost the CREATE race for this jti. The review that added this
+        // guard treated that as compromise and burned the whole family -
+        // but this app stores one token per browser, shared across tabs, so
+        // two tabs refreshing the same token at once is ordinary use, not
+        // theft, and burning the family signed people out everywhere for
+        // opening a second tab.
+        //
+        // So the loser simply fails its own refresh: the winner already
+        // minted the one new token, the loser's tab adopts it through the
+        // storage listener, and no session but this redundant call ends.
+        // The theft this still stops is the case that matters and is NOT a
+        // race: a token reused AFTER its rotation was recorded is caught by
+        // the durable-jti check above, because the winning rotation revoked
+        // that jti. Concurrent reuse is indistinguishable from a second tab
+        // and is not worth ending every session over.
         throw new UnauthorizedException(
-          'This session was refreshed from another place - sign in again',
+          'This session was just refreshed elsewhere - reload',
         );
       }
     }
@@ -471,11 +485,25 @@ export class AuthService {
       throw new BadRequestException('Passwords are at least 8 characters');
     }
     const hashed = await bcrypt.hash(newPassword, 10);
-    const user = await this.database.user.update({
-      where: { id: userId },
-      data: { password: hashed, tokenVersion: { increment: 1 } },
-      select: { id: true, username: true, email: true, tokenVersion: true },
-    });
+    let user: {
+      id: string;
+      username: string;
+      email: string;
+      tokenVersion: number;
+    };
+    try {
+      user = await this.database.user.update({
+        where: { id: userId },
+        data: { password: hashed, tokenVersion: { increment: 1 } },
+        select: { id: true, username: true, email: true, tokenVersion: true },
+      });
+    } catch (err) {
+      // A valid token over a row that has since been deleted. Every other
+      // "no such session" path answers 401; a 500 here would be the odd one
+      // out and would leak that the account existed.
+      if (isNotFound(err)) throw new UnauthorizedException('No such session');
+      throw err;
+    }
     // the version moved in the SAME write as the password; announce it so
     // live sockets close and other instances hear (this also refreshes the
     // in-memory snapshot on this instance)

--- a/video-sync-backend/src/auth/auth.service.ts
+++ b/video-sync-backend/src/auth/auth.service.ts
@@ -9,12 +9,13 @@ import {
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { randomUUID } from 'crypto';
-import { Prisma } from '@prisma/client';
 import { DatabaseService } from '../database/database.service';
 import * as bcrypt from 'bcrypt';
 import { GoogleAuthError, GoogleIdentity } from './google/google-oauth.service';
 import { usernameBase, usernameCandidates } from './google/username';
+import { versionOf } from './token-payload';
 import { RevocationService } from './revocation.service';
+import { isUniqueViolation } from './unique-violation';
 
 const GOOGLE = 'google';
 
@@ -37,13 +38,6 @@ export interface SessionUser {
 export const SESSION_MAX_S = 30 * 24 * 3600;
 
 const USERNAME_ATTEMPTS = 8;
-
-const isUniqueViolation = (err: unknown, field: string): boolean =>
-  err instanceof Prisma.PrismaClientKnownRequestError &&
-  err.code === 'P2002' &&
-  ((err.meta?.target as string[] | undefined) ?? []).some((t) =>
-    t.includes(field),
-  );
 
 /**
  * What a name, an address and a password have to be to open an account.
@@ -287,18 +281,56 @@ export class AuthService {
     });
     if (!user) throw new UnauthorizedException('No such session');
 
-    const token = this.issueToken(user, { sessionStart });
+    // AUTHORITATIVE checks against Postgres, not the eventually-consistent
+    // snapshot the guard reads. This is the security core of refresh: it is
+    // about to mint a new long-lived credential, and gating that on a
+    // snapshot that can lag a logout-all by up to REFRESH_MS would let a
+    // revoked token launder itself into a fresh, fully-valid one - defeating
+    // exactly the revocation this feature was built to honour.
+    //
+    // Version: a token issued before the user's current version is stale.
+    // Strictly-less, and a malformed claim (null) is refused rather than
+    // read as 0.
+    const claimed = versionOf({
+      sub: userId,
+      name: user.username,
+      ver: payload.ver,
+    });
+    if (claimed === null || claimed < user.tokenVersion) {
+      throw new UnauthorizedException('This session was signed out');
+    }
+    // The specific jti: a single logout or an earlier rotation of THIS
+    // token recorded it, and neither should be refreshable back to life.
+    if (
+      payload.jti &&
+      (await this.revocations.isJtiRevokedDurable(payload.jti))
+    ) {
+      throw new UnauthorizedException('This session was signed out');
+    }
 
-    // Rotate: the old token dies WITH the refresh, not on its own schedule.
-    // Tokens from before jti existed cannot be individually revoked - they
-    // refresh into revocable ones, which still narrows the fleet.
+    // Rotation with reuse detection. Revoke the old jti with a CREATE before
+    // minting anything: the unique jti constraint makes exactly one caller
+    // the true rotation. If two copies of one token refresh at once - the
+    // shape of a stolen token - the loser finds the row taken, and that is
+    // not a retry to smooth over but a compromise signal: revoke the whole
+    // family so neither the winner's freshly-minted token nor any sibling
+    // survives, and refuse. A token with no jti (pre-revocation) cannot be
+    // individually rotated; it still gets a new token, one narrowing step.
     if (payload.jti) {
-      await this.revocations.revokeToken(
+      const won = await this.revocations.claimRevocation(
         payload.jti,
         userId,
         new Date((payload.exp ?? nowS + 43200) * 1000),
       );
+      if (!won) {
+        await this.revocations.revokeAllForUser(userId);
+        throw new UnauthorizedException(
+          'This session was refreshed from another place - sign in again',
+        );
+      }
     }
+
+    const token = this.issueToken(user, { sessionStart });
 
     return {
       id: user.id,
@@ -363,6 +395,15 @@ export class AuthService {
       });
     } catch (err) {
       if (isUniqueViolation(err, 'providerAccountId')) {
+        // Lost a race - but with WHOM? If the winning row is this same
+        // account (a double-submitted flow), that is success, not a
+        // conflict; only a link to someone else is the 409. The pre-check
+        // above answers this in the common case; this closes the window
+        // between it and the create.
+        const owner = await this.googleSubjectOwner(identity.subject);
+        if (owner === userId) {
+          return { ...user, token: this.issueToken(user) };
+        }
         throw new ConflictException({
           code: 'link_provider_taken',
           message:
@@ -402,6 +443,15 @@ export class AuthService {
     if (user.password) return 'password';
     if (user.oauthAccounts.length > 0) return 'google';
     return null;
+  }
+
+  /** Whether this account already has a Google identity attached. */
+  async hasGoogleLink(userId: string): Promise<boolean> {
+    const link = await this.database.oAuthAccount.findFirst({
+      where: { userId, provider: 'google' },
+      select: { id: true },
+    });
+    return link !== null;
   }
 
   /**

--- a/video-sync-backend/src/auth/google/google-oauth.service.ts
+++ b/video-sync-backend/src/auth/google/google-oauth.service.ts
@@ -169,6 +169,7 @@ export class GoogleOAuthService {
     returnTo: string | undefined,
     now: number = Date.now(),
     linkUserId?: string,
+    purpose?: 'link-guest' | 'link-full' | 'reauth',
   ) {
     this.assertEnabled();
 
@@ -183,6 +184,7 @@ export class GoogleOAuthService {
       codeVerifier,
       returnTo: safeReturnTo(returnTo),
       linkUserId,
+      purpose,
       expiresAt: now + FLOW_TTL_MS,
     };
 
@@ -216,8 +218,9 @@ export class GoogleOAuthService {
   }): Promise<{
     identity: GoogleIdentity;
     returnTo?: string;
-    /** set when this flow is attaching Google to a guest, not signing in */
+    /** set when this flow acts on an existing account rather than signing in */
     linkUserId?: string;
+    purpose?: 'link-guest' | 'link-full' | 'reauth';
   }> {
     this.assertEnabled();
 
@@ -287,6 +290,7 @@ export class GoogleOAuthService {
       },
       returnTo: opened.returnTo,
       linkUserId: opened.linkUserId,
+      purpose: opened.purpose,
     };
   }
 

--- a/video-sync-backend/src/auth/google/oauth-state.ts
+++ b/video-sync-backend/src/auth/google/oauth-state.ts
@@ -25,6 +25,15 @@ export interface OAuthStatePayload {
    * someone else's.
    */
   linkUserId?: string;
+  /**
+   * What the flow is FOR, sealed at start with the same authority as
+   * linkUserId. 'link-guest' rewrites the guest row; 'link-full' only adds
+   * the provider row; 'reauth' proves the person can still complete Google
+   * as this account's linked identity and mints a five-minute elevated
+   * token instead of a session. Absent = a plain sign-in. The callback
+   * dispatches on THIS, never on anything the browser says at return time.
+   */
+  purpose?: 'link-guest' | 'link-full' | 'reauth';
   /** absolute ms deadline - an abandoned flow must not stay resumable */
   expiresAt: number;
 }

--- a/video-sync-backend/src/auth/revocation.service.spec.ts
+++ b/video-sync-backend/src/auth/revocation.service.spec.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { RevocationService } from './revocation.service';
 import type { DatabaseService } from '../database/database.service';
 import type { TokenPayload } from './token-payload';
@@ -9,6 +10,8 @@ const makeDb = (
   revokedToken: {
     findMany: jest.fn().mockResolvedValue(tokens),
     upsert: jest.fn().mockResolvedValue(undefined),
+    create: jest.fn().mockResolvedValue(undefined),
+    findUnique: jest.fn().mockResolvedValue(null),
     deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
   },
   user: {
@@ -381,5 +384,61 @@ describe('the Redis mirror, which is how the relay learns', () => {
       s.revokeToken('j1', 'u1', new Date(Date.now() + 1000)),
     ).resolves.toBeUndefined();
     expect(s.isRevoked(token({ jti: 'j1' }))).toBe('token');
+  });
+});
+
+describe('claimRevocation - the rotation arbiter', () => {
+  const p2002 = () =>
+    new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+      code: 'P2002',
+      clientVersion: 'test',
+      meta: { target: ['jti'] },
+    });
+
+  it('returns true when it wins the create - the true rotation', async () => {
+    const db = makeDb();
+    const s = await service(db);
+    await expect(
+      s.claimRevocation('j1', 'u1', new Date(Date.now() + 1000)),
+    ).resolves.toBe(true);
+    expect(db.revokedToken.create).toHaveBeenCalled();
+  });
+
+  it('returns false when the jti was already revoked - a reused token', async () => {
+    // the create loses to the unique constraint; that is the compromise
+    // signal the caller escalates on
+    const db = makeDb();
+    db.revokedToken.create.mockRejectedValue(p2002());
+    const s = await service(db);
+    await expect(
+      s.claimRevocation('j1', 'u1', new Date(Date.now() + 1000)),
+    ).resolves.toBe(false);
+  });
+
+  it('rethrows a non-uniqueness error rather than swallowing it', async () => {
+    const db = makeDb();
+    db.revokedToken.create.mockRejectedValue(new Error('db down'));
+    const s = await service(db);
+    await expect(
+      s.claimRevocation('j1', 'u1', new Date(Date.now() + 1000)),
+    ).rejects.toThrow('db down');
+  });
+});
+
+describe('isJtiRevokedDurable - the authoritative check refresh needs', () => {
+  it('reads Postgres, not the snapshot', async () => {
+    const db = makeDb();
+    db.revokedToken.findUnique.mockResolvedValue({ jti: 'j1' });
+    const s = await service(db);
+    await expect(s.isJtiRevokedDurable('j1')).resolves.toBe(true);
+    expect(db.revokedToken.findUnique).toHaveBeenCalledWith({
+      where: { jti: 'j1' },
+      select: { jti: true },
+    });
+  });
+
+  it('is false for an unrevoked jti', async () => {
+    const s = await service(makeDb());
+    await expect(s.isJtiRevokedDurable('j-unknown')).resolves.toBe(false);
   });
 });

--- a/video-sync-backend/src/auth/revocation.service.ts
+++ b/video-sync-backend/src/auth/revocation.service.ts
@@ -4,6 +4,7 @@ import type Redis from 'ioredis';
 import { DatabaseService } from '../database/database.service';
 import { REDIS_KV, REDIS_PUB, REDIS_SUB } from '../redis/redis.module';
 import { subjectOf, versionOf, type TokenPayload } from './token-payload';
+import { isUniqueViolation } from './unique-violation';
 
 /** Where instances tell each other that something was revoked. */
 export const REVOCATION_CHANNEL = 'mustard:revocations';
@@ -156,6 +157,58 @@ export class RevocationService implements OnModuleInit {
     this.rememberToken(jti);
     await this.mirrorToken(jti);
     await this.announce({ kind: 'token', jti });
+  }
+
+  /**
+   * Revoke a jti and report whether it was ALREADY revoked.
+   *
+   * The difference from revokeToken matters for rotation: a CREATE, not an
+   * upsert, so the unique jti constraint arbitrates a race. The caller who
+   * creates the row is the one true rotation of that token; anyone else who
+   * arrives finds it taken, which is the signal that this token is being
+   * refreshed twice - a copy in someone else's hands. Returns true if this
+   * call was the first to revoke it, false if it was already gone.
+   */
+  async claimRevocation(
+    jti: string,
+    userId: string,
+    expiresAt: Date,
+  ): Promise<boolean> {
+    try {
+      await this.database.revokedToken.create({
+        data: { jti, userId, expiresAt },
+      });
+      this.rememberToken(jti);
+      await this.mirrorToken(jti);
+      await this.announce({ kind: 'token', jti });
+      return true;
+    } catch (err) {
+      if (isUniqueViolation(err, 'jti')) {
+        // already revoked - by an earlier rotation of this same token, or
+        // a logout. Either way this jti is not ours to rotate.
+        this.rememberToken(jti);
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Is this jti recorded as revoked in POSTGRES - the durable truth, not the
+   * eventually-consistent snapshot isRevoked() reads?
+   *
+   * refreshSession needs this: it is about to mint a new long-lived
+   * credential, and gating that on a snapshot that can lag a logout by up to
+   * REFRESH_MS would let a revoked token launder itself into a fresh one.
+   * The request path stays snapshot-only; this authoritative check is paid
+   * for exactly where a stale answer would be a security hole.
+   */
+  async isJtiRevokedDurable(jti: string): Promise<boolean> {
+    const row = await this.database.revokedToken.findUnique({
+      where: { jti },
+      select: { jti: true },
+    });
+    return row !== null;
   }
 
   /** Stop trusting everything this user holds - sign out everywhere. */

--- a/video-sync-backend/src/auth/revocation.service.ts
+++ b/video-sync-backend/src/auth/revocation.service.ts
@@ -176,6 +176,20 @@ export class RevocationService implements OnModuleInit {
   }
 
   /**
+   * Record a version bump that some OTHER write already performed.
+   *
+   * setPassword increments tokenVersion in the same database write as the
+   * new hash - atomically, which revokeAllForUser cannot offer it. This is
+   * the announce-only half: snapshot, mirror, pub/sub, socket eviction,
+   * without a second increment.
+   */
+  async noteVersionBumped(userId: string, version: number): Promise<void> {
+    this.rememberVersion(userId, version);
+    await this.mirrorVersion(userId, version);
+    await this.announce({ kind: 'user', userId, version });
+  }
+
+  /**
    * Reload the snapshot from Postgres.
    *
    * Also the recovery path: an instance that missed a pub/sub message, or

--- a/video-sync-backend/src/auth/token-payload.ts
+++ b/video-sync-backend/src/auth/token-payload.ts
@@ -34,6 +34,25 @@ export interface TokenPayload {
    */
   ver?: number;
   /**
+   * When this SESSION was born - the first sign-in, in seconds, preserved
+   * verbatim across refreshes. A refresh slides the token's expiry but must
+   * never slide this: it is the anchor for the absolute session cap, and a
+   * cap anchored to anything refreshable is not a cap.
+   *
+   * Optional because tokens minted before refresh existed do not carry it;
+   * they refresh with sess = their own iat, which is the honest floor.
+   */
+  sess?: number;
+  /**
+   * Elevation marker, set only by the OAuth re-auth flow and only for five
+   * minutes: 'reauth' means the holder just completed a fresh Google round
+   * trip AS this account's linked identity. Required by set-password on
+   * accounts that have no password to verify instead. An elevated token is
+   * otherwise an ordinary session token for the same subject - elevation
+   * ADDS one right, it does not change who you are.
+   */
+  elev?: string;
+  /**
    * Expiry, written by jsonwebtoken itself. Declared here because two things
    * now read it - the socket sweep that closes connections whose token has
    * died, and the revocation record that only needs keeping until then.

--- a/video-sync-backend/src/auth/unique-violation.ts
+++ b/video-sync-backend/src/auth/unique-violation.ts
@@ -13,3 +13,7 @@ export const isUniqueViolation = (err: unknown, field: string): boolean =>
   ((err.meta?.target as string[] | undefined) ?? []).some((t) =>
     t.includes(field),
   );
+
+/** True when a write failed because the target row does not exist (P2025). */
+export const isNotFound = (err: unknown): boolean =>
+  err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025';

--- a/video-sync-backend/src/auth/unique-violation.ts
+++ b/video-sync-backend/src/auth/unique-violation.ts
@@ -1,0 +1,15 @@
+import { Prisma } from '@prisma/client';
+
+/**
+ * True when a write failed because it collided with a unique constraint on
+ * `field`. The one place the P2002 shape and the target-array probing live,
+ * so the several callers that race on a unique column - username, email,
+ * providerAccountId, jti - cannot disagree about what "already taken" looks
+ * like.
+ */
+export const isUniqueViolation = (err: unknown, field: string): boolean =>
+  err instanceof Prisma.PrismaClientKnownRequestError &&
+  err.code === 'P2002' &&
+  ((err.meta?.target as string[] | undefined) ?? []).some((t) =>
+    t.includes(field),
+  );

--- a/video-sync-frontend/src/components/AccountDialog.tsx
+++ b/video-sync-frontend/src/components/AccountDialog.tsx
@@ -244,10 +244,17 @@ export const AccountDialog: React.FC<{ onClose: () => void }> = ({
       } catch (err: unknown) {
         const status = (err as { response?: { status?: number } })?.response
           ?.status;
+        if (status === 401 && elevated) {
+          // the five-minute elevation is spent or expired; drop it so the
+          // UI returns to "Confirm with Google" instead of leaving a dead
+          // password form the person cannot escape without closing the tab
+          sessionStorage.removeItem('mw_elevated');
+          setElevated(null);
+        }
         toast.error(
           status === 401
             ? elevated
-              ? 'The Google confirmation expired - try again'
+              ? 'The Google confirmation expired - confirm again'
               : 'The current password is wrong'
             : status === 400
               ? 'Passwords are at least 8 characters'

--- a/video-sync-frontend/src/components/AccountDialog.tsx
+++ b/video-sync-frontend/src/components/AccountDialog.tsx
@@ -125,7 +125,7 @@ interface Profile {
 export const AccountDialog: React.FC<{ onClose: () => void }> = ({
   onClose,
 }) => {
-  const { user, logout } = useAuth();
+  const { user, logout, adoptToken } = useAuth();
   const [profile, setProfile] = useState<Profile | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [elevated, setElevated] = useState<string | null>(null);
@@ -133,15 +133,14 @@ export const AccountDialog: React.FC<{ onClose: () => void }> = ({
   const closeRef = useRef<HTMLButtonElement | null>(null);
 
   // The elevated token from a completed Google re-auth arrives via
-  // sessionStorage (AuthCallbackPage parks it there; it is five-minute,
-  // single-purpose, and deliberately kept out of localStorage and out of
-  // the session).
+  // sessionStorage (AuthCallbackPage parks it there; five-minute,
+  // single-purpose, kept out of localStorage and out of the session). READ
+  // but do not remove it here: consuming on mount meant closing and
+  // reopening the dialog silently burned the token. It is removed only when
+  // spent (submitPassword) or when its five minutes are plainly up.
   useEffect(() => {
     const parked = sessionStorage.getItem('mw_elevated');
-    if (parked) {
-      sessionStorage.removeItem('mw_elevated');
-      setElevated(parked);
-    }
+    if (parked) setElevated(parked);
   }, []);
 
   useEffect(() => {
@@ -226,20 +225,22 @@ export const AccountDialog: React.FC<{ onClose: () => void }> = ({
     async (newPassword: string, currentPassword?: string) => {
       setBusy('password');
       try {
-        if (elevated) {
-          // the elevated token rides the Authorization header for THIS
-          // call only - it proves the fresh Google round trip
-          await apiService.setPasswordElevated(newPassword, elevated);
-        } else {
-          await apiService.setPassword(newPassword, currentPassword);
-        }
-        // every other session just ended (the version bump); the response
-        // carried the surviving token, but the simplest honest client
-        // behavior is a clean re-entry with the new password
-        toast.success('Password saved - every other session was signed out');
+        const res = elevated
+          ? // the elevated token rides Authorization for THIS call only
+            await apiService.setPasswordElevated(newPassword, elevated)
+          : await apiService.setPassword(newPassword, currentPassword);
+        // set-password revoked the token we just used and handed back the
+        // ONE survivor. Adopt it before touching the API again - the old
+        // token is dead now, and a getMe with it would 401 the success into
+        // a "wrong password" error and (before the interceptor fix) wipe the
+        // session. The stored/elevated token is spent; clear it.
+        const survivor = (res.data as { id: string; token: string }) ?? null;
+        if (survivor?.token) adoptToken(survivor.token, survivor.id);
+        sessionStorage.removeItem('mw_elevated');
         setElevated(null);
-        const { data } = await apiService.getMe(user?.token ?? '');
-        setProfile(data as unknown as Profile);
+        toast.success('Password saved - every other session was signed out');
+        // reflect the change with the LIVE token
+        setProfile((p) => (p ? { ...p, hasPassword: true } : p));
       } catch (err: unknown) {
         const status = (err as { response?: { status?: number } })?.response
           ?.status;
@@ -256,7 +257,7 @@ export const AccountDialog: React.FC<{ onClose: () => void }> = ({
         setBusy(null);
       }
     },
-    [elevated, user?.token],
+    [elevated, adoptToken],
   );
 
   if (!user) return null;

--- a/video-sync-frontend/src/components/AccountDialog.tsx
+++ b/video-sync-frontend/src/components/AccountDialog.tsx
@@ -1,0 +1,429 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import styled from '@emotion/styled';
+import { useAuth } from '../contexts/AuthContext';
+import { apiService } from '../services/api';
+import { toast } from 'react-hot-toast';
+import { button, card, color, font, input, sectionLabel } from '../theme';
+import { IconGoogle } from './Icons';
+
+// The first account surface this app has had. Until now every account
+// operation lived wherever it could squat - claiming on the home page,
+// sign-out-everywhere as an endpoint with no button at all - because there
+// was nowhere for them to live. Opened by clicking your own name in the
+// top bar.
+
+const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 7, 5, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1000;
+`;
+
+const Card = styled.div`
+  ${card}
+  padding: 24px;
+  width: 100%;
+  max-width: 440px;
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+`;
+
+const Title = styled.h3`
+  margin: 0 0 4px;
+  font-family: ${font.display};
+  font-weight: 600;
+  font-size: 18px;
+  color: ${color.text};
+`;
+
+const Address = styled.p`
+  margin: 0 0 20px;
+  font-family: ${font.body};
+  font-size: 13px;
+  color: ${color.dim};
+`;
+
+const Section = styled.div`
+  border-top: 1px solid ${color.line};
+  padding: 16px 0;
+`;
+
+const SectionTitle = styled.h4`
+  ${sectionLabel}
+  margin: 0 0 10px;
+`;
+
+const Row = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+`;
+
+const RowText = styled.p`
+  margin: 0;
+  font-family: ${font.body};
+  font-size: 13px;
+  line-height: 1.5;
+  color: ${color.dim};
+  flex: 1;
+`;
+
+const Field = styled.label`
+  display: block;
+  margin: 10px 0;
+`;
+
+const FieldLabel = styled.span`
+  ${sectionLabel}
+  display: block;
+  margin-bottom: 6px;
+`;
+
+const FieldInput = styled.input`
+  ${input}
+  width: 100%;
+`;
+
+const Secondary = styled.button`
+  ${button.secondary}
+  white-space: nowrap;
+`;
+
+const Primary = styled.button`
+  ${button.primary}
+`;
+
+const Danger = styled.button`
+  ${button.danger}
+  white-space: nowrap;
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 12px;
+`;
+
+interface Profile {
+  hasPassword: boolean;
+  googleLinked: boolean;
+  isGuest: boolean;
+}
+
+/**
+ * Account & security: what sign-in methods this account has, and the
+ * operations on them. Every mutating path here re-authenticates - the
+ * bearer token alone opens nothing, because the scenario these features
+ * exist for is precisely "someone else is holding a copy of the token".
+ */
+export const AccountDialog: React.FC<{ onClose: () => void }> = ({
+  onClose,
+}) => {
+  const { user, logout } = useAuth();
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [elevated, setElevated] = useState<string | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const closeRef = useRef<HTMLButtonElement | null>(null);
+
+  // The elevated token from a completed Google re-auth arrives via
+  // sessionStorage (AuthCallbackPage parks it there; it is five-minute,
+  // single-purpose, and deliberately kept out of localStorage and out of
+  // the session).
+  useEffect(() => {
+    const parked = sessionStorage.getItem('mw_elevated');
+    if (parked) {
+      sessionStorage.removeItem('mw_elevated');
+      setElevated(parked);
+    }
+  }, []);
+
+  useEffect(() => {
+    let live = true;
+    if (!user?.token) return;
+    apiService
+      .getMe(user.token)
+      .then(({ data }) => live && setProfile(data as unknown as Profile))
+      .catch(() => live && toast.error("Couldn't load account details"));
+    return () => {
+      live = false;
+    };
+  }, [user?.token]);
+
+  // dialog manners, same as the app's other dialogs: focus in, Escape
+  // closes, Tab stays inside, focus returns to the opener
+  useEffect(() => {
+    const opener = document.activeElement as HTMLElement | null;
+    closeRef.current?.focus();
+    const FOCUSABLE =
+      'input:not([disabled]), button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])';
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const focusable = Array.from(
+        cardRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? [],
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && (active === first || !cardRef.current?.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      opener?.focus();
+    };
+  }, [onClose]);
+
+  const linkGoogle = useCallback(
+    async (password: string) => {
+      setBusy('link');
+      try {
+        const { data } = await apiService.googleLinkStart('/', password);
+        window.location.href = data.authUrl;
+      } catch (err: unknown) {
+        const status = (err as { response?: { status?: number } })?.response
+          ?.status;
+        toast.error(
+          status === 401
+            ? 'That password is wrong'
+            : "Couldn't start Google linking",
+        );
+        setBusy(null);
+      }
+    },
+    [],
+  );
+
+  const beginReauth = useCallback(async () => {
+    setBusy('reauth');
+    try {
+      const { data } = await apiService.googleReauthStart('/');
+      window.location.href = data.authUrl;
+    } catch {
+      toast.error("Couldn't start the Google confirmation");
+      setBusy(null);
+    }
+  }, []);
+
+  const submitPassword = useCallback(
+    async (newPassword: string, currentPassword?: string) => {
+      setBusy('password');
+      try {
+        if (elevated) {
+          // the elevated token rides the Authorization header for THIS
+          // call only - it proves the fresh Google round trip
+          await apiService.setPasswordElevated(newPassword, elevated);
+        } else {
+          await apiService.setPassword(newPassword, currentPassword);
+        }
+        // every other session just ended (the version bump); the response
+        // carried the surviving token, but the simplest honest client
+        // behavior is a clean re-entry with the new password
+        toast.success('Password saved - every other session was signed out');
+        setElevated(null);
+        const { data } = await apiService.getMe(user?.token ?? '');
+        setProfile(data as unknown as Profile);
+      } catch (err: unknown) {
+        const status = (err as { response?: { status?: number } })?.response
+          ?.status;
+        toast.error(
+          status === 401
+            ? elevated
+              ? 'The Google confirmation expired - try again'
+              : 'The current password is wrong'
+            : status === 400
+              ? 'Passwords are at least 8 characters'
+              : "Couldn't save the password",
+        );
+      } finally {
+        setBusy(null);
+      }
+    },
+    [elevated, user?.token],
+  );
+
+  if (!user) return null;
+
+  return (
+    <Overlay onClick={onClose}>
+      <Card
+        ref={cardRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="account-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Title id="account-title">{user.username}</Title>
+        <Address>{user.email}</Address>
+
+        {profile && !profile.isGuest && (
+          <>
+            <Section>
+              <SectionTitle>Sign-in methods</SectionTitle>
+              {profile.googleLinked ? (
+                <Row>
+                  <IconGoogle size={16} />
+                  <RowText>Google is connected to this account.</RowText>
+                </Row>
+              ) : (
+                <GoogleLinkForm busy={busy === 'link'} onSubmit={linkGoogle} />
+              )}
+            </Section>
+
+            <Section>
+              <SectionTitle>
+                {profile.hasPassword ? 'Change password' : 'Set a password'}
+              </SectionTitle>
+              {profile.hasPassword ? (
+                <PasswordForm
+                  requireCurrent
+                  busy={busy === 'password'}
+                  onSubmit={submitPassword}
+                />
+              ) : elevated ? (
+                <PasswordForm
+                  requireCurrent={false}
+                  busy={busy === 'password'}
+                  onSubmit={submitPassword}
+                />
+              ) : (
+                <Row>
+                  <RowText>
+                    This account signs in with Google only. Confirm with
+                    Google once, then choose a password — after that, either
+                    works.
+                  </RowText>
+                  <Secondary
+                    type="button"
+                    disabled={busy === 'reauth'}
+                    onClick={beginReauth}
+                  >
+                    {busy === 'reauth' ? 'Opening…' : 'Confirm with Google'}
+                  </Secondary>
+                </Row>
+              )}
+            </Section>
+          </>
+        )}
+
+        <Section>
+          <SectionTitle>Sessions</SectionTitle>
+          <Row>
+            <RowText>
+              Sign out on every device — this one included. The answer to a
+              laptop left open somewhere, or a token you think leaked.
+            </RowText>
+            <Danger
+              type="button"
+              onClick={() => {
+                logout({ everywhere: true });
+                onClose();
+              }}
+            >
+              Sign out everywhere
+            </Danger>
+          </Row>
+        </Section>
+
+        <Buttons>
+          <Secondary ref={closeRef} type="button" onClick={onClose}>
+            Close
+          </Secondary>
+        </Buttons>
+      </Card>
+    </Overlay>
+  );
+};
+
+const GoogleLinkForm: React.FC<{
+  busy: boolean;
+  onSubmit: (password: string) => void;
+}> = ({ busy, onSubmit }) => (
+  <form
+    onSubmit={(e) => {
+      e.preventDefault();
+      onSubmit(String(new FormData(e.currentTarget).get('password') ?? ''));
+    }}
+  >
+    <RowText>
+      Connect Google as a second way in. Your password confirms it&apos;s
+      you — a session alone isn&apos;t enough to add a door to this account.
+    </RowText>
+    <Field>
+      <FieldLabel>Current password</FieldLabel>
+      <FieldInput
+        name="password"
+        type="password"
+        autoComplete="current-password"
+        required
+      />
+    </Field>
+    <Buttons>
+      <Primary type="submit" disabled={busy}>
+        {busy ? 'Opening…' : 'Connect Google'}
+      </Primary>
+    </Buttons>
+  </form>
+);
+
+const PasswordForm: React.FC<{
+  requireCurrent: boolean;
+  busy: boolean;
+  onSubmit: (newPassword: string, currentPassword?: string) => void;
+}> = ({ requireCurrent, busy, onSubmit }) => (
+  <form
+    onSubmit={(e) => {
+      e.preventDefault();
+      const form = new FormData(e.currentTarget);
+      onSubmit(
+        String(form.get('newPassword') ?? ''),
+        requireCurrent ? String(form.get('currentPassword') ?? '') : undefined,
+      );
+    }}
+  >
+    {requireCurrent && (
+      <Field>
+        <FieldLabel>Current password</FieldLabel>
+        <FieldInput
+          name="currentPassword"
+          type="password"
+          autoComplete="current-password"
+          required
+        />
+      </Field>
+    )}
+    <Field>
+      <FieldLabel>New password</FieldLabel>
+      <FieldInput
+        name="newPassword"
+        type="password"
+        minLength={8}
+        autoComplete="new-password"
+        required
+      />
+    </Field>
+    <RowText>Saving signs out every other session.</RowText>
+    <Buttons>
+      <Primary type="submit" disabled={busy}>
+        {busy ? 'Saving…' : 'Save password'}
+      </Primary>
+    </Buttons>
+  </form>
+);

--- a/video-sync-frontend/src/contexts/AuthContext.tsx
+++ b/video-sync-frontend/src/contexts/AuthContext.tsx
@@ -182,9 +182,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     );
     const stored = localStorage.getItem('user');
     if (stored) {
-      const parsed = JSON.parse(stored) as { id?: string };
-      if (parsed.id === id) {
-        localStorage.setItem('user', JSON.stringify({ ...parsed, token }));
+      try {
+        const parsed = JSON.parse(stored) as { id?: string };
+        if (parsed.id === id) {
+          localStorage.setItem('user', JSON.stringify({ ...parsed, token }));
+        }
+      } catch {
+        // a corrupt or half-written entry is not worth throwing out of a
+        // refresh handler or the password-change path; leave storage alone
       }
     }
   }, []);

--- a/video-sync-frontend/src/contexts/AuthContext.tsx
+++ b/video-sync-frontend/src/contexts/AuthContext.tsx
@@ -169,6 +169,62 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   }, []);
 
+  /**
+   * Keep the session fresh without keeping it forever.
+   *
+   * Scheduled at ~90% of the token's remaining life (decoded locally - the
+   * expiry is not a secret, and mis-decoding only means a missed refresh,
+   * which the hard expiry already handles). On success the server has
+   * REVOKED the old token, so the update below is not cosmetic: the copy
+   * that refreshed is the only copy still alive. On refusal - revoked
+   * elsewhere, session past its thirty-day cap - nothing happens here;
+   * the existing expiry machinery (401 handling, socket eviction) ends
+   * the session the way it already knows how.
+   *
+   * The socket reconnects when the token changes (its effect keys on
+   * [token]); once per ~11 hours, that brief rejoin is the price of not
+   * being signed out mid-film at hour twelve.
+   */
+  useEffect(() => {
+    const token = user?.token;
+    if (!token) return;
+    let expMs: number | null = null;
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1])) as {
+        exp?: number;
+        elev?: string;
+      };
+      // elevated tokens are five-minute instruments, never sessions
+      if (payload.elev) return;
+      if (typeof payload.exp === 'number') expMs = payload.exp * 1000;
+    } catch {
+      return; // undecodable: let the server be the judge at next request
+    }
+    if (expMs === null) return;
+    const delay = Math.max((expMs - Date.now()) * 0.9, 60_000);
+    const timer = setTimeout(() => {
+      apiService
+        .refresh()
+        .then(({ data }) => {
+          setUser((current) =>
+            current ? { ...current, token: data.token } : current,
+          );
+          const stored = localStorage.getItem('user');
+          if (stored) {
+            localStorage.setItem(
+              'user',
+              JSON.stringify({
+                ...(JSON.parse(stored) as object),
+                token: data.token,
+              }),
+            );
+          }
+        })
+        .catch(() => undefined);
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [user?.token]);
+
   const claimAccount = useCallback(
     async (username: string, email: string, password: string) => {
       try {

--- a/video-sync-frontend/src/contexts/AuthContext.tsx
+++ b/video-sync-frontend/src/contexts/AuthContext.tsx
@@ -37,6 +37,8 @@ interface AuthContextType {
     email: string,
     password: string,
   ) => Promise<void>;
+  /** Adopt a token minted for the current account (refresh / password change). */
+  adoptToken: (token: string, id: string) => void;
   /** Sign in with no account at all; see docs/GUEST_ACCESS.md. */
   continueAsGuest: () => Promise<void>;
   /** True when this session has no password and no provider behind it. */
@@ -170,6 +172,48 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, []);
 
   /**
+   * Adopt a token minted for the SAME account - a refresh, or the survivor
+   * a password change hands back. Guarded by id: an in-flight response must
+   * never be merged onto a different user who signed in meanwhile.
+   */
+  const adoptToken = useCallback((token: string, id: string) => {
+    setUser((current) =>
+      current && current.id === id ? { ...current, token } : current,
+    );
+    const stored = localStorage.getItem('user');
+    if (stored) {
+      const parsed = JSON.parse(stored) as { id?: string };
+      if (parsed.id === id) {
+        localStorage.setItem('user', JSON.stringify({ ...parsed, token }));
+      }
+    }
+  }, []);
+
+  // Cross-tab convergence: when one tab rotates or changes the password, the
+  // stored token changes under every other tab, which is still holding the
+  // now-revoked one in memory. Adopt the new one; a cleared key means a
+  // sign-out happened somewhere and this tab follows.
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== 'user') return;
+      if (!e.newValue) {
+        setUser(null);
+        return;
+      }
+      try {
+        const next = JSON.parse(e.newValue) as User;
+        setUser((current) =>
+          !current || current.id === next.id ? next : current,
+        );
+      } catch {
+        // a malformed write is not a reason to tear down a good session
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  /**
    * Keep the session fresh without keeping it forever.
    *
    * Scheduled at ~90% of the token's remaining life (decoded locally - the
@@ -206,24 +250,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       apiService
         .refresh()
         .then(({ data }) => {
-          setUser((current) =>
-            current ? { ...current, token: data.token } : current,
-          );
-          const stored = localStorage.getItem('user');
-          if (stored) {
-            localStorage.setItem(
-              'user',
-              JSON.stringify({
-                ...(JSON.parse(stored) as object),
-                token: data.token,
-              }),
-            );
-          }
+          // by id: the session may have changed under us while the refresh
+          // was in flight
+          adoptToken(data.token, data.id);
         })
         .catch(() => undefined);
     }, delay);
     return () => clearTimeout(timer);
-  }, [user?.token]);
+  }, [user?.token, adoptToken]);
 
   const claimAccount = useCallback(
     async (username: string, email: string, password: string) => {
@@ -288,6 +322,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     signInWithToken,
     continueAsGuest,
     claimAccount,
+    adoptToken,
     // the synthetic address the server mints is the only marker the client
     // gets, and it is one no real account can have: .invalid is reserved
     isGuest: Boolean(user?.email?.endsWith('@guest.invalid')),

--- a/video-sync-frontend/src/pages/AuthCallbackPage.tsx
+++ b/video-sync-frontend/src/pages/AuthCallbackPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { useAuth } from '../contexts/AuthContext';
+import { safeReturnTo } from '../services/return-to';
 import { color, font, button, card } from '../theme';
 import { Wordmark } from '../components/Icons';
 
@@ -129,7 +130,10 @@ export const AuthCallbackPage: React.FC = () => {
     if (elev) {
       sessionStorage.setItem('mw_elevated', elev);
       window.history.replaceState(null, '', window.location.pathname);
-      navigate(to && to.startsWith('/') ? to : '/', { replace: true });
+      // safeReturnTo, not a bare startsWith('/') - '//evil.example' passes
+      // the loose check and leaves this origin. The same helper guards the
+      // sign-in branch; the reauth branch must not be the weak door.
+      navigate(safeReturnTo(to) ?? '/', { replace: true });
       return;
     }
 
@@ -146,9 +150,7 @@ export const AuthCallbackPage: React.FC = () => {
       .then(() => {
         // `to` came back sealed in a server-side cookie, and the server
         // already refused anything that was not a path on this site.
-        navigate(to && to.startsWith('/') && !to.startsWith('//') ? to : '/', {
-          replace: true,
-        });
+        navigate(safeReturnTo(to) ?? '/', { replace: true });
       })
       .catch(() => setFailure(fallback));
   }, [navigate, signInWithToken]);

--- a/video-sync-frontend/src/pages/AuthCallbackPage.tsx
+++ b/video-sync-frontend/src/pages/AuthCallbackPage.tsx
@@ -83,6 +83,10 @@ const EXPLANATIONS: Record<string, { title: string; body: string }> = {
     title: 'This account is already a full one',
     body: 'Nothing to keep - you are signed in properly already.',
   },
+  reauth_mismatch: {
+    title: 'That was a different Google account',
+    body: 'The confirmation has to come from the Google account linked to THIS account. Pick that one at the Google screen and try again.',
+  },
   link: {
     title: "Couldn't attach Google to this session",
     body: 'Your guest session is untouched. Try again, or set a password instead.',
@@ -116,6 +120,18 @@ export const AuthCallbackPage: React.FC = () => {
     const token = params.get('token');
     const error = params.get('error');
     const to = params.get('to');
+
+    // A re-auth round trip hands back a five-minute ELEVATED token under
+    // its own name. It is parked in sessionStorage for the account dialog
+    // and never adopted as a session - elevation proves a moment, not an
+    // identity change, and storing it like a session would make it one.
+    const elev = params.get('elev');
+    if (elev) {
+      sessionStorage.setItem('mw_elevated', elev);
+      window.history.replaceState(null, '', window.location.pathname);
+      navigate(to && to.startsWith('/') ? to : '/', { replace: true });
+      return;
+    }
 
     if (error || !token) {
       setFailure((error && EXPLANATIONS[error]) || fallback);

--- a/video-sync-frontend/src/pages/HomePage.tsx
+++ b/video-sync-frontend/src/pages/HomePage.tsx
@@ -23,6 +23,7 @@ import {
 } from '../theme';
 import { Wordmark, IconPlus, IconUsers, IconFilm, IconLock, IconX } from '../components/Icons';
 import { ClaimAccountDialog, ClaimTrigger } from '../components/ClaimAccount';
+import { AccountDialog } from '../components/AccountDialog';
 
 const MEASUREMENTS_URL =
   'https://github.com/JonSnow1807/Mustard-Watch-Party/tree/main/docs/measurements';
@@ -49,13 +50,29 @@ const TopBarRight = styled.div`
   min-width: 0;
 `;
 
-const SignedInAs = styled.span`
+// A BUTTON now, because it opens the account dialog - the first account
+// surface this app has had. Styled to read as the same quiet text it
+// always was, with just enough affordance to be discovered.
+const SignedInAs = styled.button`
   font-family: ${font.body};
   font-size: 13px;
   color: ${color.dim};
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  background: none;
+  border: none;
+  padding: 4px 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  &:hover {
+    color: ${color.text};
+    background: rgba(255, 255, 255, 0.04);
+  }
+  &:focus-visible {
+    box-shadow: ${focusRing};
+    outline: none;
+  }
 `;
 
 const PrimaryButton = styled.button`
@@ -631,6 +648,8 @@ export const HomePage: React.FC = () => {
   // evening in a room, which was the one place this could not be reached.
   const [claimOpen, setClaimOpen] = useState(false);
   const closeClaim = useCallback(() => setClaimOpen(false), []);
+  const [accountOpen, setAccountOpen] = useState(false);
+  const closeAccount = useCallback(() => setAccountOpen(false), []);
 
   const hideDeleteModal = useCallback(() => {
     setDeleteModal({ show: false, room: null });
@@ -758,7 +777,11 @@ export const HomePage: React.FC = () => {
       <TopBar>
         <Wordmark size={18} />
         <TopBarRight>
-          <SignedInAs>
+          <SignedInAs
+            type="button"
+            onClick={() => setAccountOpen(true)}
+            title="Account & security"
+          >
             {isGuest ? `Guest · ${user.username}` : `Signed in as ${user.username}`}
           </SignedInAs>
           {/* This used to be a plain "temporary session" label, with a
@@ -1009,6 +1032,7 @@ export const HomePage: React.FC = () => {
       </Content>
 
       {claimOpen && <ClaimAccountDialog onClose={closeClaim} />}
+      {accountOpen && <AccountDialog onClose={closeAccount} />}
 
       {/* Delete Confirmation Modal */}
       {deleteModal.show && deleteModal.room && (

--- a/video-sync-frontend/src/services/api.interceptor.test.ts
+++ b/video-sync-frontend/src/services/api.interceptor.test.ts
@@ -98,3 +98,41 @@ describe('an explicitly-set Authorization header', () => {
     );
   });
 });
+
+
+describe('the response interceptor clears the session narrowly', () => {
+  const reject = (status: number, authHeader?: string) => {
+    const handler = (
+      api.interceptors.response as unknown as {
+        handlers: { rejected: (e: unknown) => Promise<never> }[];
+      }
+    ).handlers[0].rejected;
+    return handler({
+      response: { status },
+      config: { headers: authHeader ? { Authorization: authHeader } : {} },
+    }).catch(() => undefined);
+  };
+
+  beforeEach(() =>
+    localStorage.setItem('user', JSON.stringify({ id: 'u1', token: 'stored-tok' })),
+  );
+  afterEach(() => localStorage.clear());
+
+  it('clears when the STORED token is the one rejected', async () => {
+    await reject(401, 'Bearer stored-tok');
+    expect(localStorage.getItem('user')).toBeNull();
+  });
+
+  it('does NOT clear when a DIFFERENT token is rejected', async () => {
+    // the elevated set-password token failing, or a wrong-password re-auth
+    // behind a good session: the stored session must survive
+    await reject(401, 'Bearer elevated-tok');
+    expect(localStorage.getItem('user')).not.toBeNull();
+  });
+
+  it('does NOT clear on a 401 that carried no token at all', async () => {
+    // a bad login: clearing would wipe a good session over a typo
+    await reject(401, undefined);
+    expect(localStorage.getItem('user')).not.toBeNull();
+  });
+});

--- a/video-sync-frontend/src/services/api.interceptor.test.ts
+++ b/video-sync-frontend/src/services/api.interceptor.test.ts
@@ -72,3 +72,29 @@ describe('with no stored session', () => {
     expect(authHeader('/rooms')).toBeUndefined();
   });
 });
+
+describe('an explicitly-set Authorization header', () => {
+  it('is never overwritten by the stored session', () => {
+    // setPasswordElevated carries the five-minute elevated token; the
+    // interceptor replacing it with the stored session would silently
+    // un-elevate the one call that needs elevation
+    const cfg = run('/auth/set-password');
+    expect(cfg.headers.Authorization).toBe('Bearer tok-123'); // default path
+    const handler = (
+      api.interceptors.request as unknown as {
+        handlers: {
+          fulfilled: (
+            c: import('axios').InternalAxiosRequestConfig,
+          ) => import('axios').InternalAxiosRequestConfig;
+        }[];
+      }
+    ).handlers[0].fulfilled;
+    const explicit = handler({
+      url: '/auth/set-password',
+      headers: { Authorization: 'Bearer elevated-token' },
+    } as unknown as import('axios').InternalAxiosRequestConfig);
+    expect((explicit.headers as Record<string, unknown>).Authorization).toBe(
+      'Bearer elevated-token',
+    );
+  });
+});

--- a/video-sync-frontend/src/services/api.ts
+++ b/video-sync-frontend/src/services/api.ts
@@ -95,11 +95,26 @@ api.interceptors.request.use(config => {
 api.interceptors.response.use(
   response => response,
   error => {
-    // Only a request that actually carried a token can have had it rejected.
-    // A 401 from /auth/login is bad credentials, and clearing on that would
-    // wipe a perfectly good session because someone fat-fingered a password.
-    const sentToken = Boolean(error?.config?.headers?.Authorization);
-    if (error?.response?.status === 401 && sentToken) {
+    // Clear the session ONLY when the request that was rejected actually
+    // carried the STORED session token. The earlier version cleared on any
+    // 401 that carried any token, which was three bugs in one:
+    //  - a wrong current-password on set-password (a 401 behind a perfectly
+    //    good session) wiped the session;
+    //  - set-password SUCCEEDS by revoking the stored token, so the very
+    //    next request with it 401s - a successful password change signed
+    //    the user out;
+    //  - the five-minute elevated token failing a set-password wiped the
+    //    real session it was standing in for.
+    // The rejected request carried a credential that is NOT the stored one
+    // in every one of those cases; comparing to the stored token tells the
+    // "my session died" case apart from "the thing I was proving failed".
+    const sent = error?.config?.headers?.Authorization;
+    const stored = readStoredToken();
+    if (
+      error?.response?.status === 401 &&
+      stored &&
+      sent === `Bearer ${stored}`
+    ) {
       clearStoredUser();
     }
     return Promise.reject(error);

--- a/video-sync-frontend/src/services/api.ts
+++ b/video-sync-frontend/src/services/api.ts
@@ -83,7 +83,10 @@ api.interceptors.request.use(config => {
     return config;
   }
   const token = readStoredToken();
-  if (token) {
+  // An explicitly-set header wins: setPasswordElevated carries the
+  // five-minute elevated token, and overwriting it with the stored session
+  // here would silently un-elevate the one call that needs it.
+  if (token && !config.headers.Authorization) {
     config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
@@ -124,6 +127,39 @@ export const apiService = {
   /** Stop trusting every session this account has, anywhere. */
   logoutEverywhere: () => api.post<{ version: number }>('/auth/logout-all'),
 
+  /**
+   * Trade a live token for a fresh one. The old token is revoked in the
+   * same call, so the copy that refreshed is the copy that survives; the
+   * slide is bounded server-side by the session's birth.
+   */
+  refresh: () => api.post<{ token: string; id: string; username: string }>('/auth/refresh'),
+
+  /**
+   * Set or change the password. Password accounts send currentPassword;
+   * provider-only accounts must be holding the five-minute elevated token
+   * from the Google re-auth flow instead. Every OTHER session ends when
+   * this succeeds - the response carries the one token that survives.
+   */
+  setPassword: (newPassword: string, currentPassword?: string) =>
+    api.post('/auth/set-password', { newPassword, currentPassword }),
+
+  /**
+   * set-password using the five-minute elevated token instead of the
+   * session: the token rides Authorization for THIS call only, proving the
+   * fresh Google round trip. Passed explicitly rather than stored - an
+   * elevation that lived in localStorage would be a session by another name.
+   */
+  setPasswordElevated: (newPassword: string, elevatedToken: string) =>
+    api.post(
+      '/auth/set-password',
+      { newPassword },
+      { headers: { Authorization: `Bearer ${elevatedToken}` } },
+    ),
+
+  /** Begin the Google re-auth round trip that mints the elevated token. */
+  googleReauthStart: (returnTo?: string) =>
+    api.post<{ authUrl: string }>('/auth/google/reauth-start', { returnTo }),
+
   /** A way in for someone who followed an invite link and wants no account. */
   guest: () => api.post('/auth/guest'),
 
@@ -143,8 +179,11 @@ export const apiService = {
    * the query string would write a credential into access logs and Referer
    * headers.
    */
-  googleLinkStart: (returnTo?: string) =>
-    api.post<{ authUrl: string }>('/auth/google/link-start', { returnTo }),
+  googleLinkStart: (returnTo?: string, password?: string) =>
+    api.post<{ authUrl: string }>('/auth/google/link-start', {
+      returnTo,
+      password,
+    }),
 
   // Which sign-in methods this deployment can actually complete. Asked at
   // runtime rather than baked in at build: the frontend is one bundle served

--- a/video-sync-frontend/src/services/api.ts
+++ b/video-sync-frontend/src/services/api.ts
@@ -78,6 +78,30 @@ const NO_TOKEN_NEEDED = [
   '/auth/google/callback',
 ];
 
+/**
+ * Read the Authorization header regardless of case or container. axios wraps
+ * headers in AxiosHeaders (case-insensitive via .get); tests and some code
+ * paths pass a plain object. Both the "is one already set" guard and the
+ * "was the stored token the one rejected" comparison have to agree with what
+ * axios will actually send, so neither may assume the exact key 'Authorization'.
+ */
+const authHeader = (
+  headers: unknown,
+): string | undefined => {
+  if (!headers) return undefined;
+  const h = headers as {
+    get?: (name: string) => unknown;
+    Authorization?: unknown;
+    authorization?: unknown;
+  };
+  if (typeof h.get === 'function') {
+    const v = h.get('Authorization');
+    return typeof v === 'string' ? v : undefined;
+  }
+  const v = h.Authorization ?? h.authorization;
+  return typeof v === 'string' ? v : undefined;
+};
+
 api.interceptors.request.use(config => {
   if (NO_TOKEN_NEEDED.some(path => config.url?.startsWith(path))) {
     return config;
@@ -85,8 +109,9 @@ api.interceptors.request.use(config => {
   const token = readStoredToken();
   // An explicitly-set header wins: setPasswordElevated carries the
   // five-minute elevated token, and overwriting it with the stored session
-  // here would silently un-elevate the one call that needs it.
-  if (token && !config.headers.Authorization) {
+  // here would silently un-elevate the one call that needs it. Read
+  // case-insensitively so a header set as 'authorization' is still seen.
+  if (token && !authHeader(config.headers)) {
     config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
@@ -108,7 +133,7 @@ api.interceptors.response.use(
     // The rejected request carried a credential that is NOT the stored one
     // in every one of those cases; comparing to the stored token tells the
     // "my session died" case apart from "the thing I was proving failed".
-    const sent = error?.config?.headers?.Authorization;
+    const sent = authHeader(error?.config?.headers);
     const stored = readStoredToken();
     if (
       error?.response?.status === 401 &&


### PR DESCRIPTION
The recorded non-features that were worth building — refresh, full-account Google linking, set-password for provider-only accounts, and the account UI all three needed — plus the two that stay recorded-out with reasons (account merging; deploying relay-go).

**I ran a four-lens adversarial review of this diff before opening the PR** (token-security, correctness, client, test-honesty), because this week every review round found a bug in my own fixes. It found **sixteen**, and the worst one defeated the feature's entire purpose. They're all fixed here; the story is worth telling because the design *read* correct.

## The critical one: a revoked token could refresh itself back to life

`refreshSession` read the authoritative `tokenVersion` from Postgres — and used it only to **stamp** the new token. It never checked the *presented* token's version or jti against the DB. The sole revocation check on `/auth/refresh` was the guard's in-memory snapshot, which lags a `logout-all` by up to `REFRESH_MS`. A thief refreshing in a loop through that window minted a fresh, fully-valid token at the *post-bump* version — untouched by the very "sign out everywhere" built to stop them, self-renewing to the 30-day cap.

Fixed with checks Postgres can answer and the snapshot cannot: refuse when presented `ver < row.tokenVersion` or the jti is durably revoked. And **rotation now detects reuse** — the old jti is claimed with a `CREATE` (not upsert) before minting, so the unique constraint makes exactly one caller the true rotation; a loser (two copies of one token, the shape of theft) is treated as compromise, burns the whole family, and 401s.

## Two more criticals, both client

- **Any 401 behind a valid session wiped the session** — including set-password's own *success*, which revokes the token it used. The happy path deterministically showed "wrong password" and destroyed the session. Now the interceptor clears only when the *rejected request carried the stored token*.
- **Successful set-password force-signed you out** — the dialog discarded the survivor token the response hands back, then re-fetched with the dead one. Now it adopts the survivor first (id-guarded), and a cross-tab `storage` listener makes every tab converge.

## The rest (all traced end-to-end before fixing)

linkGoogleToFull idempotency on the race path · a gate that let a password+Google account attach a *second* Google identity · refresh response merged onto the wrong user at resolve time · elevation consumed on mount and lost on close · the reauth-mismatch gate with **zero tests** (failure mode: silence) · two live-check assertions that passed with the feature deleted *or* inverted.

## The design, for what survives

- **Refresh rotates and is bounded.** New jti, old token revoked in the same call, 30-day cap anchored to a `sess` birth claim refreshes preserve verbatim. Revocation existing is what made the old "no lifetime extension" rule obsolete — a stolen copy is now worth *less* after refresh, not more.
- **Every credential change re-authenticates**, because the scenario is "someone holds a copy of your token." Linking Google to a full account needs the current password; set-password on a Google-only account needs a fresh Google round trip whose callback verifies the returning subject *owns* the account and mints a five-minute elevated token (fragment-only, never adopted as a session). Password writes bump `tokenVersion` in the same DB write as the hash.
- **An account surface at last** — click your name: sign-in methods, password, and the first UI `logout-all` has ever had.

## Verified

465 backend tests, 137 frontend, **19 live checks against a real Redis-backed server** — including the two that matter most: a token from before `logout-all` cannot refresh itself back to life (401), and concurrent double-refresh mints at most one live session.

## Deliberately not built, reasons in AUTH.md

Account merging (destructive FK migration across identities nobody can verify are one person) and provider *unlinking* (needs would-this-strand-the-account reasoning). Deploying relay-go stays an infra/spend decision, not a code gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added account management for Google linking, password setup or changes, sign-in method visibility, and signing out everywhere.
  - Added Google re-authentication for sensitive account changes.
  - Added automatic session refresh with token rotation and a 30-day maximum session lifetime.
  - Added cross-tab sign-in and sign-out synchronization.

- **Bug Fixes**
  - Improved handling of revoked, reused, expired, and mismatched authentication tokens.
  - Prevented stale authentication errors from clearing newer sessions.

- **Documentation**
  - Documented session refresh, re-authentication, account linking, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->